### PR TITLE
Added ignore_unavailable to queries

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -141,7 +141,7 @@ class ElastAlerter():
         """
         query = {'sort': {timestamp_field: {'order': 'asc'}}}
         try:
-            res = self.current_es.search(index=index, size=1, body=query, _source_include=[timestamp_field])
+            res = self.current_es.search(index=index, size=1, body=query, _source_include=[timestamp_field], ignore_unavailable=True)
         except ElasticsearchException as e:
             self.handle_error("Elasticsearch query error: %s" % (e), {'index': index})
             return '1969-12-30T00:00:00Z'
@@ -161,7 +161,7 @@ class ElastAlerter():
         """
         query = self.get_query(rule['filter'], starttime, endtime, timestamp_field=rule['timestamp_field'])
         try:
-            res = self.current_es.search(index=index, size=self.max_query_size, body=query, _source_include=rule['include'])
+            res = self.current_es.search(index=index, size=self.max_query_size, body=query, _source_include=rule['include'], ignore_unavailable=True)
         except ElasticsearchException as e:
             # Elasticsearch sometimes gives us GIGANTIC error messages
             # (so big that they will fill the entire terminal buffer)
@@ -195,7 +195,7 @@ class ElastAlerter():
         query = {'query': {'filtered': query}}
 
         try:
-            res = self.current_es.count(index=index, doc_type=rule['doc_type'], body=query)
+            res = self.current_es.count(index=index, doc_type=rule['doc_type'], body=query, ignore_unavailable=True)
         except ElasticsearchException as e:
             # Elasticsearch sometimes gives us GIGANTIC error messages
             # (so big that they will fill the entire terminal buffer)
@@ -217,7 +217,7 @@ class ElastAlerter():
         query = self.get_terms_query(base_query, rule.get('terms_size', 5), key)
 
         try:
-            res = self.current_es.search(index=index, doc_type=rule['doc_type'], body=query, search_type='count')
+            res = self.current_es.search(index=index, doc_type=rule['doc_type'], body=query, search_type='count', ignore_unavailable=True)
         except ElasticsearchException as e:
             # Elasticsearch sometimes gives us GIGANTIC error messages
             # (so big that they will fill the entire terminal buffer)

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -76,7 +76,7 @@ def test_init_rule(ea):
 def test_query(ea):
     ea.current_es.search.return_value = {'hits': {'hits': []}}
     ea.run_query(ea.rules[0], START, END)
-    ea.current_es.search.assert_called_with(body={'filter': {'bool': {'must': [{'range': {'@timestamp': {'to': END_TIMESTAMP, 'from': START_TIMESTAMP}}}]}}, 'sort': [{'@timestamp': {'order': 'asc'}}]}, index='idx', _source_include=['@timestamp'], size=100000)
+    ea.current_es.search.assert_called_with(body={'filter': {'bool': {'must': [{'range': {'@timestamp': {'to': END_TIMESTAMP, 'from': START_TIMESTAMP}}}]}}, 'sort': [{'@timestamp': {'order': 'asc'}}]}, index='idx', _source_include=['@timestamp'], ignore_unavailable=True, size=100000)
 
 
 def test_no_hits(ea):
@@ -325,7 +325,7 @@ def test_count(ea):
         query['query']['filtered']['filter']['bool']['must'][0]['range']['@timestamp']['to'] = dt_to_ts(end)
         query['query']['filtered']['filter']['bool']['must'][0]['range']['@timestamp']['from'] = dt_to_ts(start)
         start = start + ea.run_every
-        ea.current_es.count.assert_any_call(body=query, doc_type='doctype', index='idx')
+        ea.current_es.count.assert_any_call(body=query, doc_type='doctype', index='idx', ignore_unavailable=True)
 
 
 def test_queries_with_rule_buffertime(ea):
@@ -347,7 +347,7 @@ def test_queries_with_rule_buffertime(ea):
         query['filter']['bool']['must'][0]['range']['@timestamp']['to'] = dt_to_ts(end)
         query['filter']['bool']['must'][0]['range']['@timestamp']['from'] = dt_to_ts(start)
         start = start + ea.run_every
-        ea.current_es.search.assert_any_call(body=query, size=ea.max_query_size, index='idx', _source_include=['@timestamp'])
+        ea.current_es.search.assert_any_call(body=query, size=ea.max_query_size, index='idx', ignore_unavailable=True, _source_include=['@timestamp'])
 
     # Assert that num_hits correctly summed every result
     assert ea.num_hits == ea.current_es.search.call_count


### PR DESCRIPTION
When using use_stftime_index, 404 IndexMissingExceptions may occur when the time rolls over to a new day and nothing is in that index yet. This treats a missing index as an empty index.