### PR TITLE
Top count bug fix

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -77,11 +77,11 @@ where X is 5 by default, or ``top_count_number`` if it exists.
 For example, if ``num_events`` is 100, and ``top_count_keys`` is ``- "username"``, the alert will say how many of the 100 events
 have each username, for the top 5 usernames. When this is computed, the time range used is from ``timeframe`` before the most recent event
 to 10 minutes past the most recent event. Because ElastAlert uses an aggregation query to compute this, it will attempt to use the
-field name plus ".raw" to count unanalyzed terms. To turn this off, set ``count_raw_keys`` to false.
+field name plus ".raw" to count unanalyzed terms. To turn this off, set ``raw_count_keys`` to false.
 
 ``top_count_number``: The number of terms to list if ``top_count_keys`` is set. (Optional, integer, default 5)
 
-``count_raw_keys``: If true, all fields in ``top_count_keys`` will have ``.raw`` appended to them. (Optional, boolean, default true)
+``raw_count_keys``: If true, all fields in ``top_count_keys`` will have ``.raw`` appended to them. (Optional, boolean, default true)
 
 ``generate_kibana_link``: If true, ElastAlert will generate a temporary Kibana dashboard and include a link to it in alerts. The dashboard
 consists of an events over time graph and a table with ``include`` fields selected in the table. If the rule uses ``query_key``, the

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -76,9 +76,12 @@ For more information writing filters, see :ref:`Writing Filters <writingfilters>
 where X is 5 by default, or ``top_count_number`` if it exists.
 For example, if ``num_events`` is 100, and ``top_count_keys`` is ``- "username"``, the alert will say how many of the 100 events
 have each username, for the top 5 usernames. When this is computed, the time range used is from ``timeframe`` before the most recent event
-to 10 minutes past the most recent event.
+to 10 minutes past the most recent event. Because ElastAlert uses an aggregation query to compute this, it will attempt to use the
+field name plus ".raw" to count unanalyzed terms. To turn this off, set ``count_raw_keys`` to false.
 
-``top_count_number``: The number of terms to list if ``top_count_keys`` is set.
+``top_count_number``: The number of terms to list if ``top_count_keys`` is set. (Optional, integer, default 5)
+
+``count_raw_keys``: If true, all fields in ``top_count_keys`` will have ``.raw`` appended to them. (Optional, boolean, default true)
 
 ``generate_kibana_link``: If true, ElastAlert will generate a temporary Kibana dashboard and include a link to it in alerts. The dashboard
 consists of an events over time graph and a table with ``include`` fields selected in the table. If the rule uses ``query_key``, the

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -157,6 +157,10 @@ def load_configuration(filename):
     include.append(rule['timestamp_field'])
     rule['include'] = list(set(include))
 
+    # Change top_count_keys to .raw
+    if 'top_count_keys' in rule and rule.get('raw_count_keys', True):
+	rule['top_count_keys'] = [key+'.raw' if not key.endswith('.raw') else key for key in rule.get('top_count_keys')] 
+
     # Check that generate_kibana_url is compatible with the filters
     if rule.get('generate_kibana_link'):
         for es_filter in rule.get('filter'):

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -159,7 +159,8 @@ def load_configuration(filename):
 
     # Change top_count_keys to .raw
     if 'top_count_keys' in rule and rule.get('raw_count_keys', True):
-        rule['top_count_keys'] = [key + '.raw' if not key.endswith('.raw') else key for key in rule.get('top_count_keys')]
+        keys = rule.get('top_count_keys')
+        rule['top_count_keys'] = [key + '.raw' if not key.endswith('.raw') else key for key in keys]
 
     # Check that generate_kibana_url is compatible with the filters
     if rule.get('generate_kibana_link'):

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -159,7 +159,7 @@ def load_configuration(filename):
 
     # Change top_count_keys to .raw
     if 'top_count_keys' in rule and rule.get('raw_count_keys', True):
-	rule['top_count_keys'] = [key+'.raw' if not key.endswith('.raw') else key for key in rule.get('top_count_keys')] 
+        rule['top_count_keys'] = [key + '.raw' if not key.endswith('.raw') else key for key in rule.get('top_count_keys')]
 
     # Check that generate_kibana_url is compatible with the filters
     if rule.get('generate_kibana_link'):

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -176,9 +176,9 @@ class ElastAlerter():
         logging.info("Queried rule %s from %s to %s: %s hits" % (rule['name'], pretty_ts(starttime, lt), pretty_ts(endtime, lt), len(hits)))
         self.replace_ts(hits, rule)
 
-	# Record doc_type for use in get_top_counts
-	if 'doc_type' not in rule and len(hits):
-		rule['doc_type'] = hits[0]['_type']
+        # Record doc_type for use in get_top_counts
+        if 'doc_type' not in rule and len(hits):
+            rule['doc_type'] = hits[0]['_type']
         return hits
 
     def replace_ts(self, hits, rule):
@@ -216,9 +216,9 @@ class ElastAlerter():
     def get_hits_terms(self, rule, starttime, endtime, index, key, qk=None):
         rule_filter = copy.copy(rule['filter'])
         if qk:
-	    filter_key = rule['query_key']
-	    if rule.get('raw_count_terms', True) and not rule['query_key'].endswith('.raw'):
-	        filter_key += '.raw'
+            filter_key = rule['query_key']
+            if rule.get('raw_count_terms', True) and not rule['query_key'].endswith('.raw'):
+                filter_key += '.raw'
             rule_filter.extend([{'term': {filter_key: qk}}])
         base_query = self.get_query(rule_filter, starttime, endtime, timestamp_field=rule['timestamp_field'], sort=False)
         query = self.get_terms_query(base_query, rule.get('terms_size', 5), key)

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -675,8 +675,8 @@ class ElastAlerter():
                     qk = match[rule['query_key']]
                 else:
                     qk = None
-                start = ts_add(match[rule['timestamp_field']], -rule.get('timeframe', datetime.timedelta(minutes=10)))
-                end = ts_add(match[rule['timestamp_field']], datetime.timedelta(minutes=10))
+                start = ts_to_dt(match[rule['timestamp_field']]) - rule.get('timeframe', datetime.timedelta(minutes=10))
+                end = ts_to_dt(match[rule['timestamp_field']]) + datetime.timedelta(minutes=10)
                 keys = rule.get('top_count_keys')
                 counts = self.get_top_counts(rule, start, end, keys, rule.get('top_count_number'), qk)
                 match.update(counts)

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -217,7 +217,7 @@ class ElastAlerter():
         rule_filter = copy.copy(rule['filter'])
         if qk:
             filter_key = rule['query_key']
-            if rule.get('raw_count_terms', True) and not rule['query_key'].endswith('.raw'):
+            if rule.get('raw_count_keys', True) and not rule['query_key'].endswith('.raw'):
                 filter_key += '.raw'
             rule_filter.extend([{'term': {filter_key: qk}}])
         base_query = self.get_query(rule_filter, starttime, endtime, timestamp_field=rule['timestamp_field'], sort=False)

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -175,6 +175,10 @@ class ElastAlerter():
         lt = rule.get('use_local_time')
         logging.info("Queried rule %s from %s to %s: %s hits" % (rule['name'], pretty_ts(starttime, lt), pretty_ts(endtime, lt), len(hits)))
         self.replace_ts(hits, rule)
+
+	# Record doc_type for use in get_top_counts
+	if 'doc_type' not in rule and len(hits):
+		rule['doc_type'] = hits[0]['_type']
         return hits
 
     def replace_ts(self, hits, rule):
@@ -212,7 +216,10 @@ class ElastAlerter():
     def get_hits_terms(self, rule, starttime, endtime, index, key, qk=None):
         rule_filter = copy.copy(rule['filter'])
         if qk:
-            rule_filter.extend([{'term': {rule['query_key']: qk}}])
+	    filter_key = rule['query_key']
+	    if rule.get('raw_count_terms', True) and not rule['query_key'].endswith('.raw'):
+	        filter_key += '.raw'
+            rule_filter.extend([{'term': {filter_key: qk}}])
         base_query = self.get_query(rule_filter, starttime, endtime, timestamp_field=rule['timestamp_field'], sort=False)
         query = self.get_terms_query(base_query, rule.get('terms_size', 5), key)
 

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -30,7 +30,7 @@ def generate_hits(timestamps, **kwargs):
     hits = []
     id_iter = xrange(len(timestamps)).__iter__()
     for ts in timestamps:
-        data = {'_id': 'id' + str(id_iter.next()), '_source': {'@timestamp': ts}}
+        data = {'_id': 'id' + str(id_iter.next()), '_source': {'@timestamp': ts}, '_type': 'logs'}
         for key, item in kwargs.iteritems():
             data['_source'][key] = item
         hits.append(data)


### PR DESCRIPTION
Couple of fixes/features here:

1. Match timestamp fields are properly converted before calling get_top_counts
2. Query key is filtered by '.raw' field. With an analyzed field, passing the data to a term filter can result in an unexpected lack of hits.
3. Similarly, top_count_keys are defaulted to '.raw'. This is because otherwise they often come up as
"this": 5
"field": 5
"is": 5
"analyzed": 5

instead of

"this field is analyzed": 5