### PR TITLE
Added initial support for kibana4 links

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -196,9 +196,9 @@ ElastAlert can use an existing dashboard. It will set the time range on the dash
 upload it as a temporary dashboard, add a filter to the ``query_key`` of the alert if applicable,
 and put the url to the dashboard in the alert. (Optional, string, no default)
 
-``use_kibana4_dashboard``: The name of a Kibana 4 dashboard to link to. This will set the time setting on the dashboard
-from the match time minus the timeframe, to 10 minutes after the match time. Note that this does not support filtering
-by ``query_key`` like Kibana 3.
+``use_kibana4_dashboard``: A link to a Kibana 4 dashboard. For example, "https://kibana.example.com/#/dashboard/My-Dashboard". 
+This will set the time setting on the dashboard from the match time minus the timeframe, to 10 minutes after the match time. 
+Note that this does not support filtering by ``query_key`` like Kibana 3.
 
 ``use_local_time``: Whether to convert timestamps to the local time zone in alerts. If false, timestamps will
 be converted to UTC, which is what ElastAlert uses internally. (Optional, boolean, default true)

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -188,7 +188,7 @@ dashboard will also contain a filter for the ``query_key`` of the alert. The das
 be uploaded to the kibana-int index as a temporary dashboard. (Optional, boolean, default False)
 
 ``kibana_url``: The url to access Kibana. This will be used if ``generate_kibana_link`` or
-``use_kibana[4]_dashboard`` is true. This must be specified with ``use_kibana4_dashboard``.
+``use_kibana_dashboard`` is true. If not specified, a URL will be constructed using ``es_host`` and ``es_port``.
 (Optional, string, default ``http://<es_host>:<es_port>/_plugin/kibana/``)
 
 ``use_kibana_dashboard``: The name of a Kibana 3 dashboard to link to. Instead of generating a dashboard from a template,

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -181,18 +181,24 @@ field name plus ".raw" to count unanalyzed terms. To turn this off, set ``raw_co
 
 ``raw_count_keys``: If true, all fields in ``top_count_keys`` will have ``.raw`` appended to them. (Optional, boolean, default true)
 
-``generate_kibana_link``: If true, ElastAlert will generate a temporary Kibana dashboard and include a link to it in alerts. The dashboard
+``generate_kibana_link``: This option is for Kibana 3 only.
+If true, ElastAlert will generate a temporary Kibana dashboard and include a link to it in alerts. The dashboard
 consists of an events over time graph and a table with ``include`` fields selected in the table. If the rule uses ``query_key``, the
 dashboard will also contain a filter for the ``query_key`` of the alert. The dashboard schema will
 be uploaded to the kibana-int index as a temporary dashboard. (Optional, boolean, default False)
 
-``kibana_url``: The url to access the kibana plugin. This will be used if ``generate_kibana_link`` is true.
+``kibana_url``: The url to access Kibana. This will be used if ``generate_kibana_link`` or
+``use_kibana[4]_dashboard`` is true. This must be specified with ``use_kibana4_dashboard``.
 (Optional, string, default ``http://<es_host>:<es_port>/_plugin/kibana/``)
 
-``use_kibana_dashboard``: The name of a dashboard to link to. Instead of generating a dashboard from a template,
+``use_kibana_dashboard``: The name of a Kibana 3 dashboard to link to. Instead of generating a dashboard from a template,
 ElastAlert can use an existing dashboard. It will set the time range on the dashboard to around the match time,
 upload it as a temporary dashboard, add a filter to the ``query_key`` of the alert if applicable,
 and put the url to the dashboard in the alert. (Optional, string, no default)
+
+``use_kibana4_dashboard``: The name of a Kibana 4 dashboard to link to. This will set the time setting on the dashboard
+from the match time minus the timeframe, to 10 minutes after the match time. Note that this does not support filtering
+by ``query_key`` like Kibana 3.
 
 ``use_local_time``: Whether to convert timestamps to the local time zone in alerts. If false, timestamps will
 be converted to UTC, which is what ElastAlert uses internally. (Optional, boolean, default true)

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -151,6 +151,10 @@ def load_options(rule):
                                 'The index will be formatted like %s' % (token,
                                                                          datetime.datetime.now().strftime(rule.get('index'))))
 
+    # Kibana4 urls can't be generated based on host:port
+    if rule.get('use_kibana4_dashboard') and not rule.get('kibana_url'):
+        raise EAException('kibana_url must be specified with use_kibana4_dashboard')
+
 
 def load_modules(rule):
     """ Loads things that could be modules. Enhancements, alerts and rule type. """

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -151,10 +151,6 @@ def load_options(rule):
                                 'The index will be formatted like %s' % (token,
                                                                          datetime.datetime.now().strftime(rule.get('index'))))
 
