### PR TITLE
Added email notifications and disabling rules which throw exceptions

### DIFF
--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -127,6 +127,23 @@ can be overridden by any individual rule.
 When ElastAlert starts, for each rule, it will search ``elastalert_metadata`` for the most recently run query and start
 from that time, unless it is older than ``old_query_limit``, in which case it will start from the present time. The default is one week.
 
+``disable_rules_on_error``: If true, ElastAlert will disable rules which throw uncaught (not EAException) exceptions. It
+will upload a traceback message to ``elastalert_metadata`` and if ``notify_email`` is set, send an email notification. The
+rule will no longer be run until either ElastAlert restarts or the rule file has been modified. This defaults to True.
+
+``notify_email``: An email address, or list of email addresses, to which notification emails will be sent. Currently,
+only an uncaught exception will send a notification email. The from address, SMTP host, and reply-to header can be set
+using ``from_addr``, ``smtp_host``, and ``email_reply_to`` options, respectively. By default, no emails will be sent.
+
+``from_addr``: The address to use as the from header in email notifications.
+This value will be used for email alerts as well, unless overwritten in the rule config. The default value
+is "ElastAlert".
+
+``smtp_host``: The SMTP host used to send email notifications. This value will be used for email alerts as well,
+unless overwritten in the rule config. The default is "localhost".
+
+``email_reply_to``: This sets the Reply-To header in emails. The default is the recipient address.
+
 .. _runningelastalert:
 
 Running ElastAlert

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -59,6 +59,7 @@ def load_configuration(filename, conf=None):
     """ Load a yaml rule file and fill in the relevant fields with objects.
 
     :param filename: The name of a rule configuration file.
+    :param conf: The global configuration dictionary, used for populating defaults.
     :return: The rule configuration, a dictionary.
     """
     try:
@@ -73,7 +74,11 @@ def load_configuration(filename, conf=None):
 
 
 def load_options(rule, conf=None):
-    """ Converts time objects, sets defaults, and validates some settings. """
+    """ Converts time objects, sets defaults, and validates some settings.
+
+    :param rule: A dictionary of parsed YAML from a rule config file.
+    :param conf: The global configuration dictionary, used for populating defaults.
+    """
 
     try:
         rule_schema.validate(rule)

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 import datetime
 import hashlib
-import jsonschema
 import logging
 import os
 
 import alerts
 import enhancements
+import jsonschema
 import ruletypes
 import yaml
 import yaml.scanner
@@ -55,7 +55,7 @@ def get_module(module_name):
     return module
 
 
-def load_configuration(filename):
+def load_configuration(filename, conf=None):
     """ Load a yaml rule file and fill in the relevant fields with objects.
 
     :param filename: The name of a rule configuration file.
@@ -67,12 +67,12 @@ def load_configuration(filename):
         raise EAException('Could not parse file %s: %s' % (filename, e))
 
     rule['rule_file'] = filename
-    load_options(rule)
+    load_options(rule, conf)
     load_modules(rule)
     return rule
 
 
-def load_options(rule):
+def load_options(rule, conf=None):
     """ Converts time objects, sets defaults, and validates some settings. """
 
     try:
@@ -106,6 +106,13 @@ def load_options(rule):
     rule.setdefault('timestamp_field', '@timestamp')
     rule.setdefault('filter', [])
     rule.setdefault('use_local_time', True)
+
+    # Set email options from global config
+    if conf:
+        rule.setdefault('smtp_host', conf.get('smtp_host', 'localhost'))
+        rule.setdefault('from_addr', conf.get('from_addr', 'ElastAlert'))
+        if 'email_reply_to' in conf:
+            rule.setdefault('email_reply_to', conf['email_reply_to'])
 
     # Make sure we have required options
     if required_locals - frozenset(rule.keys()):
@@ -248,6 +255,7 @@ def load_rules(filename, use_rule=None):
         raise EAException('%s must contain %s' % (filename, ', '.join(required_globals - frozenset(conf.keys()))))
 
     conf.setdefault('max_query_size', 100000)
+    conf.setdefault('disable_rules_on_error', True)
 
     # Convert run_every, buffer_time into a timedelta object
     try:
@@ -269,7 +277,7 @@ def load_rules(filename, use_rule=None):
     rule_files = get_file_paths(conf, use_rule)
     for rule_file in rule_files:
         try:
-            rule = load_configuration(rule_file)
+            rule = load_configuration(rule_file, conf)
             if rule['name'] in names:
                 raise EAException('Duplicate rule named %s' % (rule['name']))
         except EAException as e:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -7,6 +7,10 @@ import os
 import sys
 import time
 import traceback
+from email.mime.text import MIMEText
+from smtplib import SMTP
+from smtplib import SMTPException
+from socket import error
 
 import argparse
 import kibana
@@ -64,6 +68,10 @@ class ElastAlerter():
         self.run_every = self.conf['run_every']
         self.alert_time_limit = self.conf['alert_time_limit']
         self.old_query_limit = self.conf['old_query_limit']
+        self.disable_rules_on_error = self.conf['disable_rules_on_error']
+        self.notify_email = self.conf.get('notify_email')
+        self.from_addr = self.conf.get('from_addr', 'ElastAlert')
+        self.smtp_host = self.conf.get('smtp_host', 'localhost')
         self.alerts_sent = 0
         self.num_hits = 0
         self.current_es = None
@@ -72,6 +80,7 @@ class ElastAlerter():
         self.silence_cache = {}
         self.rule_hashes = get_rule_hashes(self.conf, self.args.rule)
         self.starttime = self.args.start
+        self.disabled_rules = []
 
         self.es_conn_config = self.build_es_conn_config(self.conf)
 
@@ -535,6 +544,13 @@ class ElastAlerter():
                     continue
                 logging.info("Reloading configuration for rule %s" % (rule_file))
 
+                # Re-enable if rule had been disabled
+                for disabled_rule in self.disabled_rules:
+                    if disabled_rule['name'] == new_rule['name']:
+                        self.rules.append(disabled_rule)
+                        self.disabled_rules.remove(disabled_rule)
+                        break
+
                 # Initialize the rule that matches rule_file
                 self.rules = [rule if rule['rule_file'] != rule_file else self.init_rule(new_rule, False) for rule in self.rules]
 
@@ -595,6 +611,8 @@ class ElastAlerter():
                 num_matches = self.run_rule(rule, endtime, self.starttime)
             except EAException as e:
                 self.handle_error("Error running rule %s: %s" % (rule['name'], e), {'rule': rule['name']})
+            except Exception as e:
+                self.handle_uncaught_exception(e, rule)
             else:
                 old_starttime = pretty_ts(rule.get('original_starttime'), rule.get('use_local_time'))
                 logging.info("Ran %s from %s to %s: %s query hits, %s matches,"
@@ -734,6 +752,13 @@ class ElastAlerter():
         return filters
 
     def alert(self, matches, rule, alert_time=None):
+        """ Wraps alerting, kibana linking and enhancements in an exception handler """
+        try:
+            return self.send_alert(matches, rule, alert_time=None)
+        except Exception as e:
+            self.handle_uncaught_exception(e, rule)
+
+    def send_alert(self, matches, rule, alert_time=None):
         """ Send out an alert.
 
         :param matches: A list of matches.
