### PR TITLE
Added docs for terms_size, upped the default, and fixed top_count_number

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -251,7 +251,7 @@ of tens of thousands or more. ``doc_type`` must be set to use this.
 ``doc_type``: Specify the ``_type`` of document to search for. This must be present if ``use_count_query`` or ``use_terms_query`` is set.
 
 ``use_terms_query``: If true, ElastAlert will make an aggregation query against Elasticsearch to get counts of documents matching
-each unique value of ``query_key``. This be used with ``query_key`` and ``doc_type``. This will only return a maximum of ``terms_size``,
+each unique value of ``query_key``. This must be used with ``query_key`` and ``doc_type``. This will only return a maximum of ``terms_size``,
 default 50, unique terms.
 
 ``terms_size``: When used with ``use_terms_query``, this is the maximum number of terms returned per query. Default is 50.
@@ -377,7 +377,7 @@ of tens of thousands or more. ``doc_type`` must be set to use this.
 ``doc_type``: Specify the ``_type`` of document to search for. This must be present if ``use_count_query`` or ``use_terms_query`` is set.
 
 ``use_terms_query``: If true, ElastAlert will make an aggregation query against Elasticsearch to get counts of documents matching
-each unique value of ``query_key``. This be used with ``query_key`` and ``doc_type``. This will only return a maximum of ``terms_size``,
+each unique value of ``query_key``. This must be used with ``query_key`` and ``doc_type``. This will only return a maximum of ``terms_size``,
 default 50, unique terms.
 
 ``terms_size``: When used with ``use_terms_query``, this is the maximum number of terms returned per query. Default is 50.

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -251,7 +251,10 @@ of tens of thousands or more. ``doc_type`` must be set to use this.
 ``doc_type``: Specify the ``_type`` of document to search for. This must be present if ``use_count_query`` or ``use_terms_query`` is set.
 
 ``use_terms_query``: If true, ElastAlert will make an aggregation query against Elasticsearch to get counts of documents matching
-each unique value of ``query_key``. This be used with ``query_key`` and ``doc_type``.
+each unique value of ``query_key``. This be used with ``query_key`` and ``doc_type``. This will only return a maximum of ``terms_size``,
+default 50, unique terms.
+
+``terms_size``: When used with ``use_terms_query``, this is the maximum number of terms returned per query. Default is 50.
 
 ``query_key``: The number of events is remembered separately for each unique ``query_key`` field. If this option
 is set, the field must be present for all events.
@@ -374,7 +377,10 @@ of tens of thousands or more. ``doc_type`` must be set to use this.
 ``doc_type``: Specify the ``_type`` of document to search for. This must be present if ``use_count_query`` or ``use_terms_query`` is set.
 
 ``use_terms_query``: If true, ElastAlert will make an aggregation query against Elasticsearch to get counts of documents matching
-each unique value of ``query_key``. This be used with ``query_key``. ``doc_type`` must be set to use this.
+each unique value of ``query_key``. This be used with ``query_key`` and ``doc_type``. This will only return a maximum of ``terms_size``,
+default 50, unique terms.
+
+``terms_size``: When used with ``use_terms_query``, this is the maximum number of terms returned per query. Default is 50.
 
 Flatline
 ~~~~~~~~


### PR DESCRIPTION
This fixes #73 and #83. terms_size was undocumented and had a ridiculously low default. Also, it overrode top_count_number because the code was shared.