### PR TITLE
Alert pipeline

### DIFF
--- a/docs/source/recipes/adding_alerts.rst
+++ b/docs/source/recipes/adding_alerts.rst
@@ -34,7 +34,7 @@ should be in the rule configuration file and can be accessed here.
 
 ``self.pipeline``: This is a dictionary object that serves to transfer information between alerts. When an alert is triggered,
 a new empty pipeline object will be created and each alerter can add or receive information from it. Note that alerters
-are called in the order they are defined in the rule file. For example, the JIRA alerter will add it's ticket number
+are called in the order they are defined in the rule file. For example, the JIRA alerter will add its ticket number
 to the pipeline and the email alerter will add that link if it's present in the pipeline.
 
 alert(self, match):

--- a/docs/source/recipes/adding_alerts.rst
+++ b/docs/source/recipes/adding_alerts.rst
@@ -32,6 +32,11 @@ present. ElastAlert will not instantiate the alert if any are missing.
 ``self.rule``: The dictionary containing the rule configuration. All options specific to the alert
 should be in the rule configuration file and can be accessed here.
 
+``self.pipeline``: This is a dictionary object that serves to transfer information between alerts. When an alert is triggered,
+a new empty pipeline object will be created and each alerter can add or receive information from it. Note that alerters
+are called in the order they are defined in the rule file. For example, the JIRA alerter will add it's ticket number
+to the pipeline and the email alerter will add that link if it's present in the pipeline.
+
 alert(self, match):
 -------------------
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -639,7 +639,8 @@ Jira
 ~~~~~
 
 The JIRA alerter will open a ticket on jira whenever an alert is triggered. You must have a service account for ElastAlert to connect with.
-The credentials of the service account are loaded from a separate file.
+The credentials of the service account are loaded from a separate file. The ticket number will be written to the alert pipeline, and if it
+is followed by an email alerter, a link will be included in the email.
 
 This alert requires four additional options:
 

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -778,6 +778,8 @@ class ElastAlerter():
         alert_exception = None
         alert_pipeline = {}
         for alert in rule['alert']:
+            # Alert.pipeline is a single object shared between every alerter
+            # This allows alerters to pass objects and data between themselves
             alert.pipeline = alert_pipeline
             try:
                 alert.alert(matches)

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -776,7 +776,9 @@ class ElastAlerter():
         # Run the alerts
         alert_sent = False
         alert_exception = None
+        alert_pipeline = {}
         for alert in rule['alert']:
+            alert.pipeline = alert_pipeline
             try:
                 alert.alert(matches)
             except EAException as e:


### PR DESCRIPTION
Fixes issue #68 

Each alerter is given a shared dictionary object which can be used to transfer information between alerters. This allows the rules with both JIRA and email alerters to have the ticket created linked in the email. The order in which the alerters are defined matters in this case. I'm not sure whether this warrants a check in config to automatically reorder email to always come after JIRA if they both exist.