### PR TITLE
Flatline terms query, and some general build/testing fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ virtualenv_run/
 dist/
 venv/
 docs/build/
+build/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,18 @@
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: 5fe82b3a37983b3270b7afa2ed80b90b158f3a7c
+    sha: 2d83e302cc2757a28cedc03e6bb075de913c1804
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: autopep8-wrapper
-        args: ['-i', '--ignore=E265,E309,E501']
+        args:
+        - -i
+        - --ignore=E265,E309,E501
     -   id: flake8
     -   id: check-yaml
     -   id: debug-statements
     -   id: requirements-txt-fixer
     -   id: name-tests-test
 -   repo: git://github.com/asottile/reorder_python_imports
-    sha: a46fdf085aaa9afc4ab68015f903ac6c824a5b42
+    sha: 3d86483455ab5bd06cc1069fdd5ac57be5463f10
     hooks:
     -   id: reorder-python-imports

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ clean:
 	make -C docs clean
 	find . -name '*.pyc' -delete
 	find . -name '__pycache__' -delete
-	rm -rf virtualenv_run .tox .coverage *.egg-info
+	rm -rf virtualenv_run .tox .coverage *.egg-info build
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ envdir = virtualenv_run
 commands =
 
 [pytest]
-norecursedirs = .* virtualenv_run docs
+norecursedirs = .* virtualenv_run docs build
 
 [testenv:docs]
 deps = {[testenv]deps}


### PR DESCRIPTION
Did a few thing here:

*Flatline terms query*
* Now supporting `use_terms_query` for flatline rule. Added some tests.

*check_for_match optimization*
* when used with a terms query, the `check_for_match` function loops over all the keys. I pulled the for loop outside of that function.  

*Build/test stuff:*
* ignored the `build/` (created by running `python setup.py install` directory in lots of places. This directory was causing import errors when tox ran
* updated pre-commit hooks sha - old one was causing some issues