### PR TITLE
Test with mock data

### DIFF
--- a/docs/source/recipes/writing_filters.rst
+++ b/docs/source/recipes/writing_filters.rst
@@ -114,10 +114,10 @@ Any of the filters can be embedded in not, and, and or::
                   _type: "something"
 
 
-Loading Filters Directly From Kibana
-------------------------------------
+Loading Filters Directly From Kibana 3
+--------------------------------------
 
-There are two ways to load filters directly from a kibana dashboard. You can set your filter to::
+There are two ways to load filters directly from a Kibana 3 dashboard. You can set your filter to::
 
     filter:
       download_dashboard: "My Dashboard Name"

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -50,7 +50,7 @@ Rule Configuration Cheat Sheet
 +------------------------------------------------+-----+-----------+-----------+--------+-----------+-------+----------+--------+
 | ``ignore_null`` (boolean, no default)          |     |           |   Req     |  Req   |           |       |          |        |
 +------------------------------------------------+-----+-----------+-----------+--------+-----------+-------+----------+--------+
-| ``query_key`` (string, no default)             |     |           |           |   Req  |           |  Opt  |          |        |
+| ``query_key`` (string, no default)             |     |           |           |   Req  |    Opt    |  Opt  |          |  Req   |
 +------------------------------------------------+-----+-----------+-----------+--------+-----------+-------+----------+--------+
 | ``timeframe`` (time, no default)               |     |           |           |   Opt  |    Req    |  Req  |   Req    |        |
 +------------------------------------------------+-----+-----------+-----------+--------+-----------+-------+----------+--------+
@@ -210,30 +210,45 @@ that will be given the match dictionary and can modify it before it is passed to
 
 Some rules and alerts require additional options, which also go in the top level of the rule configuration file.
 
-Testing If Your Rule Is Valid
-==============================
 
-Once you've written a rule configuration, you will want to validate it. To do so, use ``elastalert-test-rule``.
+.. _testing :
 
-This will:
+Testing Your Rule
+====================
+
+Once you've written a rule configuration, you will want to validate it. To do so, you can either run ElastAlert in debug mode,
+or use ``elastalert-test-rule``, which is a script that makes various aspects of testing easier.
+
+It can:
 
 - Check that the configuration file loaded successfully.
 
 - Check that the Elasticsearch filter parses.
 
-- Run against the last day and the show the number of hits that match your filter.
+- Run against the last X day(s) and the show the number of hits that match your filter.
 
 - Show the available terms in one of the results.
 
+- Save documents returned to a JSON file.
+
+- Run ElastAlert using either a JSON file or actual results from Elasticsearch.
+
+- Print out debug alerts or trigger real alerts.
+
 - Check that, if they exist, the primary_key, compare_key and include terms are in the results.
 
-This tool does NOT test whether an alert would be triggered.
+- Show what metadata documents would be written to ``elastalert_status``. 
+
+Without any optional arguments, it will ran ElastAlert over the last 24 hours and print out any alerts that would have occured.
+Here is an example test run which triggered an alert:
 
 .. code-block:: console
 
-    $ elastalert-test-rule my_rules/rule1.yaml my_rules/rule2.yaml
-    Loaded Example rule1
-    Got 100+ hits from the last 1 day
+    $ elastalert-test-rule my_rules/rule1.yaml
+    Successfully Loaded Example rule1
+    
+    Got 105 hits from the last 1 day
+    
     Available terms in first hit:
         @timestamp
         field1
@@ -241,15 +256,56 @@ This tool does NOT test whether an alert would be triggered.
         ...
     Included term this_field_doesnt_exist may be missing or null
 
-    Loaded Other rule2
-    Got 2 hits from the last 1 day
-    Available terms in first hit:
-        @timestamp
-        field1
-        field2
-        ....
+    INFO:root:Queried rule Example rule1 from 6-16 15:21 PDT to 6-17 15:21 PDT: 105 hits
+    INFO:root:Alert for Example rule1 at 2015-06-16T23:53:12Z:
+    INFO:root:Example rule1
 
-Optionally, you may pass --days N to query the last N days, instead of the default 1 day.
+    At least 50 events occured between 6-16 18:30 PDT and 6-16 20:30 PDT
+
+    field1:
+    value1: 25
+    value2: 25
+
+    @timestamp: 2015-06-16T20:30:04-07:00
+    field1: value1
+    field2: something
+
+
+    Would have written the following documents to elastalert_status:
+
+    silence - {'rule_name': 'Example rule1', '@timestamp': datetime.datetime( ... ), 'exponent': 0, 'until': 
+    datetime.datetime( ... )}
+
+    elastalert_status - {'hits': 105, 'matches': 1, '@timestamp': datetime.datetime( ... ), 'rule_name': 'Example rule1',
+    'starttime': datetime.datetime( ... ), 'endtime': datetime.datetime( ... ), 'time_taken': 3.1415926}
+
+Note that everything between "Alert for Example rule1 at ..." and "Would have written the following ..." is the exact text body that an alert would have.
+See the section below on alert content for more details.
+Also note that datetime objects are converted to ISO8601 timestamps when uploaded to Elasticsearch. See :ref:`the section on metadata <metadata>` for more details.
+
+Other options include:
+
+``--schema-only``: Only perform schema validation on the file. It will not load modules or query Elasticsearch. This may catch invalid YAML
+and missing or misconfigured fields.
+
+``--count-only``: Only find the number of matching documents and list available fields. ElastAlert will not be run and documents will not be downloaded.
+
+``--days N``: Instead of the default 1 day, query N days. For selecting more specific time ranges, you must run ElastAlert itself and use ``--start``
+and ``--end``.
+
+``--save-json FILE``: Save all documents downloaded to a file as JSON. This is useful if you wish to modify data while testing or do offline
+testing in conjunction with ``--data FILE``. A maximum of 10,000 documents will be downloaded.
+
+``--data FILE``: Use a JSON file as a data source instead of Elasticsearch. The file should be a single list containing objects, 
+rather than objects on separate lines. Note than this uses mock functions which mimic some Elasticsearch query methods and is not
+guarenteed to have the exact same results as with Elasticsearch. For example, analyzed string fields may behave differently.
+
+``--alert``: Trigger real alerts instead of the debug (logging text) alert.
+
+.. note::
+   Results from running this script may not always be the same as if an actual ElastAlert instance was running. Some rule types, such as spike
+   and flatline require a minimum elapsed time before they begin alerting, based on their timeframe. In addition, use_count_query and
+   use_terms_query rely on run_every to determine their resolution. This script uses a fixed 5 minute window, which is the same as the default.
 
 
 .. _ruletypes:

