### PR TITLE
Removed tox env from precommit hooks install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ docs:
 dev: $(LOCAL_CONFIG_DIR) $(LOGS_DIR) install-hooks
 
 install-hooks:
-	@tox -e pre-commit -- install -f --install-hooks
+	pre-commit install -f --install-hooks
 
 test:
 	tox


### PR DESCRIPTION
The pre-commit section in tox was removed in https://github.com/Yelp/elastalert/commit/d9ab6864d56908e9379ae9e0911a56432779e6da. Update the Makefile accordingly