### PR TITLE
Changed EventWindow.count to use a running sum

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -244,6 +244,7 @@ class EventWindow(object):
         self.onRemoved = onRemoved
         self.get_ts = getTimestamp
         self.data = deque()
+        self.running_count = 0
 
     def append(self, event):
         """ Add an event to the window. Event should be of the form (dict, count).
@@ -254,9 +255,11 @@ class EventWindow(object):
             self.append_middle(event)
         else:
             self.data.append(event)
+            self.running_count += event[1]
 
         while self.duration() >= self.timeframe:
             oldest = self.data.popleft()
+            self.running_count -= oldest[1]
             self.onRemoved and self.onRemoved(oldest)
 
     def duration(self):
@@ -267,7 +270,7 @@ class EventWindow(object):
 
     def count(self):
         """ Count the number of events in the window. """
-        return sum(map(lambda e: e[1], self.data))
+        return self.running_count
 
     def __iter__(self):
         return iter(self.data)
@@ -281,6 +284,7 @@ class EventWindow(object):
         # Append left if ts is earlier than first event
         if self.get_ts(self.data[0]) > ts:
             self.data.appendleft(event)
+            self.running_count += event[1]
             return
 
         # Rotate window until we can insert event
@@ -291,6 +295,7 @@ class EventWindow(object):
                 # This should never happen
                 return
         self.data.append(event)
+        self.running_count += event[1]
         self.data.rotate(-rotation)
 
 

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -157,23 +157,23 @@ def test_freq_terms():
 
 def test_eventwindow():
     timeframe = datetime.timedelta(minutes=10)
-    window = EventWindow(timeframe, getTimestamp=lambda e: e['@timestamp'])
+    window = EventWindow(timeframe, getTimestamp=lambda e: e[0]['@timestamp'])
     timestamps = [ts_to_dt(x) for x in ['2014-01-01T10:00:00',
                                         '2014-01-01T10:05:00',
                                         '2014-01-01T10:03:00',
                                         '2014-01-01T09:55:00',
                                         '2014-01-01T10:09:00']]
     for ts in timestamps:
-        window.append({'@timestamp': ts})
+        window.append([{'@timestamp': ts}, 1])
 
     timestamps.sort()
     for exp, actual in zip(timestamps[1:], window.data):
-        assert actual['@timestamp'] == exp
+        assert actual[0]['@timestamp'] == exp
 
-    window.append({'@timestamp': ts_to_dt('2014-01-01T10:14:00')})
+    window.append([{'@timestamp': ts_to_dt('2014-01-01T10:14:00')}, 1])
     timestamps.append(ts_to_dt('2014-01-01T10:14:00'))
     for exp, actual in zip(timestamps[3:], window.data):
-        assert actual['@timestamp'] == exp
+        assert actual[0]['@timestamp'] == exp
 
 
 def test_spike_count():


### PR DESCRIPTION
EventWindow.count() previous summed the counts of all events each time it ran, which was very inefficient considering it is often called after every append. This changes EventWindow to use a running count which is updated on insertion and deletion.

This also fixes a test which has been incorrectly using EventWindow.

I ran a small performance test which appended 10,000 events with random timestamps and called count() after each append. These changes cut the runtime roughly in half.