--- a/docs/source/running_elastalert.rst
+++ b/docs/source/running_elastalert.rst
@@ -110,16 +110,11 @@ As is, this rule means "Send an email to elastalert@example.com when there are m
 Testing Your Rule
 -----------------
 
-Running ``elastalert-test-rule`` tools will test that your config file successfully loads and will query Elasticsearch with its filters. If successful, it should display the number of hits (up to 100) that match your filters from the last 24 hours and the fields available in those documents::
+Running the ``elastalert-test-rule`` tool will test that your config file successfully loads and run it in debug mode over the last 24 hours::
 
     $ elastalert-test-rule example_rules/example_frequency.yaml
-    Loaded Example rule
-    Got 100+ hits from the last 1 days
-    Available terms in first hit:
-      @timestamp
-      type
-      some_field
-      ...
+
+See :ref:`the testing section for more details <testing>`
 
 Running ElastAlert
 ------------------

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -153,13 +153,12 @@ class DebugAlerter(Alerter):
     """ The debug alerter uses a Python logger (by default, alerting to terminal). """
 
     def alert(self, matches):
-        logging.info('%d match(es)' % (len(matches)))
         qk = self.rule.get('query_key', None)
         for match in matches:
             if qk in match:
-                logging.info('%s matched %s at %s' % (match[qk], self.rule['name'], match[self.rule['timestamp_field']]))
+                logging.info('Alert for %s, %s at %s:' % (self.rule['name'], match[qk], match[self.rule['timestamp_field']]))
             else:
-                logging.info('%s at %s' % (self.rule['name'], match[self.rule['timestamp_field']]))
+                logging.info('Alert for %s at %s:' % (self.rule['name'], match[self.rule['timestamp_field']]))
             logging.info(str(BasicMatchString(self.rule, match)))
 
     def get_info(self):

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -4,18 +4,31 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import datetime
+import random
+import re
+import string
 
 import argparse
+import mock
+import simplejson
 import yaml
 
+from elastalert.config import load_modules
 from elastalert.config import load_options
 from elastalert.elastalert import ElastAlerter
 from elastalert.elastalert import Elasticsearch
 from elastalert.util import lookup_es_key
+from elastalert.util import replace_hits_ts
 from elastalert.util import ts_now
+from elastalert.util import ts_to_dt
+
+
+data = []
 
 
 def print_terms(terms, parent):
+    """ Prints a list of flattened dictionary keys """
+    print("\nAvailable terms in first hit:")
     for term in terms:
         if type(terms[term]) != dict:
             print('\t', parent + term)
@@ -23,63 +36,245 @@ def print_terms(terms, parent):
             print_terms(terms[term], parent + term + '.')
 
 
