### PR TITLE
Initialized last_command member of CommandAlerter class

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -404,6 +404,7 @@ class CommandAlerter(Alerter):
 
     def __init__(self, *args):
         super(CommandAlerter, self).__init__(*args)
+        self.last_command = []
         if isinstance(self.rule['command'], basestring) and '%' in self.rule['command']:
             logging.warning('Warning! You could be vulnerable to shell injection!')
             self.rule['command'] = [self.rule['command']]


### PR DESCRIPTION
Fix for

    ERROR:root:Uncaught exception running rule xyz: 'CommandAlerter' object has no attribute 'last_command'

Happens especially when running in --verbose mode.