### PR TITLE
Segmenting is different for count queries versus normal

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -400,14 +400,15 @@ class ElastAlerter():
         # Use buffer for normal queries, or run_every increments otherwise
         buffer_time = rule.get('buffer_time', self.buffer_time)
         if not rule.get('use_count_query') and not rule.get('use_terms_query'):
+            buffer_delta = endtime - buffer_time
             # If we started using a previous run, don't go past that
-            if 'minimum_starttime' in rule and rule['minimum_starttime'] > endtime - buffer_time:
+            if 'minimum_starttime' in rule and rule['minimum_starttime'] > buffer_delta:
                 rule['starttime'] = rule['minimum_starttime']
             # If buffer_time doesn't bring us past the previous endtime, use that instead
-            elif 'previous_endtime' in rule and rule['previous_endtime'] > endtime - buffer_time:
+            elif 'previous_endtime' in rule and rule['previous_endtime'] > buffer_delta:
                 rule['starttime'] = rule['previous_endtime']
             else:
-                rule['starttime'] = endtime - buffer_time
+                rule['starttime'] = buffer_delta
         else:
             # Query from the end of the last run, if it exists, otherwise a run_every sized window
             rule['starttime'] = rule.get('previous_endtime', endtime - self.run_every)

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -443,8 +443,8 @@ class ElastAlerter():
             logging.warning("Attempted to use query start time in the future (%s), sleeping instead" % (starttime))
             return 0
 
-        # Run the rule. Ff querying over a large time period, split it up into segments
-        # The segment size is either buffer_size for normal queryes or run_every for
+        # Run the rule. If querying over a large time period, split it up into segments
+        # The segment size is either buffer_size for normal queries or run_every for
         # count style queries
         self.num_hits = 0
         if not rule.get('use_count_query') and not rule.get('use_terms_query'):

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -403,6 +403,9 @@ class ElastAlerter():
             # If we started using a previous run, don't go past that
             if 'minimum_starttime' in rule and rule['minimum_starttime'] > endtime - buffer_time:
                 rule['starttime'] = rule['minimum_starttime']
+            # If buffer_time doesn't bring us past the previous endtime, use that instead
+            elif 'previous_endtime' in rule and rule['previous_endtime'] > endtime - buffer_time:
+                rule['starttime'] = rule['previous_endtime']
             else:
                 rule['starttime'] = endtime - buffer_time
         else:
@@ -440,11 +443,16 @@ class ElastAlerter():
             logging.warning("Attempted to use query start time in the future (%s), sleeping instead" % (starttime))
             return 0
 
-        # Run the rule
-        # If querying over a large time period, split it up into chunks
+        # Run the rule. Ff querying over a large time period, split it up into segments
+        # The segment size is either buffer_size for normal queryes or run_every for
+        # count style queries
         self.num_hits = 0
-        while endtime - rule['starttime'] > self.run_every:
-            tmp_endtime = rule['starttime'] + self.run_every
+        if not rule.get('use_count_query') and not rule.get('use_terms_query'):
+            segment_size = rule.get('buffer_time', self.buffer_time)
+        else:
+            segment_size = self.run_every
+        while endtime - rule['starttime'] > segment_size:
+            tmp_endtime = rule['starttime'] + segment_size
             if not self.run_query(rule, rule['starttime'], tmp_endtime):
                 return 0
             rule['starttime'] = tmp_endtime

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -403,41 +403,37 @@ def test_count(ea):
         ea.current_es.count.assert_any_call(body=query, doc_type='doctype', index='idx', ignore_unavailable=True)
 
 
-def test_queries_with_rule_buffertime(ea):
+def run_and_assert_segmented_queries(ea, start, end, segment_size):
+    with mock.patch.object(ea, 'run_query') as mock_run_query:
+        ea.run_rule(ea.rules[0], end, start)
+        original_end = end
+        for call_args in mock_run_query.call_args_list:
+            end = min(start + segment_size, original_end)
+            assert call_args[0][1:3] == (start, end)
+            start += segment_size
+
+
+def test_query_segmenting(ea):
+    # buffer_time segments with normal queries
     ea.rules[0]['buffer_time'] = datetime.timedelta(minutes=53)
     mock_es = mock.Mock()
     mock_es.search.side_effect = _duplicate_hits_generator([START_TIMESTAMP])
     with mock.patch('elastalert.elastalert.Elasticsearch') as mock_es_init:
         mock_es_init.return_value = mock_es
-        ea.run_rule(ea.rules[0], END, START)
-
-    # Assert that es.search is run against every buffer_time timeframe between START and END
-    end = END_TIMESTAMP
-    start = START
-    query = {'filter': {'bool': {'must': [{'range': {'@timestamp': {'to': END_TIMESTAMP, 'from': START_TIMESTAMP}}}]}},
-             'sort': [{'@timestamp': {'order': 'asc'}}]}
-    while END - start > ea.rules[0]['buffer_time']:
-        end = start + ea.rules[0]['buffer_time']
-        query['filter']['bool']['must'][0]['range']['@timestamp']['to'] = dt_to_ts(end)
-        query['filter']['bool']['must'][0]['range']['@timestamp']['from'] = dt_to_ts(start)
-        start = start + ea.rules[0]['buffer_time']
-        ea.current_es.search.assert_any_call(body=query, size=ea.max_query_size, index='idx', ignore_unavailable=True, _source_include=['@timestamp'])
-
-    # Assert that num_hits correctly summed every result
+        run_and_assert_segmented_queries(ea, START, END, ea.rules[0]['buffer_time'])
+    # Assert that num_hits correctly includes the 1 hit per query
     assert ea.num_hits == ea.current_es.search.call_count
 
-
-def test_query_segmenting(ea):
-    # Test that with use_count_query is set, segmenting occurs by run_every instead of buffer_time
+    # run_every segments with count queries
     ea.rules[0]['use_count_query'] = True
     with mock.patch('elastalert.elastalert.Elasticsearch'):
-        with mock.patch.object(ea, 'run_query') as mock_run_query:
-            ea.run_rule(ea.rules[0], END, START)
-            start = START
-            for call_args in mock_run_query.call_args_list:
-                end = start + ea.run_every
-                assert call_args[0][1:3] == (start, end)
-                start += ea.run_every
+        run_and_assert_segmented_queries(ea, START, END, ea.run_every)
+
+    # run_every segments with terms queries
+    ea.rules[0].pop('use_count_query')
+    ea.rules[0]['use_terms_query'] = True
+    with mock.patch('elastalert.elastalert.Elasticsearch'):
+        run_and_assert_segmented_queries(ea, START, END, ea.run_every)
 
 
 def test_get_starttime(ea):


### PR DESCRIPTION
Two changes:

- If `buffer_time` is less than the time elapsed since the previous query end time, use the previous `endtime`. Previously, if you set `buffer_time` less than `run_every`, each query would be skipping the difference. This would also happen if total query time was greater than `run_every`.

- Fixes #135. Segmenting is done by either `buffer_time` or `run_every`, depending on the type of query. This mimicks the query size of normal operation, where buffer_time would be used for normal queries and `run_every` would be used for `use_count`/`terms_query`