### PR TITLE
Unhashable qk

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -443,7 +443,7 @@ class ElastAlerter():
             # concatenate query_key (or none) with rule_name to form silence_cache key
             if 'query_key' in rule:
                 try:
-                    key = '.' + match[rule['query_key']]
+                    key = '.' + str(match[rule['query_key']])
                 except KeyError:
                     # Some matches may not have a query key
                     key = ''

--- a/elastalert/kibana.py
+++ b/elastalert/kibana.py
@@ -200,7 +200,12 @@ def add_filter(dashboard, es_filter):
         if isinstance(f_query, basestring):
             f_query = '"%s"' % (f_query.replace('"', '\\"'))
         if isinstance(f_query, list):
-            f_query = '(%s)' % (' AND '.join(['"%s"' % (item.replace('"', '\\"')) for item in f_query]))
+            # Escape quotes
+            f_query = [item.replace('"', '\\"') for item in f_query]
+            # Wrap in quotes
+            f_query = ['"%s"' % (item) for item in f_query]
+            # Convert into joined query
+            f_query = '(%s)' % (' AND '.join(f_query))
         kibana_filter['field'] = f_field
         kibana_filter['query'] = f_query
     elif 'range' in es_filter:

--- a/elastalert/kibana.py
+++ b/elastalert/kibana.py
@@ -199,6 +199,8 @@ def add_filter(dashboard, es_filter):
         # Wrap query in quotes, otherwise certain characters cause kibana to throw errors
         if isinstance(f_query, basestring):
             f_query = '"%s"' % (f_query.replace('"', '\\"'))
+        if isinstance(f_query, list):
+            f_query = '(%s)' % (' AND '.join(['"%s"' % (item.replace('"', '\\"')) for item in f_query]))
         kibana_filter['field'] = f_field
         kibana_filter['query'] = f_query
     elif 'range' in es_filter:

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -39,8 +39,14 @@ class RuleType(object):
 
         :param event: The matching event, a dictionary of terms.
         """
-        if '@timestamp' in event:
-            event['@timestamp'] = dt_to_ts(event['@timestamp'])
+        # Convert datetime's back to timestamps
+        ts = self.rules.get('timestamp_field')
+        if ts in event:
+            event[ts] = dt_to_ts(event[ts])
+        # Convert unhashable query_key values to strings
+        qk = self.rules.get('query_key')
+        if qk and qk in event:
+            event[qk] = hashable(event[qk])
         self.matches.append(event)
 
     def get_match_str(self, match):
@@ -228,7 +234,8 @@ class AnyRule(RuleType):
     """ A rule that will match on any input data """
 
     def add_data(self, data):
-        self.matches += data
+        for datum in data:
+            self.add_match(datum)
 
 
 class EventWindow(object):

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -43,10 +43,6 @@ class RuleType(object):
         ts = self.rules.get('timestamp_field')
         if ts in event:
             event[ts] = dt_to_ts(event[ts])
-        # Convert unhashable query_key values to strings
-        qk = self.rules.get('query_key')
-        if qk and qk in event:
-            event[qk] = hashable(event[qk])
         self.matches.append(event)
 
     def get_match_str(self, match):

--- a/tests/kibana_test.py
+++ b/tests/kibana_test.py
@@ -1,5 +1,8 @@
+import copy
 import json
 
+from elastalert.kibana import add_filter
+from elastalert.kibana import dashboard_temp
 from elastalert.kibana import filters_from_dashboard
 
 
@@ -52,3 +55,15 @@ def test_filters_from_dashboard():
     filters = filters_from_dashboard(test_dashboard)
     assert {'term': {'_log_type': '"active_directory"'}} in filters
     assert {'query': {'query_string': {'query': 'ad.security_auditing_code:4740'}}} in filters
+
+
+def test_add_filter():
+    basic_filter = {"term": {"this": "that"}}
+    db = copy.deepcopy(dashboard_temp)
+    add_filter(db, basic_filter)
+    assert db['services']['filter']['list']['1'] == {'field': 'this', 'alias': '', 'mandate': 'must', 'active': True, 'query': '"that"', 'type': 'field', 'id': 1}
+
+    list_filter = {"term": {"this": ["that", "those"]}}
+    db = copy.deepcopy(dashboard_temp)
+    add_filter(db, list_filter)
+    assert db['services']['filter']['list']['1'] == {'field': 'this', 'alias': '', 'mandate': 'must', 'active': True, 'query': '("that" AND "those")', 'type': 'field', 'id': 1}

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -47,6 +47,7 @@ def test_freq():
     assert len(rule.matches) == 1
 
     # Test wit query_key
+    events = hits(60, 'blah', username='qlo')
     rules['query_key'] = 'username'
     rule = FrequencyRule(rules)
     rule.add_data(events)


### PR DESCRIPTION
Fixed error when trying to construct "rulename.query_key" when query_key is a list.
Added support for lists in kibana add_filter.
Fixed datetime's not being converted if timestamp_field wasn't the default.
Fixed type=any rule skipping timestamp conversion.
Added a test for kibana.
Fixed a test that broke when I fixed the timestamp conversion. (Hits was reused, broke when timestamp field was converted in add_match)