### PR TITLE
Added from_addr option to email alerter

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -635,6 +635,9 @@ Optional:
 ``email_reply_to``: This sets the Reply-To header in the email. By default, the from address is ElastAlert@ and the domain will be set
 by the smtp server.
 
+``from_addr``: This sets the From header in the email. By default, the from address is ElastAlert@ and the domain will be set
+by the smtp server.
+
 Jira
 ~~~~~
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -68,7 +68,6 @@ class Alerter(object):
 
     def __init__(self, rule):
         self.rule = rule
-        self.from_addr = 'ElastAlert'
         self.pipeline = None
 
     def alert(self, match):
@@ -132,6 +131,7 @@ class EmailAlerter(Alerter):
         super(EmailAlerter, self).__init__(*args)
 
         self.smtp_host = self.rule.get('smtp_host', 'localhost')
+        self.from_addr = self.rule.get('from_addr', 'ElastAlert')
         # Convert email to a list if it isn't already
         if isinstance(self.rule['email'], str):
             self.rule['email'] = [self.rule['email']]
@@ -154,6 +154,7 @@ class EmailAlerter(Alerter):
         email_msg = MIMEText(body)
         email_msg['Subject'] = self.create_title(matches)
         email_msg['To'] = ', '.join(self.rule['email'])
+        email_msg['From'] = self.from_addr
         email_msg['Reply-To'] = self.rule.get('email_reply_to', email_msg['To'])
 
         try:

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -48,7 +48,7 @@ def test_alert_text(ea):
 
 
 def test_email():
-    rule = {'name': 'test alert', 'email': ['testing@test.test', 'test@test.test'],
+    rule = {'name': 'test alert', 'email': ['testing@test.test', 'test@test.test'], 'from_addr': 'testfrom@test.test',
             'type': mock_rule(), 'timestamp_field': '@timestamp', 'email_reply_to': 'test@example.com',
             'alert_subject': 'Test alert for {0}', 'alert_subject_args': ['test_term']}
     with mock.patch('elastalert.alerts.SMTP') as mock_smtp:
@@ -62,8 +62,10 @@ def test_email():
         assert mock_smtp.mock_calls == expected
 
         body = mock_smtp.mock_calls[1][1][2]
+
         assert 'Reply-To: test@example.com' in body
         assert 'To: testing@test.test' in body
+        assert 'From: testfrom@test.test' in body
         assert 'Subject: Test alert for test_value' in body
 
 


### PR DESCRIPTION
Added a from_addr option that allows you to specify the email from address in the rule.