### PR TITLE
Changed example to actually work

### DIFF
--- a/docs/source/recipes/adding_alerts.rst
+++ b/docs/source/recipes/adding_alerts.rst
@@ -86,7 +86,7 @@ Now, in a file named ``my_alerts.py``, add
                     
                     # basic_match_string will transform the match into the default
                     # human readable string format
-                    match_string = basic_match_string(match)
+                    match_string = basic_match_string(self.rule, match)
                     
                     output_file.write(match_string)
 
@@ -95,7 +95,7 @@ Now, in a file named ``my_alerts.py``, add
         # It should return a dict of information relevant to what the alert does
         def get_info(self):
             return {'type': 'Awesome Alerter',
-                    'output_file': self.rule['output_file_path'}
+                    'output_file': self.rule['output_file_path']}
 
 
 In the rule configuration file, we are going to specify the alert by writing

--- a/docs/source/running_elastalert.rst
+++ b/docs/source/running_elastalert.rst
@@ -120,7 +120,7 @@ Running ElastAlert
 
 There are two ways of invoking ElastAlert. As a daemon, through Supervisor (http://supervisord.org/), or directly with Python. For easier debugging purposes in this tutorial, we will invoke it directly::
 
-    $ python elastalert/elastalert.py --verbose --rule example_frequency.yaml
+    $ python -m elastalert.elastalert --verbose --rule example_frequency.yaml
     No handlers could be found for logger "elasticsearch"
     INFO:root:Queried rule Example rule from 1-15 14:22 PST to 1-15 15:07 PST: 5 hits
     INFO:elasticsearch:POST http://elasticsearch.example.com:14900/elastalert_status/elastalert_status?op_type=create [status:201 request:0.025s]

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -44,8 +44,8 @@ def get_module(module_name):
         module_path, module_class = module_name.rsplit('.', 1)
         base_module = __import__(module_path, globals(), locals(), [module_class])
         module = getattr(base_module, module_class)
-    except (ImportError, AttributeError, ValueError):
-        raise EAException("Could not import match module %s" % (module_name))
+    except (ImportError, AttributeError, ValueError) as e:
+        raise EAException("Could not import module %s: %s" % (module_name, e))
     return module
 
 

--- a/example_rules/example_change.yaml
+++ b/example_rules/example_change.yaml
@@ -36,6 +36,10 @@ index: logstash-*
 # The field to look for changes in
 compare_key: country_name
 
+# (Required, change specific)
+# Ignore documents without the compare_key (country_name) field
+ignore_null: true
+
 # (Optional, change specific)
 # The change must occur in two documents with the same query_key
 query_key: username


### PR DESCRIPTION
1. example_change was missing a required ignore_null field.
2. The invocation of elastalert as a file causes the module to attempt import from the wrong location.
3. There were two errors in the example alerter.
4. Import errors were cryptic