-def check_files():
-    print("Note: This tool is for testing filters and config syntax. It will not process data or alert.\n")
+def check_files(args):
+    """ Loads a rule config file, performs a query over the last day (args.days), lists available keys
+    and prints the number of results. """
+    filename = args.file
+    with open(filename) as fh:
+        conf = yaml.load(fh)
+    load_options(conf)
+    print("Successfully loaded %s\n" % (conf['name']))
+
+    if args.schema_only:
+        return []
+
+    # Set up elasticsearch client and query
+    es_client = Elasticsearch(host=conf['es_host'], port=conf['es_port'])
+    start_time = ts_now() - datetime.timedelta(days=args.days)
+    end_time = ts_now()
+    ts = conf.get('timestamp_field', '@timestamp')
+    query = ElastAlerter.get_query(conf['filter'], starttime=start_time, endtime=end_time, timestamp_field=ts)
+    index = ElastAlerter.get_index(conf, start_time, end_time)
+
+    # Get one document for schema
+    try:
+        res = es_client.search(index, size=1, body=query, ignore_unavailable=True)
+    except Exception as e:
+        print("Error running your filter:")
+        print(repr(e)[:2048])
+        return None
+    num_hits = len(res['hits']['hits'])
+    if not num_hits:
+        return []
+
+    terms = res['hits']['hits'][0]['_source']
+    doc_type = res['hits']['hits'][0]['_type']
+
+    # Get a count of all docs
+    count_query = ElastAlerter.get_query(conf['filter'], starttime=start_time, endtime=end_time, timestamp_field=ts, sort=False)
+    count_query = {'query': {'filtered': count_query}}
+    try:
+        res = es_client.count(index, doc_type=doc_type, body=count_query, ignore_unavailable=True)
+    except Exception as e:
+        print("Error querying Elasticsearch:")
+        print(repr(e)[:2048])
+        return None
+
+    num_hits = res['count']
+    print("Got %s hits from the last %s day%s" % (num_hits, args.days, 's' if args.days > 1 else ''))
+    print_terms(terms, '')
+
+    # Check for missing keys
+    pk = conf.get('primary_key')
+    ck = conf.get('compare_key')
+    if pk and not lookup_es_key(terms, pk):
+        print("Warning: primary key %s is either missing or null!")
+    if ck and not lookup_es_key(terms, ck):
+        print("Warning: compare key %s is either missing or null!")
+
+    include = conf.get('include')
+    if include:
+        for term in include:
+            if not lookup_es_key(terms, term) and '*' not in term:
+                print("Included term %s may be missing or null" % (term))
+
+    for term in conf.get('top_count_keys', []):
+        if term not in terms:
+            print("top_count_key %s may be missing" % (term))
+    print('')
+
+    # Download up to 10,000 documents to save
+    if args.save and not args.count:
+        try:
+            res = es_client.search(index, size=10000, body=query, ignore_unavailable=True)
+        except Exception as e:
+            print("Error running your filter:")
+            print(repr(e)[:2048])
+            return None
+        num_hits = len(res['hits']['hits'])
+        print("Downloaded %s documents to save" % (num_hits))
+        return res['hits']['hits']
+
+    return None
+
+
+def mock_count(rule, start, end, index):
+    """ Mocks the effects of get_hits_count using global data instead of Elasticsearch """
+    count = 0
+    for doc in data:
+        if start <= ts_to_dt(doc[rule['timestamp_field']]) < end:
+            count += 1
+    return {end: count}
+
+
+def mock_hits(rule, start, end, index):
+    """ Mocks the effects of get_hits using global data instead of Elasticsearch. """
+    docs = []
+    for doc in data:
+        if start <= ts_to_dt(doc[rule['timestamp_field']]) < end:
+            docs.append(doc)
+
+    # Remove all fields which don't match 'include'
+    for doc in docs:
+        for field in doc.keys():
+            if field != '_id':
+                if not any([re.match(incl.replace('*', '.*'), field) for incl in rule['include']]):
+                    doc.pop(field)
+
+    # Separate _source and _id, convert timestamps
+    resp = [{'_source': doc, '_id': doc['_id']} for doc in docs]
+    [doc['_source'].pop('_id') for doc in resp]
+    replace_hits_ts(resp, rule)
+    return resp
+
+
+def mock_terms(rule, start, end, index, key, qk=None, size=None):
+    """ Mocks the effects of get_hits_terms using global data instead of Elasticsearch. """
+    if key.endswith('.raw'):
+        key = key[:-4]
+    buckets = {}
+    for doc in data:
+        if key not in doc:
+            continue
+        if start <= ts_to_dt(doc[rule['timestamp_field']]) < end:
+            if qk is None or doc[rule['query_key']] == qk:
+                buckets.setdefault(doc[key], 0)
+                buckets[doc[key]] += 1
+    counts = buckets.items()
+    counts.sort(key=lambda x: x[1], reverse=True)
+    if size:
+        counts = counts[:size]
+    buckets = [{'key': value, 'doc_count': count} for value, count in counts]
+    return {end: buckets}
+
+
+def mock_elastalert(elastalert):
+    """ Replaces elastalert's get_hits functions with mocks. """
+    elastalert.get_hits_count = mock_count
+    elastalert.get_hits_terms = mock_terms
+    elastalert.get_hits = mock_hits
+    elastalert.new_elasticsearch = mock.Mock()
+
+
+def run_elastalert(args):
+    """ Creates an ElastAlert instance and run's over for a specific rule using either real or mock data. """
+    # Mock configuration. Nothing here is used except run_every
+    conf = {'rules_folder': 'rules',
+            'run_every': datetime.timedelta(minutes=5),
+            'buffer_time': datetime.timedelta(minutes=10),
+            'alert_time_limit': datetime.timedelta(hours=24),
+            'es_host': 'es',
+            'es_port': 14900,
+            'writeback_index': 'wb',
+            'max_query_size': 100000,
+            'old_query_limit': datetime.timedelta(weeks=1),
+            'disable_rules_on_error': False}
+
+    # Load and instantiate rule
+    with open(args.file) as fh:
+        rule = yaml.load(fh)
+    load_options(rule)
+    load_modules(rule)
+    conf['rules'] = [rule]
+
+    # If using mock data, make sure it's sorted and find appropriate time range
+    timestamp_field = rule.get('timestamp_field', '@timestamp')
+    if args.json:
+        global data
+        if not data:
+            return
+        try:
+            data.sort(key=lambda x: x[timestamp_field])
+            starttime = ts_to_dt(data[0][timestamp_field])
+            endtime = data[-1][timestamp_field]
+            endtime = ts_to_dt(endtime) + datetime.timedelta(seconds=1)
+        except KeyError as e:
+            print("All documents must have a timestamp and _id", e)
+            return
+
+        # Create mock _id for documents if it's missing
+        def get_id():
+            return ''.join([random.choice(string.letters) for i in range(16)])
+
+        [doc.update({'_id': doc.get('_id', get_id())}) for doc in data]
+    else:
+        endtime = ts_now()
+        starttime = endtime - datetime.timedelta(days=1)
+
+    # Set run_every to cover the entire time range unless use_count_query or use_terms_query is set
+    # This is to prevent query segmenting which unnecessarily slows down tests
+    if not rule.get('use_terms_query') and not rule.get('use_count_query'):
+        conf['run_every'] = endtime - starttime
+
+    # Instantiate ElastAlert to use mock config and special rule
+    with mock.patch('elastalert.elastalert.get_rule_hashes'):
+        with mock.patch('elastalert.elastalert.load_rules') as load_conf:
+            load_conf.return_value = conf
+            if args.alert:
+                client = ElastAlerter(['--verbose'])
+            else:
+                client = ElastAlerter(['--debug'])
+
+    # Replace get_hits_* functions to use mock data
+    if args.json:
+        mock_elastalert(client)
+
+    # Mock writeback for both real data and json data
+    client.writeback_es = None
+    with mock.patch.object(client, 'writeback') as mock_writeback:
+        client.run_rule(rule, endtime, starttime)
+
+        if mock_writeback.call_count:
+            print("\nWould have written the following documents to elastalert_status:\n")
+            for call in mock_writeback.call_args_list:
+                print(call[0][0], '-', call[0][1], '\n')
+
+
+def run_rule_test():
     parser = argparse.ArgumentParser(description='Validate a rule configuration')
