### PR TITLE
Add new term rule

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -401,6 +401,29 @@ of tens of thousands or more. ``doc_type`` must be set to use this.
 
 ``doc_type``: Specify the ``_type`` of document to search for. This must be present if ``use_count_query`` or ``use_terms_query`` is set.
 
+New Term
+~~~~~~~~
+
+``new_term``: This rule matches when a new value appears in a field that has never been seen before. When ElastAlert starts, it will
+use an aggregation query to gather all known terms for a list of fields.
+
+This rule requires one additional option:
+
+``fields``: A list of fields to monitor for new terms. 
+
+Optional:
+
+``terms_window_size``: The amount of the used for the initial query to find existing terms. No term that has occured within this time frame
+will trigger an alert. The default is 30 days.
+
+``alert_on_missing_field``: Whether or not to alert when a field is missing from a document. The default is false.
+
+``use_terms_query``: If true, ElastAlert will use aggregation queries to get terms instead of regular search queries. This is faster
+than regular searching if there is a large number of documents. If this is used, you may only specify a single field, and must also set
+``query_key`` to that field. Also, note that by default, ``terms_size``, the number of buckets returned per query, defaults to 50. This means
+that if a new term appears but there are at least 50 terms which appear more frequently, it will not be found.
+
+
 .. _alerts:
 
 Alerts

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -25,7 +25,8 @@ rules_mapping = {
     'blacklist': ruletypes.BlacklistRule,
     'whitelist': ruletypes.WhitelistRule,
     'change': ruletypes.ChangeRule,
-    'flatline': ruletypes.FlatlineRule
+    'flatline': ruletypes.FlatlineRule,
+    'new_terms': ruletypes.NewTermsRule
 }
 
 # Used to map names of alerts to their classes

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -2,11 +2,14 @@
 import datetime
 from collections import deque
 
+from elasticsearch.client import Elasticsearch
 from util import dt_to_ts
 from util import EAException
+from util import format_index
 from util import hashable
 from util import lookup_es_key
 from util import pretty_ts
+from util import ts_now
 from util import ts_to_dt
 
 
@@ -466,3 +469,60 @@ class FlatlineRule(FrequencyRule):
         for key in self.occurrences.keys():
             self.occurrences.setdefault(key, EventWindow(self.rules['timeframe'], getTimestamp=self.get_ts)).append(({self.ts_field: ts}, 0))
             self.check_for_match(key)
+
+
+class NewTermsRule(RuleType):
+    """ Alerts on a new value in a list of fields. """
+
+    def __init__(self, *args):
+        super(NewTermsRule, self).__init__(*args)
+        self.seen_values = {}
+        # Allow the use of query_key or fields
+        if 'fields' not in self.rules:
+            if 'query_key' not in self.rules:
+                raise EAException("fields or query_key must be specified")
+            self.fields = self.rules['query_key']
+        else:
+            self.fields = self.rules['fields']
+        if type(self.fields) != list:
+            self.fields = [self.fields]
+        if self.rules.get('use_terms_query') and len(self.fields) > 1:
+            raise EAException("use_terms_query can only be used with one field at a time")
+        self.get_all_terms()
+
+    def get_all_terms(self):
+        """ Performs a terms aggregation for each field to get every existing term. """
+        self.es = Elasticsearch(host=self.rules['es_host'], port=self.rules['es_port'])
+        window_size = datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))
+
+        field_name = {"field": "", "size": 999999}
+        query_template = {"aggs": {"values": {"terms": field_name}}}
+        if self.rules.get('use_strftime_index'):
+            end = ts_now()
+            start = end - window_size
+            index = format_index(self.rules['index'], start, end)
+        else:
+            index = self.rules['index']
+
+        for field in self.fields:
+            field_name['field'] = field
+            res = self.es.search(body=query_template, index=index, ignore_unavailable=True, timeout=50)
+            buckets = res['aggregations']['values']['buckets']
+            keys = [bucket['key'] for bucket in buckets]
+            self.seen_values[field] = keys
+
+    def add_data(self, data):
+        for document in data:
+            for field in self.fields:
+                value = document.get(field)
+                if not value and self.rules.get('alert_on_missing_field'):
+                    document['missing_field'] = field
+                    self.add_match(document)
+                elif value:
+                    if value not in self.seen_values[field]:
+                        document['new_field'] = field
+                        self.add_match(document)
+                        self.seen_values[field].append(value)
+
+    def garbage_collect(self, ts):
+        pass

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -484,6 +484,8 @@ class NewTermsRule(RuleType):
             self.fields = self.rules['query_key']
         else:
             self.fields = self.rules['fields']
+        if not self.fields:
+            raise EAException("fields must not be an empty list")
         if type(self.fields) != list:
             self.fields = [self.fields]
         if self.rules.get('use_terms_query') and len(self.fields) != 1:
@@ -495,7 +497,7 @@ class NewTermsRule(RuleType):
         self.es = Elasticsearch(host=self.rules['es_host'], port=self.rules['es_port'])
         window_size = datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))
 
-        field_name = {"field": "", "size": 999999}
+        field_name = {"field": "", "size": 2147483647}  # Integer.MAX_VALUE
         query_template = {"aggs": {"values": {"terms": field_name}}}
         if self.rules.get('use_strftime_index'):
             end = ts_now()
@@ -535,6 +537,3 @@ class NewTermsRule(RuleType):
                                  self.rules['timestamp_field']: timestamp,
                                  'new_field': field}
                         self.add_match(match)
-
-    def garbage_collect(self, ts):
-        pass


### PR DESCRIPTION
A new rule type which will search for a list of existing terms when it starts, and then alert on new values. It can take a number of different fields, and can use_terms_query.