### PR TITLE
Segment queries by run_every only

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -439,8 +439,7 @@ class ElastAlerter():
         # Run the rule
         # If querying over a large time period, split it up into chunks
         self.num_hits = 0
-        buffer_time = rule.get('buffer_time', self.buffer_time)
-        while endtime - rule['starttime'] > buffer_time:
+        while endtime - rule['starttime'] > self.run_every:
             tmp_endtime = rule['starttime'] + self.run_every
             if not self.run_query(rule, rule['starttime'], tmp_endtime):
                 return 0

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -395,7 +395,7 @@ def test_count(ea):
     # Assert that es.count is run against every run_every timeframe between START and END
     start = START
     query = {'query': {'filtered': {'filter': {'bool': {'must': [{'range': {'@timestamp': {'to': END_TIMESTAMP, 'from': START_TIMESTAMP}}}]}}}}}
-    while END - start > ea.buffer_time:
+    while END - start > ea.run_every:
         end = start + ea.run_every
         query['query']['filtered']['filter']['bool']['must'][0]['range']['@timestamp']['to'] = dt_to_ts(end)
         query['query']['filtered']['filter']['bool']['must'][0]['range']['@timestamp']['from'] = dt_to_ts(start)


### PR DESCRIPTION
If buffer_time was less than run_every, the segments would overflow past endtime. There is really no reason for using buffer_time here instead of run_every.

Fixes #130 