### PR TITLE
Calling garbage collect after rule runs; test cleanup.

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -416,14 +416,13 @@ class ElastAlerter():
         # Run the rule
         # If querying over a large time period, split it up into chunks
         self.num_hits = 0
-        tmp_endtime = endtime
         buffer_time = rule.get('buffer_time', self.buffer_time)
         while endtime - rule['starttime'] > buffer_time:
             tmp_endtime = rule['starttime'] + self.run_every
             if not self.run_query(rule, rule['starttime'], tmp_endtime):
                 return 0
             rule['starttime'] = tmp_endtime
-            rule['type'].garbage_collect(endtime)
+            rule['type'].garbage_collect(tmp_endtime)
         if not self.run_query(rule, rule['starttime'], endtime):
             return 0
 

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -427,6 +427,8 @@ class ElastAlerter():
         if not self.run_query(rule, rule['starttime'], endtime):
             return 0
 
+        rule['type'].garbage_collect(endtime)
+
         # Process any new matches
         num_matches = len(rule['type'].matches)
         while rule['type'].matches:
@@ -968,14 +970,14 @@ class ElastAlerter():
     def is_silenced(self, rule_name):
         """ Checks if rule_name is currently silenced. Returns false on exception. """
 
-        if self.debug:
-            return False
-
         if rule_name in self.silence_cache:
             if ts_now() < self.silence_cache[rule_name][0]:
                 return True
             else:
                 return False
+
+        if self.debug:
+            return False
 
         query = {'filter': {'term': {'rule_name': rule_name}},
                  'sort': {'until': {'order': 'desc'}}}

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import argparse
 import copy
 import datetime
 import json
@@ -8,7 +9,6 @@ import sys
 import time
 import traceback
 
-import argparse
 import kibana
 from alerts import DebugAlerter
 from config import get_rule_hashes
@@ -20,6 +20,7 @@ from util import dt_to_ts
 from util import EAException
 from util import format_index
 from util import pretty_ts
+from util import replace_hits_ts
 from util import seconds
 from util import ts_add
 from util import ts_now
@@ -210,16 +211,12 @@ class ElastAlerter():
         self.num_hits += len(hits)
         lt = rule.get('use_local_time')
         logging.info("Queried rule %s from %s to %s: %s hits" % (rule['name'], pretty_ts(starttime, lt), pretty_ts(endtime, lt), len(hits)))
-        self.replace_ts(hits, rule)
+        replace_hits_ts(hits, rule)
 
         # Record doc_type for use in get_top_counts
         if 'doc_type' not in rule and len(hits):
             rule['doc_type'] = hits[0]['_type']
         return hits
