### PR TITLE
Allow callers to run rules using their own looping construct, or to stop the elastalert loop themselves

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -560,7 +560,8 @@ class ElastAlerter():
             except (TypeError, ValueError):
                 self.handle_error("%s is not a valid ISO 8601 timestamp (YYYY-MM-DDTHH:MM:SS+XX:00)" % (self.starttime))
                 exit(1)
-        while True:
+        self.running = True
+        while self.running:
             self.run_all_rules()
 
     def run_all_rules(self):
@@ -613,6 +614,10 @@ class ElastAlerter():
         sleep_for = (next_run - datetime.datetime.utcnow()).seconds
         logging.info("Sleeping for %s seconds" % (sleep_for))
         time.sleep(sleep_for)
+
+    def stop(self):
+        """ Stop an elastalert runner that's been started """
+        self.running = False
 
     def generate_kibana_db(self, rule, match):
         ''' Uses a template dashboard to upload a temp dashboard showing the match.

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -510,7 +510,7 @@ def test_count_keys(ea):
     assert counts['top_events_that'] == {'d': 10, 'c': 12}
 
 
-def test_expontential_realert(ea):
+def test_exponential_realert(ea):
     ea.rules[0]['exponential_realert'] = datetime.timedelta(days=1)  # 1 day ~ 10 * 2**13 seconds
     ea.rules[0]['realert'] = datetime.timedelta(seconds=10)
 
@@ -539,13 +539,14 @@ def test_expontential_realert(ea):
 
 
 def test_stop(ea):
-    with mock.patch.object(ea, 'run_all_rules'):
-        start_thread = threading.Thread(target=ea.start)
-        start_thread.start()
-    assert ea.running
+    with mock.patch.object(ea, 'sleep_for', return_value=None):
+        with mock.patch.object(ea, 'run_all_rules'):
+            start_thread = threading.Thread(target=ea.start)
+            start_thread.start()
+            assert ea.running
 
-    ea.stop()
-    start_thread.join()
+            ea.stop()
+            start_thread.join()
 
-    assert not ea.running
-    assert not start_thread.is_alive()
+            assert not ea.running
+            assert not start_thread.is_alive()

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -2,6 +2,7 @@
 import copy
 import datetime
 import json
+import threading
 
 import elasticsearch
 import mock
@@ -535,3 +536,16 @@ def test_expontential_realert(ea):
         ea.silence_cache[ea.rules[0]['name']] = (args[1], args[2])
         next_alert, exponent = ea.next_alert_time(ea.rules[0], ea.rules[0]['name'], args[0])
         assert exponent == next_res.next()
+
+
+def test_stop(ea):
+    with mock.patch.object(ea, 'run_all_rules'):
+        start_thread = threading.Thread(target=ea.start)
+        start_thread.start()
+    assert ea.running
+
+    ea.stop()
+    start_thread.join()
+
+    assert not ea.running
+    assert not start_thread.is_alive()


### PR DESCRIPTION
This should give callers greater control over starting and stopping the elastalert rule running loop. You could either call `run_all_rules` directly within your own loop, or call `stop` whenever you're ready to exit the elastalert loop. The latter approach is a bit trickier for the caller, since `start` won't return until `stop` is called, so you'll need to manage separate threads (or something similar).