-    # Kibana4 urls can't be generated based on host:port
-    if rule.get('use_kibana4_dashboard') and not rule.get('kibana_url'):
-        raise EAException('kibana_url must be specified with use_kibana4_dashboard')
-
 
 def load_modules(rule):
     """ Loads things that could be modules. Enhancements, alerts and rule type. """

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -684,7 +684,7 @@ class ElastAlerter():
                         body=db_body)
 
         # Return dashboard URL
-        kibana_url = rule.get('kibana_dashboard')
+        kibana_url = rule.get('kibana_url')
         if not kibana_url:
             kibana_url = 'http://%s:%s/_plugin/kibana/' % (rule['es_host'],
                                                            rule['es_port'])

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -628,10 +628,9 @@ class ElastAlerter():
     def generate_kibana4_db(self, rule, match):
         ''' Creates a link for a kibana4 dashboard which has time set to the match. '''
         db_name = rule.get('use_kibana4_dashboard')
-        url = rule.get('kibana_url')
         start = ts_add(match[rule['timestamp_field']], -rule.get('timeframe', datetime.timedelta(minutes=10)))
         end = ts_add(match[rule['timestamp_field']], datetime.timedelta(minutes=10))
-        link = kibana.kibana4_dashboard_link(url, db_name, start, end)
+        link = kibana.kibana4_dashboard_link(db_name, start, end)
         return link
 
     def generate_kibana_db(self, rule, match):

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -625,6 +625,15 @@ class ElastAlerter():
         logging.info("Sleeping for %s seconds" % (duration))
         time.sleep(duration)
 
+    def generate_kibana4_db(self, rule, match):
+        ''' Creates a link for a kibana4 dashboard which has time set to the match. '''
+        db_name = rule.get('use_kibana4_dashboard')
+        url = rule.get('kibana_url')
+        start = ts_add(match[rule['timestamp_field']], -rule.get('timeframe', datetime.timedelta(minutes=10)))
+        end = ts_add(match[rule['timestamp_field']], datetime.timedelta(minutes=10))
+        link = kibana.kibana4_dashboard_link(url, db_name, start, end)
+        return link
+
     def generate_kibana_db(self, rule, match):
         ''' Uses a template dashboard to upload a temp dashboard showing the match.
         Returns the url to the dashboard. '''
@@ -747,7 +756,7 @@ class ElastAlerter():
                 counts = self.get_top_counts(rule, start, end, keys, rule.get('top_count_number'), qk)
                 match.update(counts)
 
-        # Generate a kibana dashboard for the first match
+        # Generate a kibana3 dashboard for the first match
         if rule.get('generate_kibana_link') or rule.get('use_kibana_dashboard'):
             try:
                 if rule.get('generate_kibana_link'):
@@ -759,6 +768,11 @@ class ElastAlerter():
             else:
                 if kb_link:
                     matches[0]['kibana_link'] = kb_link
+
+        if rule.get('use_kibana4_dashboard'):
+            kb_link = self.generate_kibana4_db(rule, matches[0])
+            if kb_link:
+                matches[0]['kibana_link'] = kb_link
 
         for enhancement in rule['match_enhancements']:
             for match in matches:

--- a/elastalert/kibana.py
+++ b/elastalert/kibana.py
@@ -166,6 +166,8 @@ dashboard_temp = {'editable': True,
                   u'style': u'dark',
                   u'title': u'ElastAlert Alert Dashboard'}
 
+kibana4_time_temp = "(refreshInterval:(display:Off,section:0,value:0),time:(from:'%s',mode:absolute,to:'%s'))"
+
 
 def set_time(dashboard, start, end):
     dashboard['services']['filter']['list']['0']['from'] = start
@@ -258,3 +260,10 @@ def filters_from_dashboard(db):
         config_filters.append({'or': or_filters})
 
     return config_filters
+
+
+def kibana4_dashboard_link(base_url, dashboard, starttime, endtime):
+    time_settings = kibana4_time_temp % (starttime, endtime)
+    if not base_url.endswith('/'):
+        base_url += '/'
+    return "%s#/dashboard/%s?_g=%s" % (base_url, dashboard, time_settings)

--- a/elastalert/kibana.py
+++ b/elastalert/kibana.py
@@ -262,8 +262,6 @@ def filters_from_dashboard(db):
     return config_filters
 
 
-def kibana4_dashboard_link(base_url, dashboard, starttime, endtime):
+def kibana4_dashboard_link(dashboard, starttime, endtime):
     time_settings = kibana4_time_temp % (starttime, endtime)
-    if not base_url.endswith('/'):
-        base_url += '/'
-    return "%s#/dashboard/%s?_g=%s" % (base_url, dashboard, time_settings)
+    return "%s?_g=%s" % (dashboard, time_settings)


### PR DESCRIPTION
This adds the option "use_kibana4_dashboard", which when used with "kibana_url", will put a link in the alert to 
<kibana_url>/#/dashboard/<use_kibana4_dashboard>?_g=<time range>

I tried getting filters to work, but they are slightly more complicated. That can come later.

Tested with Kibana 4.0.2

