### PR TITLE
Fix rule file loading

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -3,7 +3,6 @@ import copy
 import datetime
 import json
 import logging
-import os
 import sys
 import time
 import traceback
@@ -598,7 +597,7 @@ class ElastAlerter():
         if not self.args.rule:
             for rule_file in set(rule_hashes.keys()) - set(self.rule_hashes.keys()):
                 try:
-                    new_rule = load_configuration(os.path.join(self.conf['rules_folder'], rule_file))
+                    new_rule = load_configuration(rule_file)
                     if new_rule['name'] in [rule['name'] for rule in self.rules]:
                         raise EAException("A rule with the name %s already exists" % (new_rule['name']))
                 except EAException as e:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -578,7 +578,7 @@ class ElastAlerter():
             if hash_value != rule_hashes[rule_file]:
                 # Rule file was changed, reload rule
                 try:
-                    new_rule = load_configuration(os.path.join(self.conf['rules_folder'], rule_file))
+                    new_rule = load_configuration(rule_file)
                 except EAException as e:
                     self.handle_error('Could not load rule %s: %s' % (rule_file, e))
                     continue

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -585,14 +585,14 @@ def test_kibana_dashboard(ea):
 
 
 def test_rule_changes(ea):
-    ea.rule_hashes = {'rule1.yaml': 'ABC',
-                      'rule2.yaml': 'DEF'}
-    ea.rules = [ea.init_rule(rule, True) for rule in [{'rule_file': 'rule1.yaml', 'name': 'rule1', 'filter': []},
-                                                      {'rule_file': 'rule2.yaml', 'name': 'rule2', 'filter': []}]]
+    ea.rule_hashes = {'rules/rule1.yaml': 'ABC',
+                      'rules/rule2.yaml': 'DEF'}
+    ea.rules = [ea.init_rule(rule, True) for rule in [{'rule_file': 'rules/rule1.yaml', 'name': 'rule1', 'filter': []},
+                                                      {'rule_file': 'rules/rule2.yaml', 'name': 'rule2', 'filter': []}]]
     ea.rules[1]['processed_hits'] = ['save me']
-    new_hashes = {'rule1.yaml': 'ABC',
-                  'rule3.yaml': 'XXX',
-                  'rule2.yaml': '!@#$'}
+    new_hashes = {'rules/rule1.yaml': 'ABC',
+                  'rules/rule3.yaml': 'XXX',
+                  'rules/rule2.yaml': '!@#$'}
 
     with mock.patch('elastalert.elastalert.get_rule_hashes') as mock_hashes:
         with mock.patch('elastalert.elastalert.load_configuration') as mock_load:


### PR DESCRIPTION
rule_file paths already included the elastalert_rules folder. When they were joined again, this resulted in the duplication of the elastalert_rules path. os.path.join would de-duplicate this when elastalert_rules was given as a full path but not as a relative path.

This also fixes the test to have a full path as mock rule_hashes data.