### PR TITLE
Cleanup Caps & Stuff In Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ __pycache__/
 *.pyc
 virtualenv_run/
 *.egg-info/
+dist/
+venv/
+docs/build/

--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -1,5 +1,5 @@
-ElastAlert monitoring framework
-*******************************
+ElastAlert - Easy & Flexible Alerting With ElasticSearch
+********************************************************
 
 ElastAlert is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in Elasticsearch.
 
@@ -29,7 +29,7 @@ Several rule types with common monitoring paradigms are included with ElastAlert
 - "Match on any event matching a given filter" (``any`` type)
 - "Match when a field has two different values within some time" (``change`` type)
 
-Currently, we only have support built in for two alert types:
+Currently, we have support built in for two alert types:
 
 - Email
 - JIRA

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,8 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to ElastAlert's documentation!
-======================================
+ElastAlert - Easy & Flexible Alerting With ElasticSearch
+========================================================
 
 Contents:
 
@@ -20,7 +20,7 @@ Contents:
    recipes/writing_filters
    recipes/adding_enhancements
 
-Indices and tables
+Indices and Tables
 ==================
 
 * :ref:`genindex`

--- a/docs/source/recipes/adding_alerts.rst
+++ b/docs/source/recipes/adding_alerts.rst
@@ -47,8 +47,8 @@ This function is called to get information about the alert to save back to Elast
 return a dictionary, which is uploaded directly to Elasticsearch, and should contain useful information
 about the alert such as the type, recipients, parameters, etc.
 
-Tutorial: Creating a new alert
-==============================
+Tutorial
+--------
 
 Let's create a new alert that will write alerts to a local output file. First,
 create a modules folder in the base ElastAlert folder:

--- a/docs/source/recipes/adding_rules.rst
+++ b/docs/source/recipes/adding_rules.rst
@@ -63,7 +63,7 @@ to clear any state that may be obsolete as of ``timestamp``. ``timestamp`` is an
 
 
 Tutorial
-================
+--------
 
 As an example, we are going to create a rule type for detecting suspicious logins. Lets imagine the data we are querying is login
 events that contains IP address, username and a timestamp. Our configuration will take a list of usernames and a time range

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1,17 +1,17 @@
-Rule types and configuration options
+Rule Types and Configuration Options
 ************************************
 
 Examples of several types of rule configuration can be found in the example_rules folder.
 
 .. _commonconfig:
 
-Common configuration options
+Common Configuration Options
 ============================
 
 Every file that ends in ``.yaml`` in the ``rules_folder`` will be run by default.
 The following configuration settings are common to all types of rules:
 
-Required settings
+Required Settings
 ~~~~~~~~~~~~~~~~~
 
 ``es_host``: The hostname of the Elasticsearch cluster the rule will use to query. (Required, string, no default)
@@ -38,7 +38,7 @@ or loaded from a module. For loading from a module, the type should be specified
 ``alert``: The ``Alerter`` type to use. This may be one of the built in alerts, see :ref:`Alert Types <alerts>` section below for more information,
 or loaded from a module. For loading from a module, the alert should be specified as ``module.file.AlertName``. (Required, string, no default)
 
-Optional settings
+Optional Settings
 ~~~~~~~~~~~~~~~~~
 
 ``aggregation``: This option allows you to aggregate multiple matches together into one alert. Every time a match is found,
@@ -94,7 +94,7 @@ that will be given the match dictionary and can modify it before it is passed to
 
 Some rules and alerts require additional options, which also go in the top level of the rule configuration file.
 
-Testing if your rule is valid
+Testing If Your Rule Is Valid
 ==============================
 
 Once you've written a rule configuration, you will want to validate it. To do so, use ``elastalert-test-rule``.

--- a/docs/source/running_elastalert.rst
+++ b/docs/source/running_elastalert.rst
@@ -1,6 +1,6 @@
 .. _tutorial:
 
-Running ElastAlert For The First Time
+Running ElastAlert for the First Time
 =====================================
 
 Requirements
@@ -11,7 +11,7 @@ Requirements
 - ISO8601 timestamped data
 - Python 2.6
 
-Downloading And Configuring
+Downloading and Configuring
 ---------------------------
 
 First, clone the ElastAlert repository::
@@ -40,7 +40,7 @@ Next, open up config.yaml.example. In it, you will find several configuration op
 
 Save the file as ``config.yaml``
 
-Setting up Elasticsearch
+Setting Up Elasticsearch
 ------------------------
 
 ElastAlert saves information and metadata about its queries and its alerts back to Elasticsearch. This is useful for auditing, debugging, and it allows ElastAlert to restart and resume exactly where it left off. This is not required for ElastAlert to run, but highly recommended.


### PR DESCRIPTION
* Cleanup caps
* Make the hierarchy in https://elastalert.readthedocs.org look better
* Add some directories to ```.gitignore```

*Tested With*
* ```make test```
* ```make docs```
