### PR TITLE
Fixed no hits in terms query

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -269,6 +269,8 @@ class ElastAlerter():
             self.handle_error('Error running query: %s' % (e), {'rule': rule['name']})
             return None
 
+        if 'aggregations' not in res:
+            return {}
         buckets = res['aggregations']['filtered']['counts']['buckets']
         self.num_hits += len(buckets)
         lt = rule.get('use_local_time')

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -85,6 +85,15 @@ def test_no_hits(ea):
     assert ea.rules[0]['type'].add_data.call_count == 0
 
 
+def test_no_terms_hits(ea):
+    ea.rules[0]['use_terms_query'] = True
+    ea.rules[0]['query_key'] = 'QWERTY'
+    ea.rules[0]['doc_type'] = 'uiop'
+    ea.current_es.search.return_value = {'hits': {'hits': []}}
+    ea.run_query(ea.rules[0], START, END)
+    assert ea.rules[0]['type'].add_terms_data.call_count == 0
+
+
 def test_some_hits(ea):
     hits = generate_hits([START_TIMESTAMP, END_TIMESTAMP])
     ea.current_es.search.return_value = hits

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ class mock_ruletype(object):
     def __init__(self):
         self.add_data = mock.Mock()
         self.add_count_data = mock.Mock()
+        self.add_terms_data = mock.Mock()
         self.matches = []
         self.get_match_data = lambda x: x
         self.get_match_str = lambda x: "some stuff happened"


### PR DESCRIPTION
There was a big that if there was no hits for a terms aggregation query, it would throw a KeyError.