### PR TITLE
Added exception handling for jira.search_issues

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -238,7 +238,12 @@ class JiraAlerter(Alerter):
 
         date = (datetime.datetime.now() - datetime.timedelta(days=self.max_age)).strftime('%Y/%m/%d')
         jql = 'project=%s AND summary~"%s" and created >= "%s"' % (self.project, title, date)
-        issues = self.client.search_issues(jql)
+        try:
+            issues = self.client.search_issues(jql)
+        except JIRAError as e:
+            logging.exception("Error while searching for JIRA ticket using jql '%s': %s" % (jql, e))
+            return None
+
         if len(issues):
             return issues[0]
 


### PR DESCRIPTION
Fixes issue #87. If jira.client.search_issues throws an exception, which can happen if the summary (which contains the value of query_key) contains special characters, handle it as if no results were returned.

This also adds a test case for this scenario.