### PR TITLE
Added scan_subdirectories option to load rules recursively

### DIFF
--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -108,11 +108,8 @@ even if ElastAlert is stopped and restarted, it will never miss data or look at 
 ``es_password``: Optional; basic-auth password for connecting to ``es_host``.
 
 ``rules_folder``: The name of the folder which contains rule configuration files. ElastAlert will load all
-files in this folder that end in .yaml. If the contents of this folder change, ElastAlert will load, reload
+files in this folder, and all subdirectories, that end in .yaml. If the contents of this folder change, ElastAlert will load, reload
 or remove rules based on their respective config files.
-
-``scan_subdirectories``: If true, ElastAlert will recursively scan ``rules_folder`` for yaml files to load as rules.
-If false, only the files in that directory will be loaded. This defaults to false.
 
 ``run_every``: How often ElastAlert should query Elasticsearch. ElastAlert will remember the last time
 it ran the query for a given rule, and periodically query from that time until the present. The format of
@@ -153,7 +150,8 @@ sent until that rule has finished querying over the entire time period.
 ``--end <timestamp>`` will cause ElastAlert to stop querying at the specified timestamp. By default, ElastAlert
 will periodically query until the present indefinitely.
 
-``--rule <rule.yaml>`` will only run the given rule. The rule file must still be in the ``rules_folder``.
+``--rule <rule.yaml>`` will only run the given rule. The rule file may be a complete file path or a filename in ``rules_folder``
+or it's subdirectories.
 
 ``--silence <unit>=<number>`` will silence the alerts for a given rule for a period of time. The rule must be specified using
 ``--rule``. <unit> is one of days, weeks, hours, minutes or seconds. <number> is an integer. For example,

--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -111,6 +111,9 @@ even if ElastAlert is stopped and restarted, it will never miss data or look at 
 files in this folder that end in .yaml. If the contents of this folder change, ElastAlert will load, reload
 or remove rules based on their respective config files.
 
+``scan_subdirectories``: If true, ElastAlert will recursively scan ``rules_folder`` for yaml files to load as rules.
+If false, only the files in that directory will be loaded. This defaults to false.
+
 ``run_every``: How often ElastAlert should query Elasticsearch. ElastAlert will remember the last time
 it ran the query for a given rule, and periodically query from that time until the present. The format of
 this field is a nested unit of time, such as ``minutes: 5``. This is how time is defined in every ElastAlert

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -69,7 +69,7 @@ class ElastAlerter():
         self.current_es_addr = None
         self.buffer_time = self.conf['buffer_time']
         self.silence_cache = {}
-        self.rule_hashes = get_rule_hashes(self.conf)
+        self.rule_hashes = get_rule_hashes(self.conf, self.args.rule)
 
         self.es_conn_config = self.build_es_conn_config(self.conf)
 
@@ -517,7 +517,7 @@ class ElastAlerter():
     def load_rule_changes(self):
         ''' Using the modification times of rule config files, syncs the running rules
         to match the files in rules_folder by removing, adding or reloading rules. '''
-        rule_hashes = get_rule_hashes(self.conf)
+        rule_hashes = get_rule_hashes(self.conf, self.args.rule)
 
         # Check each current rule for changes
         for rule_file, hash_value in self.rule_hashes.iteritems():


### PR DESCRIPTION
This adds the option scan_subdirectories, which allows you to recursively load rules from rules_folder and it's subdirectories. I added a basic unit test for getting file paths. I also manually tested this and verified that it correctly picked up on changes.