### PR TITLE
Fixing reloading of rules.

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -578,7 +578,7 @@ class ElastAlerter():
             if hash_value != rule_hashes[rule_file]:
                 # Rule file was changed, reload rule
                 try:
-                    new_rule = load_configuration(os.path.join(self.conf['rules_folder'], rule_file))
+                    new_rule = load_configuration(rule_file)
                 except EAException as e:
                     self.handle_error('Could not load rule %s: %s' % (rule_file, e))
                     continue


### PR DESCRIPTION
I'm not sure if you guys encountered this but the rules folder was appended twice so I would get something like the following `rules/rules/rule_name.yaml` where I just wanted `rules/rule_name.yaml`.

This fixed the problem. Tell me if this works for you guys.