### PR TITLE
Siem 2578/bfrisbie/issue95

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -784,7 +784,10 @@ class ElastAlerter():
             try:
                 alert.alert(matches)
             except EAException as e:
-                self.handle_error('Error while running alert %s: %s' % (alert.get_info()['type'], e), {'rule': rule['name']})
+                self.handle_error('ElastAlert Error while running alert %s: %s' % (alert.get_info()['type'], e), {'rule': rule['name']})
+                alert_exception = str(e)
+            except Exception as e:
+                self.handle_error('Unexpected Error while running alert %s: %s' % (alert.get_info()['type'], e), {'rule': rule['name']})
                 alert_exception = str(e)
             else:
                 self.alerts_sent += 1

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 base_dir = os.path.dirname(__file__)
 setup(
     name='elastalert',
-    version='0.0.38',
+    version='0.0.39',
     description='Runs custom filters on Elasticsearch and alerts on matches',
     author='Quentin Long',
     author_email='qlo@yelp.com',

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -607,7 +607,8 @@ def test_list_for_email_reply_to(ea):
     }
     alert = EmailAlerter(rule)
     rule['alert'] = [alert]
+    alert.alert = mock.MagicMock(side_effect=Exception('test_exception'))
     ea.alert(matches, rule)
-    expected = ("Unexpected Error while running alert email: 'list' object has no attribute 'lstrip'",
+    expected = ("Unexpected Error while running alert email: test_exception",
                 {'rule': 'test alert'})
     ea.handle_error.assert_called_once_with(*expected)


### PR DESCRIPTION
Adds a catch for any Exceptions thrown by alerters.

This is in general to prevent ElastAlert from crashing on unexpected exceptions thrown by alerters.

In particular it's to address https://github.com/Yelp/elastalert/issues/95, where an smtplib error (from a buggy rule) can crash ElastAlert.

I ran "make test" and all tests passed.