### PR TITLE
Fixed race condition in test_stop

### DIFF
--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -4,6 +4,7 @@ import copy
 import datetime
 import json
 import threading
+import time
 
 import elasticsearch
 import mock
@@ -567,6 +568,7 @@ def test_stop(ea):
         with mock.patch.object(ea, 'run_all_rules'):
             start_thread = threading.Thread(target=ea.start)
             start_thread.start()
+            time.sleep(1)
             assert ea.running
 
             ea.stop()


### PR DESCRIPTION
An assert came directly after thread.start(), not giving it time to create the ea.running variable.

Context is this change: https://github.com/Yelp/elastalert/pull/65.

Tests fail sometimes with an AttributeError and pass most of the time

