### PR TITLE
Prevent a new rule from being loaded if there is a name conflict

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -564,6 +564,8 @@ class ElastAlerter():
             for rule_file in set(rule_hashes.keys()) - set(self.rule_hashes.keys()):
                 try:
                     new_rule = load_configuration(os.path.join(self.conf['rules_folder'], rule_file))
+                    if new_rule['name'] in [rule['name'] for rule in self.rules]:
+                        raise EAException("A rule with the name %s already exists" % (new_rule['name']))
                 except EAException as e:
                     self.handle_error('Could not load rule %s: %s' % (rule_file, e))
                     continue

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -497,6 +497,17 @@ def test_rule_changes(ea):
     mock_load.assert_any_call('rules/rule2.yaml')
     mock_load.assert_any_call('rules/rule3.yaml')
 
+    # A new rule with a conflicting name wont load
+    new_hashes = copy.copy(new_hashes)
+    new_hashes.update({'rule4.yaml': 'asdf'})
+    with mock.patch('elastalert.elastalert.get_rule_hashes') as mock_hashes:
+        with mock.patch('elastalert.elastalert.load_configuration') as mock_load:
+            mock_load.return_value = {'filter': [], 'name': 'rule3', 'new': 'stuff'}
+            mock_hashes.return_value = new_hashes
+            ea.load_rule_changes()
+    assert len(ea.rules) == 3
+    assert not any(['new' in rule for rule in ea.rules])
+
 
 def test_strf_index(ea):
     """ Test that the get_index function properly generates indexes spanning days """


### PR DESCRIPTION
Prevent a new file from being adding at runtime with a conflicting name. Fixes #101 