### PR TITLE
Fixed buffer_Time being ignored in favor of previous_endtime

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -406,7 +406,7 @@ class ElastAlerter():
             if 'minimum_starttime' in rule and rule['minimum_starttime'] > buffer_delta:
                 rule['starttime'] = rule['minimum_starttime']
             # If buffer_time doesn't bring us past the previous endtime, use that instead
-            elif 'previous_endtime' in rule and rule['previous_endtime'] > buffer_delta:
+            elif 'previous_endtime' in rule and rule['previous_endtime'] < buffer_delta:
                 rule['starttime'] = rule['previous_endtime']
             else:
                 rule['starttime'] = buffer_delta

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -516,6 +516,7 @@ def test_set_starttime(ea):
     assert ea.rules[0]['starttime'] == END
 
     # buffer_time doesn't go past previous endtime
+    ea.rules[0].pop('use_count_query')
     ea.rules[0]['previous_endtime'] = end - ea.buffer_time * 2
     ea.set_starttime(ea.rules[0], end)
     assert ea.rules[0]['starttime'] == ea.rules[0]['previous_endtime']


### PR DESCRIPTION
buffer_time was ignored UNLESS it didn't go past previous_endtime. The test didn't catch this because use_count_query had been set by a previous test.

Verified this test failed after I popped use_count_query.