@@ -1045,6 +1070,42 @@ class ElastAlerter():
         if data:
             body['data'] = data
         self.writeback('elastalert_error', body)
+
+    def handle_uncaught_exception(self, exception, rule):
+        """ Disables a rule and sends a notifcation. """
+        self.handle_error('Uncaught exception running rule %s: %s' % (rule['name'], exception), {'rule': rule['name']})
+        if self.disable_rules_on_error:
+            self.rules = [running_rule for running_rule in self.rules if running_rule['name'] != rule['name']]
+            self.disabled_rules.append(rule)
+        if self.notify_email:
+            self.send_notification_email(exception=exception, rule=rule)
+
+    def send_notification_email(self, text='', exception=None, rule=None, subject=None):
+        email_body = text
+        if exception and rule:
+            if not subject:
+                subject = 'Uncaught exception in ElastAlert - %s' % (rule['name'])
+            email_body += '\n\n'
+            email_body += 'The rule %s has raised an uncaught exception.\n\n' % (rule['name'])
+            if self.disable_rules_on_error:
+                modified = ' or if the rule config file has been modified' if not self.args.pin_rules else ''
+                email_body += 'It has been disabled and will be re-enabled when ElastAlert restarts%s.\n\n' % (modified)
+            tb = traceback.format_exc()
+            email_body += tb
+
+        if isinstance(self.notify_email, basestring):
+            self.notify_email = [self.notify_email]
+        email = MIMEText(email_body)
+        email['Subject'] = subject if subject else 'ElastAlert notification'
+        email['To'] = ', '.join(self.notify_email)
+        email['From'] = self.from_addr
+        email['Reply-To'] = self.conf.get('email_reply_to', email['To'])
+
+        try:
+            smtp = SMTP(self.smtp_host)
+            smtp.sendmail(self.from_addr, self.notify_email, email.as_string())
+        except (SMTPException, error) as e:
+            self.handle_error('Error connecting to SMTP host: %s' % (e), {'email_body': email_body})
 
     def get_top_counts(self, rule, starttime, endtime, keys, number=5, qk=None):
         """ Counts the number of events for each unique value for each key field.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,8 @@ def ea():
               'realert': datetime.timedelta(0),
               'processed_hits': {},
               'timestamp_field': '@timestamp',
-              'match_enhancements': []}]
+              'match_enhancements': [],
+              'rule_file': 'blah.yaml'}]
     conf = {'rules_folder': 'rules',
             'run_every': datetime.timedelta(minutes=10),
             'buffer_time': datetime.timedelta(minutes=5),
@@ -59,7 +60,8 @@ def ea():
             'writeback_index': 'wb',
             'rules': rules,
             'max_query_size': 100000,
-            'old_query_limit': datetime.timedelta(weeks=1)}
+            'old_query_limit': datetime.timedelta(weeks=1),
+            'disable_rules_on_error': False}
     elasticsearch.client.Elasticsearch = mock_es_client
     with mock.patch('elastalert.elastalert.get_rule_hashes'):
         with mock.patch('elastalert.elastalert.load_rules') as load_conf:


### PR DESCRIPTION
Wraps run_rule and alert (including enhancements) in catch-all exception handling. This will disable the rule by putting it into a separate disabled_rules list which are not run. When the rule is changed, it will be put back into the normal run queue.

This also adds the ability to set a global email for notifications about exceptions. It has the smtp_host, from_addr and reply_to options like the email alerter. These options can now be set globally which become the global defaults for the email alerter.