### PR TITLE
Compound query key

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -209,11 +209,12 @@ that will be given the match dictionary and can modify it before it is passed to
 ``module.file.EnhancementName``. See :ref:`Enhancements` for more information. (Optional, list of strings, no default)
 
 ``query_key``: Having a query key means that realert time will be counted separately for each unique value of ``query_key``. For rule types which
-count documents, such as spike, frequency and flatline, it also means that these counts will independent for each unique value of ``query_key``.
+count documents, such as spike, frequency and flatline, it also means that these counts will be independent for each unique value of ``query_key``.
 For example, if ``query_key`` is set to ``username`` and ``realert`` is set, and an alert triggers on a document with ``{'username': 'bob'}``,
 additional alerts for ``{'username': 'bob'}`` will be ignored while other usernames will trigger alerts. Documents which are missing the
 ``query_key`` will be grouped together. A list of fields may also be used, which will create a compound query key. This compound key is
-treated as if it were a single field whose value is the component values, or "None", joined by commas.
+treated as if it were a single field whose value is the component values, or "None", joined by commas. A new field with the key
+"field1,field2,etc" will be created in each document and may conflict with existing fields of the same name.
 
 Some rules and alerts require additional options, which also go in the top level of the rule configuration file.
 

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -126,10 +126,16 @@ def load_options(rule, conf=None):
     if 'include' in rule and type(rule['include']) != list:
         raise EAException('include option must be a list')
 
+    if isinstance(rule.get('query_key'), list):
+        rule['compound_query_key'] = rule['query_key']
+        rule['query_key'] = ','.join(rule['query_key'])
+
     # Add QK, CK and timestamp to include
     include = rule.get('include', [])
     if 'query_key' in rule:
         include.append(rule['query_key'])
+    if 'compound_query_key' in rule:
+        include += rule['compound_query_key']
     if 'compare_key' in rule:
         include.append(rule['compare_key'])
     if 'top_count_keys' in rule:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -25,7 +25,6 @@ from util import dt_to_ts
 from util import EAException
 from util import format_index
 from util import pretty_ts
-from util import replace_hits_ts
 from util import seconds
 from util import ts_add
 from util import ts_now
@@ -208,6 +207,15 @@ class ElastAlerter():
         timestamp = res['hits']['hits'][0]['_source'][timestamp_field]
         return timestamp
 
