### PR TITLE
Alert with missing query_key wont silence other values

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -141,7 +141,8 @@ occurring before 4:30. This can be very useful if you expect a large number of m
 
 ``realert``: This option allows you to ignore repeat alerts for a period of time. If the rule uses a ``query_key``, this option
 will be applied on a per key basis. All matches for a given rule, or for matches with the same ``query_key``, will be ignored for
-the given time. This is applied to the time the alert is sent, not to the time of the event. It defaults to one minute, which means
+the given time. All matches with a missing ``query_key`` will be grouped together using a value of ``_missing``.
+This is applied to the time the alert is sent, not to the time of the event. It defaults to one minute, which means
 that if ElastAlert is run over a large time period which triggers many matches, only the first alert will be sent by default. If you want
 every alert, set realert to 0 minutes. (Optional, time, default 1 minute)
 

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -460,7 +460,8 @@ class ElastAlerter():
                     key = '.' + str(match[rule['query_key']])
                 except KeyError:
                     # Some matches may not have a query key
-                    key = ''
+                    # Use a special token for these to not clobber all alerts
+                    key = '._missing'
             else:
                 key = ''
 

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -346,6 +346,46 @@ def test_realert(ea):
             assert ea.rules[0]['alert'][0].alert.call_count == 2
 
 
+def test_realert_with_query_key(ea):
+    ea.rules[0]['query_key'] = 'username'
+    ea.rules[0]['realert'] = datetime.timedelta(minutes=10)
+
+    # Alert and silence username: qlo
+    match = [{'@timestamp': '2014-11-17T00:00:00', 'username': 'qlo'}]
+    ea.rules[0]['type'].matches = match
+    with mock.patch('elastalert.elastalert.Elasticsearch'):
+        ea.run_rule(ea.rules[0], END, START)
+    assert ea.rules[0]['alert'][0].alert.call_count == 1
+
+    # Dont alert again for same username
+    match = [{'@timestamp': '2014-11-17T00:05:00', 'username': 'qlo'}]
+    ea.rules[0]['type'].matches = match
+    with mock.patch('elastalert.elastalert.Elasticsearch'):
+        ea.run_rule(ea.rules[0], END, START)
+    assert ea.rules[0]['alert'][0].alert.call_count == 1
+
+    # Do alert with a different value
+    match = [{'@timestamp': '2014-11-17T00:05:00', 'username': ''}]
+    ea.rules[0]['type'].matches = match
+    with mock.patch('elastalert.elastalert.Elasticsearch'):
+        ea.run_rule(ea.rules[0], END, START)
+    assert ea.rules[0]['alert'][0].alert.call_count == 2
+
+    # Alert with query_key missing
+    match = [{'@timestamp': '2014-11-17T00:05:00'}]
+    ea.rules[0]['type'].matches = match
+    with mock.patch('elastalert.elastalert.Elasticsearch'):
+        ea.run_rule(ea.rules[0], END, START)
+    assert ea.rules[0]['alert'][0].alert.call_count == 3
+
+    # Still alert with a different value
+    match = [{'@timestamp': '2014-11-17T00:05:00', 'username': 'ghengis_khan'}]
+    ea.rules[0]['type'].matches = match
+    with mock.patch('elastalert.elastalert.Elasticsearch'):
+        ea.run_rule(ea.rules[0], END, START)
+    assert ea.rules[0]['alert'][0].alert.call_count == 4
+
+
 def test_count(ea):
     ea.rules[0]['use_count_query'] = True
     ea.rules[0]['doc_type'] = 'doctype'


### PR DESCRIPTION
Fixes #100 
Previously, if there was a match with a missing query_key value, it would silence every other alert. Now, it only silences other alerts that are also missing a query key.

Added a test which failed before the changes.