### PR TITLE
Top count query

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -362,7 +362,7 @@ Flatline
 
 ``flatline``: This rule matches when the total number of events is under a given ``threshold`` for a time period.
 
-This rule requires two required options:
+This rule requires two additional options:
 
 ``threshold``: The minimum number of events for an alert not to be triggered.
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -18,7 +18,7 @@ def get_counts_string(match):
     message = ''
     for key, counts in match.items():
         if key.startswith('top_events_'):
-            message += 'The following are the top %s event counts, by %s:\n' % (len(counts), key[11:])
+            message += '%s:\n' % (key[11:])
             top_events = counts.items()
             top_events.sort(key=lambda x: x[1], reverse=True)
             for term, count in top_events:

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -169,10 +169,10 @@ def load_configuration(filename):
                     raise EAException('generate_kibana_link is incompatible with filters other than term, query_string and range. '
                                       'Consider creating a dashboard and using use_kibana_dashboard instead.')
 
-    # Check that doc_type is provided if use_count_query
-    if rule.get('use_count_query'):
+    # Check that doc_type is provided if use_count/terms_query
+    if rule.get('use_count_query') or rule.get('use_terms_query'):
         if 'doc_type' not in rule:
-            raise EAException('doc_type must be specified with use_count_query')
+            raise EAException('doc_type must be specified.')
 
     # Check that query_key is set if use_terms_query
     if rule.get('use_terms_query'):

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -21,7 +21,7 @@ def test_alert_text(ea):
     alert_text = basic_match_string(ea.rules[0], match)
     assert 'anytest' in alert_text
     assert 'some stuff happened' in alert_text
-    assert 'by username' in alert_text
+    assert 'username' in alert_text
     assert 'bob: 10' in alert_text
     assert 'field: value' in alert_text
 


### PR DESCRIPTION
Change top_count_keys from iterating through actual data to making an aggregation query to Elasticsearch. 

This is so top_count_keys can be used with use_count_query and use_terms_query. This was the major blocker in converting slow rules to use count instead of search+fetch. 

The function has been moved into the ElastAlerter class and is run by in it's alert function. I also changed the text "The following are the top X events by Y:" to just "Y:". 

I fixed the existing unit test and tested manually with frequency type rule both with and without query_key and with use_count_query and use_terms_query.