+    def process_hits(self, rule, hits):
+        """ Process results from Elasticearch. This replaces timestamps with datetime objects
+        and creates compound query_keys. """
+        for hit in hits:
+            hit['_source'][rule['timestamp_field']] = ts_to_dt(hit['_source'][rule['timestamp_field']])
+            if rule.get('compound_query_key'):
+                values = [hit['_source'].get(key, 'None') for key in rule['compound_query_key']]
+                hit['_source'][rule['query_key']] = ', '.join(values)
+
     def get_hits(self, rule, starttime, endtime, index):
         """ Query elasticsearch for the given rule and return the results.
 
@@ -231,7 +239,7 @@ class ElastAlerter():
         self.num_hits += len(hits)
         lt = rule.get('use_local_time')
         logging.info("Queried rule %s from %s to %s: %s hits" % (rule['name'], pretty_ts(starttime, lt), pretty_ts(endtime, lt), len(hits)))
-        replace_hits_ts(hits, rule)
+        self.process_hits(rule, hits)
 
         # Record doc_type for use in get_top_counts
         if 'doc_type' not in rule and len(hits):

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -49,7 +49,6 @@ oneOf:
       type: {enum: [change]}
       compare_key: {type: string}
       ignore_null: {type: boolean}
-      query_key: {type: string}
       timeframe: *timeframe
 
   - title: Frequency
@@ -62,7 +61,6 @@ oneOf:
       doc_type: {type: string}
       use_terms_query: {type: boolean}
       terms_size: {type: integer}
-      query_key: {type: string}
 
   - title: Spike
     required: [spike_height, spike_type, timeframe]
@@ -139,6 +137,7 @@ properties:
   use_kibana_dashboard: {type: string}
   use_local_time: {type: boolean}
   match_enhancements: {type: array, items: {type: string}}
+  query_key: *arrayOfString
 
   # Alerts
   alert: *arrayOfString

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -56,13 +56,6 @@ def lookup_es_key(lookup_dict, term):
         return go_deeper
 
 
-def replace_hits_ts(hits, rule):
-    """Iterate through a hits dictionary from ElasticSearch, and convert string timestamps to datetime objects
-    """
-    for hit in hits:
-        hit['_source'][rule['timestamp_field']] = ts_to_dt(hit['_source'][rule['timestamp_field']])
-
-
 def ts_to_dt(timestamp):
     if isinstance(timestamp, datetime.datetime):
         logging.warning('Expected str timestamp, got datetime')

--- a/example_rules/example_new_term.yaml
+++ b/example_rules/example_new_term.yaml
@@ -1,0 +1,67 @@
+# Alert when a login event is detected for a never before seen combination of (username, computer)
+# In this example, "login" logs contain which user has logged into what computer
+
+# (Required)
+# Elasticsearch host
+es_host: elasticsearch.example.com
+
+# (Required)
+# Elasticsearch port
+es_port: 14900
+
+# (OptionaL) Connect with SSL to elasticsearch
+#use_ssl: True
+
+# (Optional) basic-auth username and password for elasticsearch
+#es_username: someusername
+#es_password: somepassword
+
+# (Required)
+# Rule name, must be unique
+name: Example rule
+
+# (Required)
+# Type of alert.
+# the frequency rule type alerts when num_events events occur with timeframe time
+type: new_term
+
+# (Required)
+# Index to search, wildcard supported
+index: logstash-*
+
+# (Optional)
+# This creates the compound key ("username", "computer") in the document
+query_key:
+ - "username"
+ - "computer"
+
+# (Required, new_term specific)
+# Monitor the compound field ("username", "computer")
+# Note that this field only exists when query_key is ["username", "computer"]
+fields:
+ - "username,computer"
+
+# (Optional, new_term specific)
+# This means that we will query 90 days worth of data when ElastAlert starts to find which values of (username, computer) already exist
+# If they existed in the last 90 days, no alerts will be triggered for them when they appear
+terms_window_size:
+  days: 90
+
+# (Required)
+# A list of elasticsearch filters used for find events
+# These filters are joined with AND and nested in a filtered query
+# For more info: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html
+# We are filtering for only "login_event" type documents, which we assume contain at least the fields "username", "computer" and "@timestamp"
+filter:
+- term:
+    _type: "login_event"
+
+# (Required)
+# The alert is use when a match is found
+alert:
+- "email"
+
+# (required, email specific)
+# a list of email addresses to send alerts to
+email:
+- "elastalert@example.com"

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -293,6 +293,17 @@ def test_silence(ea):
     assert ea.rules[0]['alert'][0].alert.call_count == 1
 
 
+def test_compound_query_key(ea):
+    ea.rules[0]['query_key'] = 'this,that'
+    ea.rules[0]['compound_query_key'] = ['this', 'that']
+    hits = generate_hits([START_TIMESTAMP, END_TIMESTAMP], this='abc', that='def')
+    ea.current_es.search.return_value = hits
+    ea.run_query(ea.rules[0], START, END)
+    call_args = ea.rules[0]['type'].add_data.call_args_list[0]
+    assert 'this,that' in call_args[0][0][0]
+    assert call_args[0][0][0]['this,that'] == 'abc, def'
+
+
 def test_silence_query_key(ea):
     # Silence test rule for 4 hours
     ea.args.rule = 'test_rule.yaml'  # Not a real name, just has to be set

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -9,6 +9,7 @@ import elastalert.alerts
 import elastalert.ruletypes
 from elastalert.config import get_file_paths
 from elastalert.config import load_configuration
+from elastalert.config import load_options
 from elastalert.config import load_rules
 from elastalert.util import EAException
 
@@ -82,6 +83,17 @@ def test_load_rules():
             # Assert include doesn't contain duplicates
             assert rules['rules'][0]['include'].count('@timestamp') == 1
             assert rules['rules'][0]['include'].count('comparekey') == 1
+
+
+def test_compound_query_key():
+    test_rule_copy = copy.deepcopy(test_rule)
+    test_rule_copy.pop('use_count_query')
+    test_rule_copy['query_key'] = ['field1', 'field2']
+    load_options(test_rule_copy)
+    assert 'field1' in test_rule_copy['include']
+    assert 'field2' in test_rule_copy['include']
+    assert test_rule_copy['query_key'] == 'field1,field2'
+    assert test_rule_copy['compound_query_key'] == ['field1', 'field2']
 
 
 def test_raises_on_missing_config():


### PR DESCRIPTION
query_key can be set to a list, which will cause a compound key to be generated in the document by joining all fields by commas. The actual value of query key will then be set to this compound field name, which will exist in every document. If a value is missing, it will be treated as "None".

For example, with
```
query_key:
 - "username"
 - "computer"
```
and document 
`` {"username": "bob", "computer": "server1"} ``

query_key will be set to "username,computer" and the document will now include ``{"username,computer": "bob, server1"}`` so that the rest of the code can use this compound key.

I put this code into a new function, along with the functionality of replace_hits_ts, which did similar things. 

I added tests and documentation. I changed a bit of other document around query_key that implied it could only be used for certain rule types. I also added an example rule which uses this compound key and new_term rule.