-    parser.add_argument('files', metavar='file', type=str, nargs='+', help='rule configuration filename')
+    parser.add_argument('file', metavar='rule', type=str, help='rule configuration filename')
     parser.add_argument('--schema-only', action='store_true', help='Show only schema errors; do not run query')
-    parser.add_argument('--days', type=int, default=[1, 7], nargs='+', help='Query the previous N days with this rule')
+    parser.add_argument('--days', type=int, default=1, action='store', help='Query the previous N days with this rule')
+    parser.add_argument('--config', type=str, action='store', dest='config', default='config.yaml')
+    parser.add_argument('--data', type=str, metavar='FILENAME', action='store', dest='json', help='A JSON file containing data to run the rule against')
+    parser.add_argument('--alert', action='store_true', help='Use actual alerts instead of debug output')
+    parser.add_argument('--save-json', type=str, metavar='FILENAME', action='store', dest='save', help='A file to which documents from the last day or --days will be saved')
+    parser.add_argument('--count-only', action='store_true', dest='count', help='Only display the number of documents matching the filter')
     args = parser.parse_args()
 
-    for filename in args.files:
-        with open(filename) as fh:
-            conf = yaml.load(fh)
-        load_options(conf)
-        print("Successfully loaded %s\n" % (conf['name']))
-
-        if args.schema_only:
-            continue
-
-        es_client = Elasticsearch(host=conf['es_host'], port=conf['es_port'])
-        for days in args.days:
-            start_time = ts_now() - datetime.timedelta(days=days)
-            end_time = ts_now()
-            ts = conf.get('timestamp_field', '@timestamp')
-            query = ElastAlerter.get_query(conf['filter'], starttime=start_time, endtime=end_time, timestamp_field=ts)
-            index = ElastAlerter.get_index(conf, start_time, end_time)
-            try:
-                res = es_client.search(index, size=1000, body=query)
-            except Exception as e:
-                print("Error running your filter:")
-                print(repr(e)[:2048])
-                exit(1)
-
-            num_hits = len(res['hits']['hits'])
-            print("Got %s hits from the last %s day%s" % (num_hits if num_hits != 1000 else '1000+', days,
-                                                          's' if days > 1 else ''))
-
-        if num_hits:
-            print("\nAvailable terms in first hit:")
-            terms = res['hits']['hits'][0]['_source']
-            print_terms(terms, '')
-
-            pk = conf.get('primary_key')
-            ck = conf.get('compare_key')
-            if pk and not lookup_es_key(terms, pk):
-                print("Warning: primary key %s is either missing or null!")
-            if ck and not lookup_es_key(terms, ck):
-                print("Warning: compare key %s is either missing or null!")
-
-            include = conf.get('include')
-            if include:
-                for term in include:
-                    if not lookup_es_key(terms, term) and '*' not in term:
-                        print("Included term %s may be missing or null" % (term))
-
-            for term in conf.get('top_count_keys', []):
-                if term not in terms:
-                    print("top_count_key %s may be missing" % (term))
-        print('')
+    if args.json:
+        with open(args.json, 'r') as data_file:
+            global data
+            data = simplejson.loads(data_file.read())
+    else:
+        hits = check_files(args)
+        if hits and args.save:
+            with open(args.save, 'wb') as data_file:
+                # Add _id to _source for dump
+                [doc['_source'].update({'_id': doc['_id']}) for doc in hits]
+                data_file.write(simplejson.dumps([doc['_source'] for doc in hits], indent='    '))
+    if not args.schema_only and not args.count:
+        run_elastalert(args)
 
 if __name__ == '__main__':
-    check_files()
+    run_rule_test()

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-from __future__ import print_function
 
 import datetime
+import logging
 import random
 import re
 import string
@@ -22,258 +22,263 @@ from elastalert.util import replace_hits_ts
 from elastalert.util import ts_now
 from elastalert.util import ts_to_dt
 
-
-data = []
+logging.getLogger().setLevel(logging.INFO)
 
 
 def print_terms(terms, parent):
     """ Prints a list of flattened dictionary keys """
-    print("\nAvailable terms in first hit:")
+    logging.info("\nAvailable terms in first hit:")
     for term in terms:
         if type(terms[term]) != dict:
