### PR TITLE
Added unhashable compatibility for ChangeRule query_key

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -146,7 +146,7 @@ class ChangeRule(CompareRule):
         # TODO this is not technically correct
         # if the term changes multiple times before an alert is sent
         # this data will be overwritten with the most recent change
-        change = self.change_map.get(match[self.rules['query_key']])
+        change = self.change_map.get(hashable(lookup_es_key(match, self.rules['query_key'])))
         extra = {}
         if change:
             extra = {'old_value': change[0],

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -403,6 +403,13 @@ def test_change():
     rule.add_data(events)
     assert_matches_have(rule.matches, [('term', 'bad')])
 
+    # Unhashable QK
+    events2 = hits(10, username=['qlo'], term='good')
+    events2[9]['term'] = 'bad'
+    rule = ChangeRule(rules)
+    rule.add_data(events2)
+    assert_matches_have(rule.matches, [('term', 'bad')])
+
     # Don't ignore nulls
     rules['ignore_null'] = False
     rule = ChangeRule(rules)


### PR DESCRIPTION
If the query_key was a list for example, ChangeRule would fail when add_match attempts to access the key in the match.