### PR TITLE
Fixed elastalert_status reporting only the last segment of a query

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -509,7 +509,7 @@ class ElastAlerter():
         # Write to ES that we've run this rule against this time period
         body = {'rule_name': rule['name'],
                 'endtime': endtime,
-                'starttime': rule['starttime'],
+                'starttime': rule['original_starttime'],
                 'matches': num_matches,
                 'hits': self.num_hits,
                 '@timestamp': ts_now(),


### PR DESCRIPTION
If a query got segmented, only the last segment would be reported by as an elastalert_status. This changes the writeback body to use original_starttime instead of the (tmp) starttime