### PR TITLE
Add Vagrantfile and Salt provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,38 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+unless Vagrant.has_plugin?("vagrant-hostmanager")
+  raise 'vagrant-hostmanager is not installed! '\
+        'Please run: vagrant plugin install vagrant-hostmanager'
+end
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "rubicon/ubuntu1404-salt"
+  config.vm.synced_folder "salt/roots/", "/srv/"
+
+  config.hostmanager.enabled = true
+  config.hostmanager.manage_host = false
+
+  config.vm.provision :salt do |salt|
+    salt.log_level = "error"
+    salt.minion_config = "salt/minion"
+    salt.run_highstate = true
+  end
+
+  if Vagrant.has_plugin?("vagrant-cachier")
+    config.cache.scope = :box
+  end
+
+  config.vm.define "elasticsearch" do |elasticsearch|
+    elasticsearch.vm.hostname = "elasticsearch"
+  end
+
+  config.vm.define "elastalert" do |elastalert|
+    elastalert.vm.hostname = "elastalert"
+  end
+
+  config.vm.provision :shell, :inline => "/usr/games/cowsay $HOSTNAME is ready!"
+end

--- a/salt/minion
+++ b/salt/minion
@@ -1,0 +1,1 @@
+file_client: local

--- a/salt/roots/salt/common.sls
+++ b/salt/roots/salt/common.sls
@@ -1,0 +1,2 @@
+cowsay:
+  pkg.installed

--- a/salt/roots/salt/elastalert.sls
+++ b/salt/roots/salt/elastalert.sls
@@ -1,0 +1,50 @@
+elastalert-supervisor:
+  file.managed:
+    - name: /etc/supervisor/conf.d/elastalert.conf
+    - source: salt://supervisor/supervisor.conf
+    - template: jinja
+    - require:
+      - sls: supervisor
+  supervisord.running:
+    - name: elastalert
+    - update: True
+    - restart: True
+    - require:
+      - sls: supervisor
+      - file: elastalert-config
+      - cmd: elastalert-install
+      - cmd: elastalert-create-index
+
+elastalert-requirements:
+  pip.installed:
+    - cwd: /vagrant
+    - requirements: requirements-dev.txt
+    - require:
+      - sls: python
+
+elastalert-config:
+  file.managed:
+    - name: /etc/elastalert/config.yaml
+    - source: salt://elastalert/config.yaml
+    - template: jinja
+    - makedirs: True
+
+elastalert-rules:
+  file.recurse:
+    - name: /etc/elastalert/rules
+    - source: salt://elastalert/rules
+    - makedirs: True
+
+elastalert-create-index:
+  cmd.run:
+    - name: elastalert-create-index --no-auth --no-ssl --index=elastalert_status --old-index=''
+    - cwd: /etc/elastalert
+    - require:
+      - file: elastalert-config
+
+elastalert-install:
+  cmd.run:
+    - name: python setup.py install
+    - cwd: /vagrant
+    - require:
+      - pip: elastalert-requirements

--- a/salt/roots/salt/elastalert/config.yaml
+++ b/salt/roots/salt/elastalert/config.yaml
@@ -1,0 +1,37 @@
+# This is the folder that contains the rule yaml files
+# Any .yaml file will be loaded as a rule
+rules_folder: /etc/elastalert/rules
+
+# How often ElastAlert will query elasticsearch
+# The unit can be anything from weeks to seconds
+run_every:
+  minutes: 5
+
+# ElastAlert will buffer results from the most recent
+# period of time, in case some log sources are not in real time
+buffer_time:
+  minutes: 45
+
+# The elasticsearch hostname for metadata writeback
+# Note that every rule can have it's own elasticsearch host
+es_host: elasticsearch
+
+# The elasticsearch port
+es_port: 9200
+
+# Connect with SSL to elasticsearch
+#use_ssl: True
+
+# Option basic-auth username and password for elasticsearch
+#es_username: someusername
+#es_password: somepassword
+
+# The index on es_host which is used for metadata storage
+# This can be a unmapped index, but it is reccommended that you run
+# elastalert-create-index to set a mapping
+writeback_index: elastalert_status
+
+# If an alert fails for some reason, ElastAlert will retry
+# sending the alert until this time period has elapsed
+alert_time_limit:
+  days: 2

