### PR TITLE
Added another spike skip condition for after an alert

### DIFF
--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -312,6 +312,9 @@ def test_spike_terms():
     terms4 = {ts_to_dt('2014-01-01T00:27:00Z'): [{'key': 'userA', 'doc_count': 10},
                                                  {'key': 'userB', 'doc_count': 12},
                                                  {'key': 'userC', 'doc_count': 100}]}
+    terms5 = {ts_to_dt('2014-01-01T00:30:00Z'): [{'key': 'userD', 'doc_count': 100},
+                                                 {'key': 'userC', 'doc_count': 100}]}
+
     rule = SpikeRule(rules)
 
     # Initial input
@@ -345,6 +348,12 @@ def test_spike_terms():
     rule.add_terms_data(terms3)
     rule.add_terms_data(terms4)
     assert len(rule.matches) == 1
+
+    # Test that another alert doesn't fire immediately for userC but it does for userD
+    rule.matches = []
+    rule.add_terms_data(terms5)
+    assert len(rule.matches) == 1
+    assert rule.matches[0]['username'] == 'userD'
 
 
 def test_blacklist():


### PR DESCRIPTION
Fixes a bug where if alert_on_new_data is set, after an alert, checking for alert conditions will resume immediately, triggering an unexpected alert because ref_window was cleared. Previous, there were two conditions for skipping checks:

1. Not enough time passed for this qk and alert_on_new_data is not set
2. Not enough time passed for any qk

This adds a third condition

3. Not enough time passed for this qk and not enough time has passed since an alert for this key

Fixes issue #40 