### PR TITLE
Customizable summary field for JIRA tickets

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -383,6 +383,21 @@ or
     - email
     - jira
 
+E-mail subject or JIRA issue summary can also be customized by adding an ``alert_subject`` that contains a custom summary.
+It can be further formatted using standard Python formatting syntax::
+
+    alert_subject: Issue {0} occurred at {1}
+
+The arguments for the formatter will be fed from the matched objects related to the alert.
+The field names which values will be used as the arguments can be passed with ``alert_subject_args``::
+
+
+    alert_subject_args:
+    - issue.name
+    - @timestamp
+
+In case the rule matches multiple objects in the index, only the first match is used to populate the arguments for the formatter.
+
 Alert Content
 ~~~~~~~~~~~~~~~
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -93,7 +93,7 @@ class Alerter(object):
 
         if 'alert_subject_args' in self.rule:
             alert_subject_args = self.rule['alert_subject_args']
-            alert_subject_values = [matches[0][arg] for arg in alert_subject_args]
+            alert_subject_values = [matches[0].get(arg, '<MISSING VALUE>') for arg in alert_subject_args]
             return alert_subject.format(*alert_subject_values)
 
         return alert_subject

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -86,7 +86,8 @@ def test_jira():
     rule = {'name': 'test alert', 'jira_account_file': 'jirafile', 'type': mock_rule(),
             'jira_project': 'testproject', 'jira_issuetype': 'testtype', 'jira_server': 'jiraserver',
             'jira_label': 'testlabel', 'jira_component': 'testcomponent',
-            'timestamp_field': '@timestamp'}
+            'timestamp_field': '@timestamp', 'alert_subject': 'Issue {0} occured at {1}',
+            'alert_subject_args': ['test_term', '@timestamp']}
     with mock.patch('elastalert.alerts.JIRA') as mock_jira:
         with mock.patch('elastalert.alerts.yaml_loader') as mock_open:
             mock_open.return_value = {'user': 'jirauser', 'password': 'jirapassword'}
@@ -101,7 +102,7 @@ def test_jira():
                                                  labels=['testlabel'],
                                                  components=[{'name': 'testcomponent'}],
                                                  description=mock.ANY,
-                                                 summary=mock.ANY)]
+                                                 summary='Issue test_value occured at 2014-10-31T00:00:00')]
             assert mock_jira.mock_calls == expected
 
 

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -46,7 +46,8 @@ def test_alert_text(ea):
 
 def test_email():
     rule = {'name': 'test alert', 'email': ['testing@test.test', 'test@test.test'],
-            'type': mock_rule(), 'timestamp_field': '@timestamp', 'email_reply_to': 'test@example.com'}
+            'type': mock_rule(), 'timestamp_field': '@timestamp', 'email_reply_to': 'test@example.com',
+            'alert_subject': 'Test alert for {0}', 'alert_subject_args': ['test_term']}
     with mock.patch('elastalert.alerts.SMTP') as mock_smtp:
         mock_smtp.return_value = mock.Mock()
 
@@ -60,6 +61,7 @@ def test_email():
         body = mock_smtp.mock_calls[1][1][2]
         assert 'Reply-To: test@example.com' in body
         assert 'To: testing@test.test' in body
+        assert 'Subject: Test alert for test_value' in body
 
 
 def test_email_query_key_in_subject():


### PR DESCRIPTION
JIRA ticket summary can now be customized by adding an `alert_subject` that contains a custom summary, which can be further formatted using standard Python formatting syntax, e.g.:
```yaml
alert_subject: Issue {0} occurred at {1}
```

The arguments for the formatter will be fed from the matched objects.
The field names which values will be used as the arguments can be passed with `alert_subject_args`, e.g.:

```yaml
alert_subject_args:
- issue.name
- @timestamp
```

In case the rule matches multiple objects in the index, only the first match is used to populate the arguments for the formatter.