-            print('\t', parent + term)
+            logging.info('\t', parent + term)
         else:
             print_terms(terms[term], parent + term + '.')
 
 
-def check_files(args):
-    """ Loads a rule config file, performs a query over the last day (args.days), lists available keys
-    and prints the number of results. """
-    filename = args.file
-    with open(filename) as fh:
-        conf = yaml.load(fh)
-    load_options(conf)
-    print("Successfully loaded %s\n" % (conf['name']))
+class MockElastAlerter(object):
+    def __init__(self):
+        self.data = []
 
-    if args.schema_only:
-        return []
+    def test_file(self, args):
+        """ Loads a rule config file, performs a query over the last day (args.days), lists available keys
+        and prints the number of results. """
+        filename = args.file
+        with open(filename) as fh:
+            conf = yaml.load(fh)
+        load_options(conf)
+        logging.info("Successfully loaded %s\n" % (conf['name']))
 
-    # Set up elasticsearch client and query
-    es_client = Elasticsearch(host=conf['es_host'], port=conf['es_port'])
-    start_time = ts_now() - datetime.timedelta(days=args.days)
-    end_time = ts_now()
-    ts = conf.get('timestamp_field', '@timestamp')
-    query = ElastAlerter.get_query(conf['filter'], starttime=start_time, endtime=end_time, timestamp_field=ts)
-    index = ElastAlerter.get_index(conf, start_time, end_time)
+        if args.schema_only:
+            return []
 
-    # Get one document for schema
-    try:
-        res = es_client.search(index, size=1, body=query, ignore_unavailable=True)
-    except Exception as e:
-        print("Error running your filter:")
-        print(repr(e)[:2048])
-        return None
-    num_hits = len(res['hits']['hits'])
-    if not num_hits:
-        return []
+        # Set up elasticsearch client and query
+        es_client = Elasticsearch(host=conf['es_host'], port=conf['es_port'])
+        start_time = ts_now() - datetime.timedelta(days=args.days)
+        end_time = ts_now()
+        ts = conf.get('timestamp_field', '@timestamp')
+        query = ElastAlerter.get_query(conf['filter'], starttime=start_time, endtime=end_time, timestamp_field=ts)
+        index = ElastAlerter.get_index(conf, start_time, end_time)
 
-    terms = res['hits']['hits'][0]['_source']
-    doc_type = res['hits']['hits'][0]['_type']
-
-    # Get a count of all docs
-    count_query = ElastAlerter.get_query(conf['filter'], starttime=start_time, endtime=end_time, timestamp_field=ts, sort=False)
-    count_query = {'query': {'filtered': count_query}}
-    try:
-        res = es_client.count(index, doc_type=doc_type, body=count_query, ignore_unavailable=True)
-    except Exception as e:
-        print("Error querying Elasticsearch:")
-        print(repr(e)[:2048])
-        return None
-
-    num_hits = res['count']
-    print("Got %s hits from the last %s day%s" % (num_hits, args.days, 's' if args.days > 1 else ''))
-    print_terms(terms, '')
-
-    # Check for missing keys
-    pk = conf.get('primary_key')
-    ck = conf.get('compare_key')
-    if pk and not lookup_es_key(terms, pk):
-        print("Warning: primary key %s is either missing or null!")
-    if ck and not lookup_es_key(terms, ck):
-        print("Warning: compare key %s is either missing or null!")
-
-    include = conf.get('include')
-    if include:
-        for term in include:
-            if not lookup_es_key(terms, term) and '*' not in term:
-                print("Included term %s may be missing or null" % (term))
-
-    for term in conf.get('top_count_keys', []):
-        if term not in terms:
-            print("top_count_key %s may be missing" % (term))
-    print('')
-
-    # Download up to 10,000 documents to save
-    if args.save and not args.count:
+        # Get one document for schema
         try:
-            res = es_client.search(index, size=10000, body=query, ignore_unavailable=True)
+            res = es_client.search(index, size=1, body=query, ignore_unavailable=True)
         except Exception as e:
-            print("Error running your filter:")
-            print(repr(e)[:2048])
+            logging.info("Error running your filter:")
+            logging.info(repr(e)[:2048])
             return None
         num_hits = len(res['hits']['hits'])
-        print("Downloaded %s documents to save" % (num_hits))
-        return res['hits']['hits']
+        if not num_hits:
+            return []
 
-    return None
+        terms = res['hits']['hits'][0]['_source']
+        doc_type = res['hits']['hits'][0]['_type']
 