-
-    def replace_ts(self, hits, rule):
-        for hit in hits:
-            hit['_source'][rule['timestamp_field']] = ts_to_dt(hit['_source'][rule['timestamp_field']])
 
     def get_hits_count(self, rule, starttime, endtime, index):
         """ Query elasticsearch for the count of results and returns a list of timestamps
@@ -426,10 +423,9 @@ class ElastAlerter():
             if not self.run_query(rule, rule['starttime'], tmp_endtime):
                 return 0
             rule['starttime'] = tmp_endtime
+            rule['type'].garbage_collect(endtime)
         if not self.run_query(rule, rule['starttime'], endtime):
             return 0
-
-        rule['type'].garbage_collect(endtime)
 
         # Process any new matches
         num_matches = len(rule['type'].matches)
@@ -934,6 +930,10 @@ class ElastAlerter():
 
     def silence(self):
         """ Silence an alert for a period of time. --silence and --rule must be passed as args. """
+        if self.debug:
+            logging.error('--silence not compatible with --debug')
+            exit(1)
+
         if not self.args.rule:
             logging.error('--silence must be used with --rule')
             exit(1)
@@ -967,6 +967,10 @@ class ElastAlerter():
 
     def is_silenced(self, rule_name):
         """ Checks if rule_name is currently silenced. Returns false on exception. """
+
+        if self.debug:
+            return False
+
         if rule_name in self.silence_cache:
             if ts_now() < self.silence_cache[rule_name][0]:
                 return True

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -56,6 +56,13 @@ def lookup_es_key(lookup_dict, term):
         return go_deeper
 
 
+def replace_hits_ts(hits, rule):
+    """Iterate through a hits dictionary from ElasticSearch, and convert string timestamps to datetime objects
+    """
+    for hit in hits:
+        hit['_source'][rule['timestamp_field']] = ts_to_dt(hit['_source'][rule['timestamp_field']])
+
+
 def ts_to_dt(timestamp):
     if isinstance(timestamp, datetime.datetime):
         logging.warning('Expected str timestamp, got datetime')

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -149,6 +149,11 @@ def test_run_rule_calls_garbage_collect(ea):
     # Running elastalert every hour for 12 hours, we should see self.garbage_collect called 12 times.
     assert mock_gc.call_count == 12
 
+    # The calls should be spaced 1 hour apart
+    expected_calls = [ts_to_dt(start_time) + datetime.timedelta(hours=i) for i in range(1, 13)]
+    for e in expected_calls:
+        mock_gc.assert_any_call(e)
+
 
 def run_rule_query_exception(ea, mock_es):
     with mock.patch('elastalert.elastalert.Elasticsearch') as mock_es_init:
@@ -182,7 +187,7 @@ def test_match_with_module(ea):
     mod.process = mock.Mock()
     ea.rules[0]['match_enhancements'] = [mod]
     test_match(ea)
-    assert mod.process.called_with({'@timestamp': END})
+    mod.process.assert_called_with({'@timestamp': END})
 
 
 def test_agg(ea):
@@ -488,8 +493,8 @@ def test_rule_changes(ea):
 
     # Assert 2 and 3 were reloaded
     assert mock_load.call_count == 2
-    assert mock_load.called_with('rules/rule2.yaml')
-    assert mock_load.called_with('rules/rule3.yaml')
+    mock_load.assert_any_call('rules/rule2.yaml')
+    mock_load.assert_any_call('rules/rule3.yaml')
 
 
 def test_strf_index(ea):

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -146,9 +146,8 @@ def test_run_rule_calls_garbage_collect(ea):
     ) as (mock_gc, mock_get_hits):
         ea.run_rule(ea.rules[0], ts_to_dt(end_time), ts_to_dt(start_time))
 
-    # Running elastalert every hour for 12 hours (minus a 1 hour buffer time),
-    # we should see self.garbage_collect called 11 times
-    assert mock_gc.call_count == 11
+    # Running elastalert every hour for 12 hours, we should see self.garbage_collect called 12 times.
+    assert mock_gc.call_count == 12
 
 
 def run_rule_query_exception(ea, mock_es):

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -390,7 +390,17 @@ def test_whitelist():
     rule.add_data(events)
     assert_matches_have(rule.matches, [('term', 'bad'), ('term', 'really bad')])
 
-    # Don't ignore nulls
+
+def test_whitelist_dont_ignore_nulls():
+    events = [{'@timestamp': ts_to_dt('2014-09-26T12:34:56Z'), 'term': 'good'},
+              {'@timestamp': ts_to_dt('2014-09-26T12:34:57Z'), 'term': 'bad'},
+              {'@timestamp': ts_to_dt('2014-09-26T12:34:58Z'), 'term': 'also good'},
+              {'@timestamp': ts_to_dt('2014-09-26T12:34:59Z'), 'term': 'really bad'},
+              {'@timestamp': ts_to_dt('2014-09-26T12:35:00Z'), 'no_term': 'bad'}]
+    rules = {'whitelist': ['good', 'also good'],
+             'compare_key': 'term',
+             'ignore_null': True,
+             'timestamp_field': '@timestamp'}
     rules['ignore_null'] = False
     rule = WhitelistRule(rules)
     rule.add_data(events)


### PR DESCRIPTION
Doing a few things
* garbage collect every time a rule runs - should fix  issue with flatline rule not properly alerting when run over historical data
* add tests
* move replace_ts to util, since it doesn't really need to be a class function
* Fix all the warnings cause by `ts_to_dt` an `dt_to_ts` in test code
* Small cleanup