### PR TITLE
Changed logging back to print, fixed replace_hits_ts import error

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -207,7 +207,8 @@ class ElastAlerter():
         timestamp = res['hits']['hits'][0]['_source'][timestamp_field]
         return timestamp
 
-    def process_hits(self, rule, hits):
+    @staticmethod
+    def process_hits(rule, hits):
         """ Process results from Elasticearch. This replaces timestamps with datetime objects
         and creates compound query_keys. """
         for hit in hits:


### PR DESCRIPTION
1. Fixes replace_hits_ts which moved to process_hits in another PR.
2. Change all logging.info back to print/print to stderr. This is mostly because having "INFO:root:" preceding every line was annoying and unnecessary. I think print is appropriate for a test script.
3. buffer_time is changed to 45 minutes, which is the same as the config.yaml.example