-
-def mock_count(rule, start, end, index):
-    """ Mocks the effects of get_hits_count using global data instead of Elasticsearch """
-    count = 0
-    for doc in data:
-        if start <= ts_to_dt(doc[rule['timestamp_field']]) < end:
-            count += 1
-    return {end: count}
-
-
-def mock_hits(rule, start, end, index):
-    """ Mocks the effects of get_hits using global data instead of Elasticsearch. """
-    docs = []
-    for doc in data:
-        if start <= ts_to_dt(doc[rule['timestamp_field']]) < end:
-            docs.append(doc)
-
-    # Remove all fields which don't match 'include'
-    for doc in docs:
-        for field in doc.keys():
-            if field != '_id':
-                if not any([re.match(incl.replace('*', '.*'), field) for incl in rule['include']]):
-                    doc.pop(field)
-
-    # Separate _source and _id, convert timestamps
-    resp = [{'_source': doc, '_id': doc['_id']} for doc in docs]
-    [doc['_source'].pop('_id') for doc in resp]
-    replace_hits_ts(resp, rule)
-    return resp
-
-
-def mock_terms(rule, start, end, index, key, qk=None, size=None):
-    """ Mocks the effects of get_hits_terms using global data instead of Elasticsearch. """
-    if key.endswith('.raw'):
-        key = key[:-4]
-    buckets = {}
-    for doc in data:
-        if key not in doc:
-            continue
-        if start <= ts_to_dt(doc[rule['timestamp_field']]) < end:
-            if qk is None or doc[rule['query_key']] == qk:
-                buckets.setdefault(doc[key], 0)
-                buckets[doc[key]] += 1
-    counts = buckets.items()
-    counts.sort(key=lambda x: x[1], reverse=True)
-    if size:
-        counts = counts[:size]
-    buckets = [{'key': value, 'doc_count': count} for value, count in counts]
-    return {end: buckets}
-
-
-def mock_elastalert(elastalert):
-    """ Replaces elastalert's get_hits functions with mocks. """
-    elastalert.get_hits_count = mock_count
-    elastalert.get_hits_terms = mock_terms
-    elastalert.get_hits = mock_hits
-    elastalert.new_elasticsearch = mock.Mock()
-
-
-def run_elastalert(args):
-    """ Creates an ElastAlert instance and run's over for a specific rule using either real or mock data. """
-    # Mock configuration. Nothing here is used except run_every
-    conf = {'rules_folder': 'rules',
-            'run_every': datetime.timedelta(minutes=5),
-            'buffer_time': datetime.timedelta(minutes=10),
-            'alert_time_limit': datetime.timedelta(hours=24),
-            'es_host': 'es',
-            'es_port': 14900,
-            'writeback_index': 'wb',
-            'max_query_size': 100000,
-            'old_query_limit': datetime.timedelta(weeks=1),
-            'disable_rules_on_error': False}
-
-    # Load and instantiate rule
-    with open(args.file) as fh:
-        rule = yaml.load(fh)
-    load_options(rule)
-    load_modules(rule)
-    conf['rules'] = [rule]
-
-    # If using mock data, make sure it's sorted and find appropriate time range
-    timestamp_field = rule.get('timestamp_field', '@timestamp')
-    if args.json:
-        global data
-        if not data:
-            return
+        # Get a count of all docs
+        count_query = ElastAlerter.get_query(conf['filter'], starttime=start_time, endtime=end_time, timestamp_field=ts, sort=False)
+        count_query = {'query': {'filtered': count_query}}
         try:
-            data.sort(key=lambda x: x[timestamp_field])
-            starttime = ts_to_dt(data[0][timestamp_field])
-            endtime = data[-1][timestamp_field]
-            endtime = ts_to_dt(endtime) + datetime.timedelta(seconds=1)
-        except KeyError as e:
-            print("All documents must have a timestamp and _id", e)
-            return
+            res = es_client.count(index, doc_type=doc_type, body=count_query, ignore_unavailable=True)
+        except Exception as e:
+            logging.info("Error querying Elasticsearch:")
+            logging.info(repr(e)[:2048])
+            return None
 
-        # Create mock _id for documents if it's missing
-        def get_id():
-            return ''.join([random.choice(string.letters) for i in range(16)])
+        num_hits = res['count']
+        logging.info("Got %s hits from the last %s day%s" % (num_hits, args.days, 's' if args.days > 1 else ''))
+        print_terms(terms, '')
 
-        [doc.update({'_id': doc.get('_id', get_id())}) for doc in data]
-    else:
-        endtime = ts_now()
-        starttime = endtime - datetime.timedelta(days=1)
+        # Check for missing keys
+        pk = conf.get('primary_key')
+        ck = conf.get('compare_key')
+        if pk and not lookup_es_key(terms, pk):
+            logging.info("Warning: primary key %s is either missing or null!")
+        if ck and not lookup_es_key(terms, ck):
+            logging.info("Warning: compare key %s is either missing or null!")
 
-    # Set run_every to cover the entire time range unless use_count_query or use_terms_query is set
-    # This is to prevent query segmenting which unnecessarily slows down tests
-    if not rule.get('use_terms_query') and not rule.get('use_count_query'):
-        conf['run_every'] = endtime - starttime
+        include = conf.get('include')
+        if include:
+            for term in include:
+                if not lookup_es_key(terms, term) and '*' not in term:
+                    logging.info("Included term %s may be missing or null" % (term))
 
-    # Instantiate ElastAlert to use mock config and special rule
-    with mock.patch('elastalert.elastalert.get_rule_hashes'):
-        with mock.patch('elastalert.elastalert.load_rules') as load_conf:
-            load_conf.return_value = conf
-            if args.alert:
-                client = ElastAlerter(['--verbose'])
-            else:
-                client = ElastAlerter(['--debug'])
+        for term in conf.get('top_count_keys', []):
+            if term not in terms:
+                logging.info("top_count_key %s may be missing" % (term))
+        logging.info('')
 
-    # Replace get_hits_* functions to use mock data
-    if args.json:
-        mock_elastalert(client)
+        # Download up to 10,000 documents to save
+        if args.save and not args.count:
+            try:
+                res = es_client.search(index, size=10000, body=query, ignore_unavailable=True)
+            except Exception as e:
+                logging.info("Error running your filter:")
+                logging.info(repr(e)[:2048])
+                return None
+            num_hits = len(res['hits']['hits'])
+            logging.info("Downloaded %s documents to save" % (num_hits))
+            return res['hits']['hits']
 
