### PR TITLE
rule-wide expired silence cache cleared when query_key present

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -452,6 +452,11 @@ class ElastAlerter():
                 logging.info('Ignoring match for silenced rule %s%s' % (rule['name'], key))
                 continue
 
+            # If we have an expired entry in the cache covering all query keys, it can
+            # override a manual silence stash and won't be cleared in set_realert. Clear it here.
+            if key and rule['name'] in self.silence_cache:
+                self.silence_cache.pop(rule['name'])
+
             if rule['realert']:
                 next_alert, exponent = self.next_alert_time(rule, rule['name'] + key, ts_now())
                 self.set_realert(rule['name'] + key, next_alert, exponent)

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -317,6 +317,18 @@ def test_silence_query_key(ea):
             ea.run_rule(ea.rules[0], END, START)
     assert ea.rules[0]['alert'][0].alert.call_count == 1
 
+    # Test that a rule-wide silence cache is cleared if it's expired and the match has a QK
+    match = [{'@timestamp': '2014-11-17T00:00:00', 'username': 'qlo'}]
+    ea.rules[0]['type'].matches = match
+    ea.silence_cache[ea.rules[0]['name']] = (ts_to_dt('2013-01-01'), 0)
+    with mock.patch('elastalert.elastalert.ts_now') as mock_ts:
+        with mock.patch('elastalert.elastalert.Elasticsearch'):
+            # Converted twice to add tzinfo
+            mock_ts.return_value = ts_to_dt(dt_to_ts(datetime.datetime.utcnow() + datetime.timedelta(hours=5)))
+            ea.run_rule(ea.rules[0], END, START)
+    assert ea.rules[0]['alert'][0].alert.call_count == 2
+    assert ea.rules[0]['name'] not in ea.silence_cache
+
 
 def test_realert(ea):
     hits = ['2014-09-26T12:35:%sZ' % (x) for x in range(60)]


### PR DESCRIPTION
Fixes issue #79 