### PR TITLE
Added CommandAlerter for running arbitrary commands as an alert

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -498,7 +498,7 @@ until the command exits or sends an EOF to stdout.
 
 Example usage::
 
-    alerts:
+    alert:
       - command
     command: ["/bin/send_alert", "--username", "%(username)s"]
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -478,6 +478,36 @@ field_values will contain every key value pair included in the results from Elas
 every key in ``included``, every key in ``top_count_keys``, ``query_key``, and ``compare_key``. If the alert spans multiple events, these values may
 come from an individual event, usually the one which triggers the alert.
 
+Command
+~~~~~~~
+
+The command alert allows you to execute an arbitrary command and pass arguments or stdin from the match. Arguments to the command can use
+Python format string syntax to access parts of the match. The alerter will open a subprocess and optionally pass the match, as JSON, to 
+the stdin of the process.
+
+This alert requires one option:
+
+``command``: A list of arguments to execute or a string to execute. If in list format, the first argument is the name of the program to execute. If passing a
+string, the command will be executed through the shell. The command string or args will be formatted using Python's % string format syntax with the
+match passed the format argument. This means that a field can be accessed with ``%(field_name)s``.
+
+Optional:
+
+``pipe_match_json``: If true, the match will be converted to JSON and passed to stdin of the command. Note that this will cause ElastAlert to block
+until the command exits or sends an EOF to stdout.
+
+Example usage::
+
+    alerts:
+      - command
+    command: ["/bin/send_alert", "--username", "%(username)s"]
+
+.. warning::
+
+    Executing commmands with untrusted data can make it vulnerable to shell injection! If you use formatted data in 
+    your command, it is highly recommended that you use a args list format instead of a shell string.
+
+
 Email
 ~~~~~
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
+import copy
 import datetime
+import json
 import logging
+import subprocess
 from email.mime.text import MIMEText
 from smtplib import SMTP
 from smtplib import SMTPException
@@ -76,8 +79,9 @@ class Alerter(object):
         raise NotImplementedError()
 
     def get_info(self):
-        """ Returns a dictionary of data related to this alert. """
-        raise NotImplementedError()
+        """ Returns a dictionary of data related to this alert. At minimum, this should contain
+        a field type corresponding to the type of Alerter. """
+        return {'type': 'Unknown'}
 
     def create_title(self, matches):
         """ Creates custom alert title to be used, e.g. as an e-mail subject or JIRA issue summary.
@@ -292,3 +296,37 @@ class JiraAlerter(Alerter):
 
     def get_info(self):
         return {'type': 'jira'}
+
+
+class CommandAlerter(Alerter):
+    required_options = set(['command'])
+
+    def __init__(self, *args):
+        super(CommandAlerter, self).__init__(*args)
+        if isinstance(self.rule['command'], basestring) and '%' in self.rule['command']:
+            logging.warning('Warning! You could be vulnerable to shell injection!')
+            self.rule['command'] = [self.rule['command']]
+
+    def alert(self, matches):
+        for match in matches:
+            # Format the command and arguments
+            command = copy.copy(self.rule['command'])
+            try:
+                command = [command_arg % match for command_arg in command]
+                self.last_command = command
+            except KeyError as e:
+                raise EAException("Error formatting command: %s" % (e))
+
+            # Run command and pipe data
+            try:
+                subp = subprocess.Popen(command, stdin=subprocess.PIPE)
+
+                if self.rule.get('pipe_match_json'):
+                    match_json = json.dumps(match)
+                    stdout, stderr = subp.communicate(input=match_json)
+            except OSError as e:
+                raise EAException("Error while running command %s: %s" % (' '.join(command), e))
+
+    def get_info(self):
+        return {'type': 'command',
+                'command': ' '.join(self.last_command)}

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import copy
 import datetime
 import json
 import logging
@@ -310,9 +309,8 @@ class CommandAlerter(Alerter):
     def alert(self, matches):
         for match in matches:
             # Format the command and arguments
-            command = copy.copy(self.rule['command'])
             try:
-                command = [command_arg % match for command_arg in command]
+                command = [command_arg % match for command_arg in self.rule['command']]
                 self.last_command = command
             except KeyError as e:
                 raise EAException("Error formatting command: %s" % (e))

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -32,7 +32,8 @@ rules_mapping = {
 alerts_mapping = {
     'email': alerts.EmailAlerter,
     'jira': alerts.JiraAlerter,
-    'debug': alerts.DebugAlerter
+    'debug': alerts.DebugAlerter,
+    'command': alerts.CommandAlerter
 }
 
 


### PR DESCRIPTION
An alerter for running arbitrary commands. The command arguments can be string formatted using the match. You are also able to pass the match as json to stdin. Theres currently no support for looking at process exit codes or stdout.

Note: This uses the % formatting instead of str.format because it allows you to use objects from a dictionary without specifying an index, ie %(fieldname)s vs {0[fieldname]}