-    # Mock writeback for both real data and json data
-    client.writeback_es = None
-    with mock.patch.object(client, 'writeback') as mock_writeback:
-        client.run_rule(rule, endtime, starttime)
+        return None
 
-        if mock_writeback.call_count:
-            print("\nWould have written the following documents to elastalert_status:\n")
-            for call in mock_writeback.call_args_list:
-                print(call[0][0], '-', call[0][1], '\n')
+    def mock_count(self, rule, start, end, index):
+        """ Mocks the effects of get_hits_count using global data instead of Elasticsearch """
+        count = 0
+        for doc in self.data:
+            if start <= ts_to_dt(doc[rule['timestamp_field']]) < end:
+                count += 1
+        return {end: count}
 
+    def mock_hits(self, rule, start, end, index):
+        """ Mocks the effects of get_hits using global data instead of Elasticsearch. """
+        docs = []
+        for doc in self.data:
+            if start <= ts_to_dt(doc[rule['timestamp_field']]) < end:
+                docs.append(doc)
 
-def run_rule_test():
-    parser = argparse.ArgumentParser(description='Validate a rule configuration')
-    parser.add_argument('file', metavar='rule', type=str, help='rule configuration filename')
-    parser.add_argument('--schema-only', action='store_true', help='Show only schema errors; do not run query')
-    parser.add_argument('--days', type=int, default=1, action='store', help='Query the previous N days with this rule')
-    parser.add_argument('--data', type=str, metavar='FILENAME', action='store', dest='json', help='A JSON file containing data to run the rule against')
-    parser.add_argument('--alert', action='store_true', help='Use actual alerts instead of debug output')
-    parser.add_argument('--save-json', type=str, metavar='FILENAME', action='store', dest='save', help='A file to which documents from the last day or --days will be saved')
-    parser.add_argument('--count-only', action='store_true', dest='count', help='Only display the number of documents matching the filter')
-    args = parser.parse_args()
+        # Remove all fields which don't match 'include'
+        for doc in docs:
+            for field in doc:
+                if field != '_id':
+                    if not any([re.match(incl.replace('*', '.*'), field) for incl in rule['include']]):
+                        doc.pop(field)
 
-    if args.json:
-        with open(args.json, 'r') as data_file:
-            global data
-            data = simplejson.loads(data_file.read())
-    else:
-        hits = check_files(args)
-        if hits and args.save:
-            with open(args.save, 'wb') as data_file:
-                # Add _id to _source for dump
-                [doc['_source'].update({'_id': doc['_id']}) for doc in hits]
-                data_file.write(simplejson.dumps([doc['_source'] for doc in hits], indent='    '))
-    if not args.schema_only and not args.count:
-        run_elastalert(args)
+        # Separate _source and _id, convert timestamps
+        resp = [{'_source': doc, '_id': doc['_id']} for doc in docs]
+        for doc in resp:
+            doc['_source'].pop('_id')
+        replace_hits_ts(resp, rule)
+        return resp
+
+    def mock_terms(self, rule, start, end, index, key, qk=None, size=None):
+        """ Mocks the effects of get_hits_terms using global data instead of Elasticsearch. """
+        if key.endswith('.raw'):
+            key = key[:-4]
+        buckets = {}
+        for doc in self.data:
+            if key not in doc:
+                continue
+            if start <= ts_to_dt(doc[rule['timestamp_field']]) < end:
+                if qk is None or doc[rule['query_key']] == qk:
+                    buckets.setdefault(doc[key], 0)
+                    buckets[doc[key]] += 1
+        counts = buckets.items()
+        counts.sort(key=lambda x: x[1], reverse=True)
+        if size:
+            counts = counts[:size]
+        buckets = [{'key': value, 'doc_count': count} for value, count in counts]
+        return {end: buckets}
+
+    def mock_elastalert(self, elastalert):
+        """ Replaces elastalert's get_hits functions with mocks. """
+        elastalert.get_hits_count = self.mock_count
+        elastalert.get_hits_terms = self.mock_terms
+        elastalert.get_hits = self.mock_hits
+        elastalert.new_elasticsearch = mock.Mock()
+
+    def run_elastalert(self, args):
+        """ Creates an ElastAlert instance and run's over for a specific rule using either real or mock data. """
+        # Mock configuration. Nothing here is used except run_every
+        conf = {'rules_folder': 'rules',
+                'run_every': datetime.timedelta(minutes=5),
+                'buffer_time': datetime.timedelta(minutes=10),
+                'alert_time_limit': datetime.timedelta(hours=24),
+                'es_host': 'es',
+                'es_port': 14900,
+                'writeback_index': 'wb',
+                'max_query_size': 100000,
+                'old_query_limit': datetime.timedelta(weeks=1),
+                'disable_rules_on_error': False}
+
+        # Load and instantiate rule
+        with open(args.file) as fh:
+            rule = yaml.load(fh)
+        load_options(rule)
+        load_modules(rule)
+        conf['rules'] = [rule]
+
+        # If using mock data, make sure it's sorted and find appropriate time range
+        timestamp_field = rule.get('timestamp_field', '@timestamp')
+        if args.json:
+            if not self.data:
+                return
+            try:
+                self.data.sort(key=lambda x: x[timestamp_field])
+                starttime = ts_to_dt(self.data[0][timestamp_field])
+                endtime = self.data[-1][timestamp_field]
+                endtime = ts_to_dt(endtime) + datetime.timedelta(seconds=1)
+            except KeyError as e:
+                logging.info("All documents must have a timestamp and _id", e)
+                return
+
+            # Create mock _id for documents if it's missing
+            used_ids = []
+
+            def get_id():
+                _id = ''.join([random.choice(string.letters) for i in range(16)])
+                if _id in used_ids:
+                    return get_id()
+                used_ids.append(_id)
+                return _id
+
+            for doc in self.data:
+                doc.update({'_id': doc.get('_id', get_id())})
+        else:
+            endtime = ts_now()
+            starttime = endtime - datetime.timedelta(days=1)
+
+        # Set run_every to cover the entire time range unless use_count_query or use_terms_query is set
+        # This is to prevent query segmenting which unnecessarily slows down tests
+        if not rule.get('use_terms_query') and not rule.get('use_count_query'):
+            conf['run_every'] = endtime - starttime
+
+        # Instantiate ElastAlert to use mock config and special rule
+        with mock.patch('elastalert.elastalert.get_rule_hashes'):
+            with mock.patch('elastalert.elastalert.load_rules') as load_conf:
+                load_conf.return_value = conf
+                if args.alert:
+                    client = ElastAlerter(['--verbose'])
+                else:
+                    client = ElastAlerter(['--debug'])
+
+        # Replace get_hits_* functions to use mock data
+        if args.json:
+            self.mock_elastalert(client)
+
+        # Mock writeback for both real data and json data
+        client.writeback_es = None
+        with mock.patch.object(client, 'writeback') as mock_writeback:
+            client.run_rule(rule, endtime, starttime)
+
+            if mock_writeback.call_count:
+                logging.info("\nWould have written the following documents to elastalert_status:\n")
+                for call in mock_writeback.call_args_list:
+                    logging.info(call[0][0], '-', call[0][1], '\n')
+
+    def run_rule_test(self):
+        """ Uses args to run the various components of MockElastAlerter such as loading the file, saving data, loading data, and running. """
+        parser = argparse.ArgumentParser(description='Validate a rule configuration')
+        parser.add_argument('file', metavar='rule', type=str, help='rule configuration filename')
+        parser.add_argument('--schema-only', action='store_true', help='Show only schema errors; do not run query')
+        parser.add_argument('--days', type=int, default=1, action='store', help='Query the previous N days with this rule')
+        parser.add_argument('--data', type=str, metavar='FILENAME', action='store', dest='json', help='A JSON file containing data to run the rule against')
+        parser.add_argument('--alert', action='store_true', help='Use actual alerts instead of debug output')
+        parser.add_argument('--save-json', type=str, metavar='FILENAME', action='store', dest='save', help='A file to which documents from the last day or --days will be saved')
+        parser.add_argument('--count-only', action='store_true', dest='count', help='Only display the number of documents matching the filter')
+        args = parser.parse_args()
+
+        if args.json:
+            with open(args.json, 'r') as data_file:
+                self.data = simplejson.loads(data_file.read())
+        else:
+            hits = self.test_file(args)
+            if hits and args.save:
+                with open(args.save, 'wb') as data_file:
+                    # Add _id to _source for dump
+                    [doc['_source'].update({'_id': doc['_id']}) for doc in hits]
+                    data_file.write(simplejson.dumps([doc['_source'] for doc in hits], indent='    '))
+        if not args.schema_only and not args.count:
+            self.run_elastalert(args)
 
 if __name__ == '__main__':
