### PR TITLE
Added smtp login option

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -642,6 +642,9 @@ Optional:
 
 ``smtp_host``: The SMTP host to use, defaults to localhost.
 
+``smtp_auth_file``: The path to a file which contains SMTP authentication credentials. It should be YAML formatted and contain
+two fields, ``user`` and ``password``. If this is not present, no authentication will be attempted.
+
 ``email_reply_to``: This sets the Reply-To header in the email. By default, the from address is ElastAlert@ and the domain will be set
 by the smtp server.
 


### PR DESCRIPTION
Fixes #116 

Adds SMTP auth options. By setting ``smtp_auth_file`` to a file which contains user and password field, the SMTP connection will be authenticated.