### PR TITLE
Kibana 3 dashboards work with compound query keys

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -722,9 +722,10 @@ class ElastAlerter():
 
         # Add filter for query_key value
         if 'query_key' in rule:
-            if rule['query_key'] in match:
-                term = {'term': {rule['query_key']: match[rule['query_key']]}}
-                kibana.add_filter(db, term)
+            for qk in rule.get('compound_query_key', [rule['query_key']]):
+                if qk in match:
+                    term = {'term': {qk: match[qk]}}
+                    kibana.add_filter(db, term)
 
         # Convert to json
         db_js = json.dumps(db)


### PR DESCRIPTION
This separates filters added to kibana 3 dashboards if compound_query_key is used.

I will add a test for this (and upload_dashboard as a whole for that matter).