### PR TITLE
All SSL connections to SMTP host

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -714,6 +714,8 @@ Optional:
 
 ``smtp_host``: The SMTP host to use, defaults to localhost.
 
+``smtp_ssl``: Connect the SMTP host using SSL, defaults to ``false``.
+
 ``smtp_auth_file``: The path to a file which contains SMTP authentication credentials. It should be YAML formatted and contain
 two fields, ``user`` and ``password``. If this is not present, no authentication will be attempted.
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -4,7 +4,7 @@ import json
 import logging
 import subprocess
 from email.mime.text import MIMEText
-from smtplib import SMTP
+from smtplib import SMTP, SMTP_SSL
 from smtplib import SMTPAuthenticationError
 from smtplib import SMTPException
 from socket import error
@@ -173,6 +173,7 @@ class EmailAlerter(Alerter):
         super(EmailAlerter, self).__init__(*args)
 
         self.smtp_host = self.rule.get('smtp_host', 'localhost')
+        self.smtp_ssl = self.rule.get('smtp_ssl', False)
         self.from_addr = self.rule.get('from_addr', 'ElastAlert')
         if self.rule.get('smtp_auth_file'):
             self.get_account(self.rule['smtp_auth_file'])
@@ -217,7 +218,10 @@ class EmailAlerter(Alerter):
             to_addr = to_addr + self.rule['bcc']
 
         try:
-            self.smtp = SMTP(self.smtp_host)
+            if self.smtp_ssl:
+                self.smtp = SMTP_SSL(self.smtp_host)
+            else:
+                self.smtp = SMTP(self.smtp_host)
             if 'smtp_auth_file' in self.rule:
                 self.smtp.login(self.user, self.password)
         except (SMTPException, error) as e:


### PR DESCRIPTION
Setting `smtp_ssl` to `true` in a rule allows for the alerter class to initiate an SSL connection. Very useful when using services like Mandrill and SendGrid.
