### PR TITLE
exponential_realert option

### DIFF
--- a/docs/source/elastalert_status.rst
+++ b/docs/source/elastalert_status.rst
@@ -63,6 +63,8 @@ an alert with ``realert`` is triggered, a ``silence`` record will be written wit
 - ``@timestamp``: The time when the document was uploaded to Elasticsearch.
 - ``rule_name``: The name of the corresponding rule.
 - ``until``: The timestamp when alerts will begin being sent again.
+- ``exponent``: The exponential factor which multiplies ``realert``. The length of this silence is equal to ``realert`` * 2**exponent. This will
+be 0 unless ``exponential_realert`` is set.
 
 Whenever an alert is triggered, ElastAlert will check for a matching ``silence`` document, and if the ``until`` timestamp is in the future, it will ignore
 the alert completely. See the :ref:`Running Elastalert <runningelastalert>` section for information on how to silence an alert.

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -57,6 +57,13 @@ the given time. This is applied to the time the alert is sent, not to the time o
 that if ElastAlert is run over a large time period which triggers many matches, only the first alert will be sent by default. If you want
 every alert, set realert to 0 minutes. (Optional, time, default 1 minute)
 
+``exponential_realert``: This option causes the value of ``realert`` to exponentially increase while alerts continue to fire. If set,
+the value of ``exponential_realert`` is the maximum ``realert`` will increase to. If the time between alerts is less than twice ``realert``,
+``realert`` will double. For example, if ``realert: minutes: 10`` and ``exponential_realert: hours: 1``, an alerts fires at 1:00 and another
+at 1:15, the next alert will not be until at least 1:35. If another alert fires between 1:35 and 2:15, ``realert`` will increase to the
+1 hour maximum. If more than 2 hours elapses before the next alert, ``realert`` will go back down. Note that alerts that are ignored, eg,
+one that occured at 1:05, would not change ``realert``. (Optional, time, no default)
+
 ``buffer_time``: This options allows the rule to override the ``buffer_time`` global setting defined in config.yaml. (Optional, time)
 
 ``max_query_size``: The maximum number of documents that will be downloaded from Elasticsearch in a single query. If you

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -82,6 +82,8 @@ def load_options(rule):
             rule['query_delay'] = datetime.timedelta(**rule['query_delay'])
         if 'buffer_time' in rule:
             rule['buffer_time'] = datetime.timedelta(**rule['buffer_time'])
+        if 'exponential_realert' in rule:
+            rule['exponential_realert'] = datetime.timedelta(**rule['exponential_realert'])
     except (KeyError, TypeError) as e:
         raise EAException('Invalid time format used: %s' % (e))
 

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -139,3 +139,7 @@ def format_index(index, start, end):
 
 class EAException(Exception):
     pass
+
+
+def seconds(td):
+    return td.seconds + td.days * 24 * 3600

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -498,3 +498,31 @@ def test_count_keys(ea):
     assert calls[0][1]['body']['aggs']['filtered']['aggs']['counts']['terms'] == {'field': 'this', 'size': 5}
     assert counts['top_events_this'] == {'a': 10, 'b': 5}
     assert counts['top_events_that'] == {'d': 10, 'c': 12}
+
+
+def test_expontential_realert(ea):
+    ea.rules[0]['exponential_realert'] = datetime.timedelta(days=1)  # 1 day ~ 10 * 2**13 seconds
+    ea.rules[0]['realert'] = datetime.timedelta(seconds=10)
+
+    until = ts_to_dt('2015-03-24T00:00:00')
+    ts5s = until + datetime.timedelta(seconds=5)
+    ts15s = until + datetime.timedelta(seconds=15)
+    ts1m = until + datetime.timedelta(minutes=1)
+    ts5m = until + datetime.timedelta(minutes=5)
+    ts4h = until + datetime.timedelta(hours=4)
+
+    test_values = [(ts5s, until, 0),  # Exp will increase to 1, 10*2**0 = 10s
+                   (ts15s, until, 0),  # Exp will stay at 0, 10*2**0 = 10s
+                   (ts15s, until, 1),  # Exp will increase to 2, 10*2**1 = 20s
+                   (ts1m, until, 2),  # Exp will decrease to 1, 10*2**2 = 40s
+                   (ts1m, until, 3),  # Exp will increase to 4, 10*2**3 = 1m20s
+                   (ts5m, until, 1),  # Exp will lower back to 0, 10*2**1 = 20s
+                   (ts4h, until, 9),  # Exp will lower back to 0, 10*2**9 = 1h25m
+                   (ts4h, until, 10),  # Exp will lower back to 9, 10*2**10 = 2h50m
+                   (ts4h, until, 11)]  # Exp will increase to 12, 10*2**11 = 5h
+    results = (1, 0, 2, 1, 4, 0, 0, 9, 12)
+    next_res = iter(results)
+    for args in test_values:
+        ea.silence_cache[ea.rules[0]['name']] = (args[1], args[2])
+        next_alert, exponent = ea.next_alert_time(ea.rules[0], ea.rules[0]['name'], args[0])
+        assert exponent == next_res.next()

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -511,13 +511,13 @@ def test_expontential_realert(ea):
     ts5m = until + datetime.timedelta(minutes=5)
     ts4h = until + datetime.timedelta(hours=4)
 
-    test_values = [(ts5s, until, 0),  # Exp will increase to 1, 10*2**0 = 10s
+    test_values = [(ts5s, until, 0),   # Exp will increase to 1, 10*2**0 = 10s
                    (ts15s, until, 0),  # Exp will stay at 0, 10*2**0 = 10s
                    (ts15s, until, 1),  # Exp will increase to 2, 10*2**1 = 20s
-                   (ts1m, until, 2),  # Exp will decrease to 1, 10*2**2 = 40s
-                   (ts1m, until, 3),  # Exp will increase to 4, 10*2**3 = 1m20s
-                   (ts5m, until, 1),  # Exp will lower back to 0, 10*2**1 = 20s
-                   (ts4h, until, 9),  # Exp will lower back to 0, 10*2**9 = 1h25m
+                   (ts1m, until, 2),   # Exp will decrease to 1, 10*2**2 = 40s
+                   (ts1m, until, 3),   # Exp will increase to 4, 10*2**3 = 1m20s
+                   (ts5m, until, 1),   # Exp will lower back to 0, 10*2**1 = 20s
+                   (ts4h, until, 9),   # Exp will lower back to 0, 10*2**9 = 1h25m
                    (ts4h, until, 10),  # Exp will lower back to 9, 10*2**10 = 2h50m
                    (ts4h, until, 11)]  # Exp will increase to 12, 10*2**11 = 5h
     results = (1, 0, 2, 1, 4, 0, 0, 9, 12)


### PR DESCRIPTION
Silences now contain an exponent. By setting exponential_realert, realert will continue to double, up to exponential_realert, while the alerts are occurring within 2*realert of each other. If the time between alerts is longer, the exponent will decrease.

Fixes issue #8 