### PR TITLE
Disabled elasticsearch logging by default

### DIFF
--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -179,6 +179,8 @@ or it's subdirectories.
 ``--verbose`` will increase the logging verboseness, which allows you to see information about the state
 of queries.
 
+``--es_debug`` will enable logging for all queries made to Elasticsearch. 
+
 ``--end <timestamp>`` will force ElastAlert to stop querying after the given time, instead of the default,
 querying to the present time. This really only makes sense when running standalone. The timestamp is formatted
 as ``YYYY-MM-DDTHH:MM:SS`` (UTC) or with timezone ``YYYY-MM-DDTHH:MM:SS-XX:00`` (UTC-XX).

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -55,6 +55,7 @@ class ElastAlerter():
         parser.add_argument('--end', dest='end', help='YYYY-MM-DDTHH:MM:SS Query to this timestamp. (Default: present)')
         parser.add_argument('--verbose', action='store_true', dest='verbose', help='Increase verbosity without suppressing alerts')
         parser.add_argument('--pin_rules', action='store_true', dest='pin_rules', help='Stop ElastAlert from monitoring config file changes')
+        parser.add_argument('--es_debug', action='store_true', dest='es_debug', help='Enable verbose logging from Elasticsearch queries')
         self.args = parser.parse_args(args)
 
     def __init__(self, args):
@@ -91,6 +92,9 @@ class ElastAlerter():
 
         if self.verbose:
             logging.getLogger().setLevel(logging.INFO)
+
+        if not self.args.es_debug:
+            logging.getLogger('elasticsearch').setLevel(logging.WARNING)
 
         for rule in self.rules:
             rule = self.init_rule(rule)


### PR DESCRIPTION
This disables the extremely verbose logging from elasticsearch by default and adds the option to enable it.