-    run_rule_test()
+    test_instance = MockElastAlerter()
+    test_instance.run_rule_test()

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -255,7 +255,6 @@ def run_rule_test():
     parser.add_argument('file', metavar='rule', type=str, help='rule configuration filename')
     parser.add_argument('--schema-only', action='store_true', help='Show only schema errors; do not run query')
     parser.add_argument('--days', type=int, default=1, action='store', help='Query the previous N days with this rule')
-    parser.add_argument('--config', type=str, action='store', dest='config', default='config.yaml')
     parser.add_argument('--data', type=str, metavar='FILENAME', action='store', dest='json', help='A JSON file containing data to run the rule against')
     parser.add_argument('--alert', action='store_true', help='Use actual alerts instead of debug output')
     parser.add_argument('--save-json', type=str, metavar='FILENAME', action='store', dest='save', help='A file to which documents from the last day or --days will be saved')

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license='Copyright 2014 Yelp',
     entry_points={
         'console_scripts': ['elastalert-create-index=elastalert.create_index:main',
-                            'elastalert-test-rule=elastalert.test_rule:check_files',
+                            'elastalert-test-rule=elastalert.test_rule:run_rule_test',
                             'elastalert-rule-from-kibana=elastalert.rule_from_kibana:main']},
     packages=find_packages(),
     package_data={'elastalert': ['schema.yaml']},


### PR DESCRIPTION
This change adds the following features to this test script:

- Counts the number of documents from the last X days by using a single query to grab doc_type and fields, and then a count query to get a number, (and then up to 10,000 documents to save)
- Save data as JSON, for offline testing purposes. It will grab up to 10,000 documents form the last X days.
- Use offline data and mock out Elasticsearch for running against
- Actually runs ElastAlert using either a debug alerter or the real alert against real or file provided data
- Intercepts documents that would be written back to Elasticsearch

Other notes:

- It only takes one file at a time now
- The mock functions work for basic cases but may differ slightly sometimes.
- Some rules, like spike, may not trigger because elastalert is only run over the time period of the documents.
- Run_every affects the resolution of count and terms query, and it's set to the default 5 minutes here.
- This slightly changes the log text for when alerts are triggered

I also added a few various small changes in the docs to fix/clarify things