### PR TITLE
Pass args to RuleType.__init__ and update NewTerm to obey --start

### DIFF
--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -55,7 +55,7 @@ def get_module(module_name):
     return module
 
 
-def load_configuration(filename, conf=None):
+def load_configuration(filename, conf=None, args=None):
     """ Load a yaml rule file and fill in the relevant fields with objects.
 
     :param filename: The name of a rule configuration file.
@@ -68,12 +68,12 @@ def load_configuration(filename, conf=None):
         raise EAException('Could not parse file %s: %s' % (filename, e))
 
     rule['rule_file'] = filename
-    load_options(rule, conf)
-    load_modules(rule)
+    load_options(rule, conf, args)
+    load_modules(rule, args)
     return rule
 
 
-def load_options(rule, conf=None):
+def load_options(rule, conf=None, args=None):
     """ Converts time objects, sets defaults, and validates some settings.
 
     :param rule: A dictionary of parsed YAML from a rule config file.
@@ -180,7 +180,7 @@ def load_options(rule, conf=None):
                                                                          datetime.datetime.now().strftime(rule.get('index'))))
 
 
-def load_modules(rule):
+def load_modules(rule, args=None):
     """ Loads things that could be modules. Enhancements, alerts and rule type. """
     # Set match enhancements
     match_enhancements = []
@@ -230,7 +230,7 @@ def load_modules(rule):
 
     # Instantiate rule
     try:
-        rule['type'] = rule['type'](rule)
+        rule['type'] = rule['type'](rule, args)
     except (KeyError, EAException) as e:
         raise EAException('Error initializing rule %s: %s' % (rule['name'], e))
 
@@ -250,16 +250,17 @@ def get_file_paths(conf, use_rule=None):
     return rule_files
 
 
-def load_rules(filename, use_rule=None):
+def load_rules(args):
     """ Creates a conf dictionary for ElastAlerter. Loads the global
     config file and then each rule found in rules_folder.
 
-    :param filename: Name of the global configuration file.
-    :param use_rule: Only load the rule which has this filename.
+    :param args: The parsed arguments to ElastAlert
     :return: The global configuration, a dictionary.
     """
     names = []
+    filename = args.config
     conf = yaml_loader(filename)
+    use_rule = args.rule
 
     # Make sure we have all required globals
     if required_globals - frozenset(conf.keys()):
@@ -288,7 +289,7 @@ def load_rules(filename, use_rule=None):
     rule_files = get_file_paths(conf, use_rule)
     for rule_file in rule_files:
         try:
-            rule = load_configuration(rule_file, conf)
+            rule = load_configuration(rule_file, conf, args)
             if rule['name'] in names:
                 raise EAException('Duplicate rule named %s' % (rule['name']))
         except EAException as e:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -60,11 +60,21 @@ class ElastAlerter():
 
     def __init__(self, args):
         self.parse_args(args)
-        self.conf = load_rules(self.args.config, use_rule=self.args.rule)
-        self.max_query_size = self.conf['max_query_size']
-        self.rules = self.conf['rules']
         self.debug = self.args.debug
         self.verbose = self.args.verbose
+
+        if self.debug:
+            self.verbose = True
+
+        if self.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        if not self.args.es_debug:
+            logging.getLogger('elasticsearch').setLevel(logging.WARNING)
+
+        self.conf = load_rules(self.args)
+        self.max_query_size = self.conf['max_query_size']
+        self.rules = self.conf['rules']
         self.writeback_index = self.conf['writeback_index']
         self.run_every = self.conf['run_every']
         self.alert_time_limit = self.conf['alert_time_limit']
@@ -86,15 +96,6 @@ class ElastAlerter():
         self.es_conn_config = self.build_es_conn_config(self.conf)
 
         self.writeback_es = self.new_elasticsearch(self.es_conn_config)
-
-        if self.debug:
-            self.verbose = True
-
-        if self.verbose:
-            logging.getLogger().setLevel(logging.INFO)
-
-        if not self.args.es_debug:
-            logging.getLogger('elasticsearch').setLevel(logging.WARNING)
 
         for rule in self.rules:
             rule = self.init_rule(rule)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -39,6 +39,10 @@ test_rule = {'es_host': 'test_host',
              'aggregation': {'hours': 2},
              'include': ['comparekey', '@timestamp']}
 
+test_args = mock.Mock()
+test_args.config = 'test_config'
+test_args.rule = None
+
 
 def test_import_rules():
     test_rule_copy = copy.deepcopy(test_rule)
@@ -72,7 +76,7 @@ def test_load_rules():
 
         with mock.patch('os.listdir') as mock_ls:
             mock_ls.return_value = ['testrule.yaml']
-            rules = load_rules('test_config')
+            rules = load_rules(test_args)
             assert isinstance(rules['rules'][0]['type'], elastalert.ruletypes.RuleType)
             assert isinstance(rules['rules'][0]['alert'][0], elastalert.alerts.Alerter)
             assert isinstance(rules['rules'][0]['timeframe'], datetime.timedelta)
@@ -113,7 +117,7 @@ def test_raises_on_missing_config():
             with mock.patch('os.listdir') as mock_ls:
                 mock_ls.return_value = ['testrule.yaml']
                 with pytest.raises(EAException):
-                    load_rules('test_config')
+                    load_rules(test_args)
 
 
 def test_raises_on_bad_generate_kibana_filters():

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -455,8 +455,8 @@ def test_new_term():
     rules = {'fields': ['a', 'b'],
              'timestamp_field': '@timestamp',
              'es_host': 'example.com', 'es_port': 10, 'index': 'logstash'}
-    mock_res = {'aggregations': {'values': {'buckets': [{'key': 'key1', 'doc_count': 1},
-                                                        {'key': 'key2', 'doc_count': 5}]}}}
+    mock_res = {'aggregations': {'filtered': {'values': {'buckets': [{'key': 'key1', 'doc_count': 1},
+                                                                     {'key': 'key2', 'doc_count': 5}]}}}}
 
     with mock.patch('elastalert.ruletypes.Elasticsearch') as mock_es:
         mock_es.return_value = mock.Mock()


### PR DESCRIPTION
Fixes #166 

args gets passed to RuleType.__init__ so that rule types can use arguments. This also always adds a time range bound to get_all_terms in NewTermRule.

These changes are pretty expansive considering the small scope of the issue this is to solve. Maybe forcing load_rules to take a parsed arg object is not ideal. I am open to suggestions on better ways to do this.