--- a/salt/roots/salt/elasticsearch.sls
+++ b/salt/roots/salt/elasticsearch.sls
@@ -1,0 +1,15 @@
+openjdk-7-jre-headless:
+  pkg.installed
+
+elasticsearch:
+    pkg.installed:
+        - sources:
+            - elasticsearch: https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.6.0.deb
+        - require:
+          - pkg: openjdk-7-jre-headless
+    service.running:
+        - name: elasticsearch
+        - running: True
+        - enable: True
+        - require:
+            - pkg: elasticsearch

--- a/salt/roots/salt/python.sls
+++ b/salt/roots/salt/python.sls
@@ -1,0 +1,18 @@
+deadsnakes:
+  pkgrepo.managed:
+    - ppa: fkrull/deadsnakes
+    - require_in:
+      - pkg: python2.6
+      - pkg: python2.6-dev
+
+python2.6:
+  pkg.installed
+
+python2.6-dev:
+  pkg.installed
+
+python-pip:
+  pkg.installed
+
+python-dev:
+  pkg.installed

--- a/salt/roots/salt/supervisor.sls
+++ b/salt/roots/salt/supervisor.sls
@@ -1,0 +1,2 @@
+supervisor:
+  pkg.installed

--- a/salt/roots/salt/supervisor/supervisor.conf
+++ b/salt/roots/salt/supervisor/supervisor.conf
@@ -1,0 +1,14 @@
+[program:elastalert]
+command =
+        python -m elastalert.elastalert
+               --config=/etc/elastalert/config.yaml
+               --verbose
+process_name=elastalert
+autorestart=true
+startsecs=15
+stopsignal=INT
+stopasgroup=true
+killasgroup=true
+directory=/vagrant
+stderr_logfile=/var/log/elastalert_stderr.log
+stderr_logfile_maxbytes=5MB

--- a/salt/roots/salt/top.sls
+++ b/salt/roots/salt/top.sls
@@ -1,0 +1,9 @@
+base:
+  'elasticsearch':
+    - common
+    - elasticsearch
+  'elastalert':
+    - common
+    - python
+    - supervisor
+    - elastalert

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,16 @@ from setuptools import find_packages
 from setuptools import setup
 
 
+# Hard linking doesn't work inside VirtualBox/VMWare shared folders. This means
+# that you can't use tox in a directory that is being shared with Vagrant,
+# since tox relies on `python setup.py sdist` which uses hard links. As a
+# workaround, disable hard-linking if setup.py is a descendant of /vagrant.
+# See
+# https://stackoverflow.com/questions/7719380/python-setup-py-sdist-error-operation-not-permitted
+# for more details.
+if os.path.abspath(__file__).split(os.path.sep)[1] == 'vagrant':
+    del os.link
+
 base_dir = os.path.dirname(__file__)
 setup(
     name='elastalert',


### PR DESCRIPTION
This is an entirely optional merge, but I found this setup convenient, so perhaps Yelp  (or someone else) might too.

This branch adds a Vagrantfile which creates a multi-machine environment provisioned by Salt that consists of the following:

* `elasticsearch`:
    - This is an Ubuntu 14.04 box with Elasticsearch 1.6.
* `elastalert`:
    - This is an Ubuntu 14.04 box with:
        - ElastAlert and dependencies
        - Python 2.6 and 2.7
        - Supervisor

Upon instantiation, the `elastalert` box will be provisioned to use `elasticsearch` as its Elasticsearch host. Moreover, ElastAlert will be automatically started under `supervisord` using the configuration in `salt/roots/salt/elastalert/config.yaml` with the rules (if any) specified in `salt/roots/salt/elastalert/rules`. Combined with the scripted loading of data for the `elasticsearch` box, this can be a convenient way to test rules in an automated fashion without a persistent Elasticsearch environment.

The automatic configuration of `/etc/hosts` relies on the Vagrant plugin `vagrant-hostmanager`, and so this plugin is required in order to use this Vagrantfile.

Neither VirtualBox nor VMWare support hard links being created inside shared folders, and so `setup.py` had to be modified in order to prevent the creation of hard links during the run of `python setup.py sdist` performed by `tox`.

This PR depends on #179 to automate the initial index creation, and so it has been included in the history of this branch.

All tests pass for both Python 2.6 and 2.7 when running: `vagrant ssh elastalert -- "cd /vagrant; sudo tox"`