### PR TITLE
test_rule doesn't report .raw fields are missing if logstash is in the index

### DIFF
--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -77,7 +77,7 @@ def check_files():
                         print("Included term %s may be missing or null" % (term))
 
             for term in conf.get('top_count_keys', []):
-                if term not in terms:
+                if term not in terms and (term.endswith('.raw') and term[:-4] not in terms or 'logstash' not in index):
                     print("top_count_key %s may be missing" % (term))
         print('')
 

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -77,7 +77,8 @@ def check_files():
                         print("Included term %s may be missing or null" % (term))
 
             for term in conf.get('top_count_keys', []):
-                if term not in terms and (term.endswith('.raw') and term[:-4] not in terms or 'logstash' not in index):
+                # If the index starts with 'logstash', fields with .raw will be available but won't in _source
+                if term not in terms and not (term.endswith('.raw') and term[:-4] in terms and index.startswith('logstash')):
                     print("top_count_key %s may be missing" % (term))
         print('')
 


### PR DESCRIPTION
Fixes #86 

.raw fields are present in any index that starts with "logstash" (past logstash 1.3), which means they will work for top_count_keys. 