### PR TITLE
Add support for Elasticsearch URL prefix

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -7,7 +7,7 @@ rules_folder: example_rules
 run_every:
   minutes: 5
 
-# ElastAlert will buffer results from the most recent 
+# ElastAlert will buffer results from the most recent
 # period of time, in case some log sources are not in real time
 buffer_time:
   minutes: 45
@@ -18,6 +18,9 @@ es_host: elasticsearch.example.com
 
 # The elasticsearch port
 es_port: 14900
+
+# Optional URL prefix for elasticsearch
+#es_url_prefix: elasticsearch
 
 # Connect with SSL to elasticsearch
 #use_ssl: True

--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -107,6 +107,8 @@ even if ElastAlert is stopped and restarted, it will never miss data or look at 
 
 ``es_password``: Optional; basic-auth password for connecting to ``es_host``.
 
+``es_url_prefix``: Optional; URL prefix for the Elasticsearch endpoint.
+
 ``es_conn_timeout``: Optional; sets timeout for connecting to and reading from ``es_host``; defaults to ``10``.
 
 ``rules_folder``: The name of the folder which contains rule configuration files. ElastAlert will load all
@@ -179,7 +181,7 @@ or its subdirectories.
 ``--verbose`` will increase the logging verboseness, which allows you to see information about the state
 of queries.
 
-``--es_debug`` will enable logging for all queries made to Elasticsearch. 
+``--es_debug`` will enable logging for all queries made to Elasticsearch.
 
 ``--es_debug_trace`` will enable logging curl commands for all queries made to Elasticsearch.
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -13,30 +13,32 @@ Rule Configuration Cheat Sheet
 |              FOR ALL RULES                                                                                            |
 +==========================================+===========+====================================================+===========+
 | ``es_host`` (string)                     |           | ``buffer_time`` (time)                             | Optional  |
-+------------------------------------------+           +----------------------------------------------------+           +
++------------------------------------------+           +----------------------------------------------------+           |
 | ``es_port`` (number)                     | Required  | ``query_delay`` (time)                             |           |
-+------------------------------------------+-----------+----------------------------------------------------+           +
++------------------------------------------+-----------+----------------------------------------------------+           |
 | ``use_ssl`` (boolean, no default)        | Optional  | ``max_query_size`` (int, default 100k)             |           |
-+------------------------------------------+           +----------------------------------------------------+           +
++------------------------------------------+           +----------------------------------------------------+           |
 | ``es_username`` (string, no default)     |           | ``filter`` (DSL filter, empty default)             |           |
-+------------------------------------------+           +----------------------------------------------------+           +
++------------------------------------------+           +----------------------------------------------------+           |
 | ``es_password`` (string, no default)     |           | ``include`` (list of strs)                         |           |
-+------------------------------------------+-----------+----------------------------------------------------+           +
-| ``index`` (string)                       | Required  | ``top_count_keys`` (list of strs)                  |           |
-+------------------------------------------+-----------+----------------------------------------------------+           +
-| ``use_strftime_index`` (boolean)         | Optional  | ``top_count_number`` (int, default 5)              |           |
-+------------------------------------------+-----------+----------------------------------------------------+           +
-| ``name`` (string)                        | Required  |``raw_count_keys`` (boolean, default T)             |           |
-+------------------------------------------+           +----------------------------------------------------+           +
-| ``type`` (string)                        |           |``generate_kibana_link`` (boolean, default F)       |           |
-+------------------------------------------+           +----------------------------------------------------+           +
-| ``alert`` (string)                       |           |``kibana_dashboard`` (string, default from es_host) |           |
-+------------------------------------------+-----------+----------------------------------------------------+           +
-|``aggregation`` (time, no default)        | Optional  |``use_kibana_dashboard`` (string, no default)       |           |
-+------------------------------------------+           +----------------------------------------------------+           +
-| ``realert`` (time, default: 1 min)       |           |``use_local_time`` (boolean, default T)             |           |
-+------------------------------------------+           +----------------------------------------------------+           +
-|``exponential_realert`` (time, no default)|           |``match_enhancements`` (list of strs, no default)   |           |
++------------------------------------------+           +----------------------------------------------------+           |
+| ``es_url_prefix`` (string, empty default)|           | ``top_count_keys`` (list of strs)                  |           |
++------------------------------------------+-----------+----------------------------------------------------+           |
+| ``index`` (string)                       | Required  | ``top_count_number`` (int, default 5)              |           |
++------------------------------------------+-----------+----------------------------------------------------+           |
+| ``use_strftime_index`` (boolean)         | Optional  | ``raw_count_keys`` (boolean, default T)            |           |
++------------------------------------------+-----------+----------------------------------------------------+           |
+| ``name`` (string)                        | Required  | ``generate_kibana_link`` (boolean, default F)      |           |
++------------------------------------------+           +----------------------------------------------------+           |
+| ``type`` (string)                        |           | ``kibana_dashboard`` (string, default from es_host)|           |
++------------------------------------------+           +----------------------------------------------------+           |
+| ``alert`` (string)                       |           | ``use_kibana_dashboard`` (string, no default)      |           |
++------------------------------------------+-----------+----------------------------------------------------+           |
+|``aggregation`` (time, no default)        | Optional  | ``use_local_time`` (boolean, default T)            |           |
++------------------------------------------+           +----------------------------------------------------+           |
+| ``realert`` (time, default: 1 min)       |           | ``match_enhancements`` (list of strs, no default)  |           |
++------------------------------------------+           |                                                    |           |
+|``exponential_realert`` (time, no default)|           |                                                    |           |
 +------------------------------------------+-----------+----------------------------------------------------+-----------+
 
 +------------------------------------------------+-----+-----------+-----------+--------+-----------+-------+----------+--------+
@@ -62,7 +64,7 @@ Rule Configuration Cheat Sheet
 +------------------------------------------------+-----+-----------+-----------+--------+-----------+-------+----------+--------+
 |``use_terms_query`` (boolean, no default)       |     |           |           |        |     Opt   | Opt   |          | Opt    |
 |                                                |     |           |           |        |           |       |          |        |
-|``doc_type`` (string, no default)               |     |           |           |        |           |       |          |        | 
+|``doc_type`` (string, no default)               |     |           |           |        |           |       |          |        |
 |                                                |     |           |           |        |           |       |          |        |
 |``query_key`` (string, no default)              |     |           |           |        |           |       |          |        |
 |                                                |     |           |           |        |           |       |          |        |
@@ -105,6 +107,8 @@ Required Settings
 ``es_username``: Optional; basic-auth username for connecting to ``es_host``.
 
 ``es_password``: Optional; basic-auth password for connecting to ``es_host``.
+
+``es_url_prefix``: Optional; URL prefix for the Elasticsearch endpoint.
 
 ``index``: The name of the index that will be searched. Wildcards can be used here, such as:
 ``index: my-index-*`` which will match ``my-index-2014-10-05``. You can also use a format string containing
@@ -197,8 +201,8 @@ ElastAlert can use an existing dashboard. It will set the time range on the dash
 upload it as a temporary dashboard, add a filter to the ``query_key`` of the alert if applicable,
 and put the url to the dashboard in the alert. (Optional, string, no default)
 
-``use_kibana4_dashboard``: A link to a Kibana 4 dashboard. For example, "https://kibana.example.com/#/dashboard/My-Dashboard". 
-This will set the time setting on the dashboard from the match time minus the timeframe, to 10 minutes after the match time. 
+``use_kibana4_dashboard``: A link to a Kibana 4 dashboard. For example, "https://kibana.example.com/#/dashboard/My-Dashboard".
+This will set the time setting on the dashboard from the match time minus the timeframe, to 10 minutes after the match time.
 Note that this does not support filtering by ``query_key`` like Kibana 3.
 
 ``use_local_time``: Whether to convert timestamps to the local time zone in alerts. If false, timestamps will
@@ -245,7 +249,7 @@ It can:
 
 - Check that, if they exist, the primary_key, compare_key and include terms are in the results.
 
-- Show what metadata documents would be written to ``elastalert_status``. 
+- Show what metadata documents would be written to ``elastalert_status``.
 
 Without any optional arguments, it will run ElastAlert over the last 24 hours and print out any alerts that would have occurred.
 Here is an example test run which triggered an alert:
@@ -254,9 +258,9 @@ Here is an example test run which triggered an alert:
 
     $ elastalert-test-rule my_rules/rule1.yaml
     Successfully Loaded Example rule1
-    
+
     Got 105 hits from the last 1 day
-    
+
     Available terms in first hit:
         @timestamp
         field1
@@ -281,7 +285,7 @@ Here is an example test run which triggered an alert:
 
     Would have written the following documents to elastalert_status:
 
-    silence - {'rule_name': 'Example rule1', '@timestamp': datetime.datetime( ... ), 'exponent': 0, 'until': 
+    silence - {'rule_name': 'Example rule1', '@timestamp': datetime.datetime( ... ), 'exponent': 0, 'until':
     datetime.datetime( ... )}
 
     elastalert_status - {'hits': 105, 'matches': 1, '@timestamp': datetime.datetime( ... ), 'rule_name': 'Example rule1',
@@ -304,7 +308,7 @@ and ``--end``.
 ``--save-json FILE``: Save all documents downloaded to a file as JSON. This is useful if you wish to modify data while testing or do offline
 testing in conjunction with ``--data FILE``. A maximum of 10,000 documents will be downloaded.
 
-``--data FILE``: Use a JSON file as a data source instead of Elasticsearch. The file should be a single list containing objects, 
+``--data FILE``: Use a JSON file as a data source instead of Elasticsearch. The file should be a single list containing objects,
 rather than objects on separate lines. Note than this uses mock functions which mimic some Elasticsearch query methods and is not
 guarenteed to have the exact same results as with Elasticsearch. For example, analyzed string fields may behave differently.
 
@@ -409,7 +413,7 @@ default 50, unique terms.
 
 ``terms_size``: When used with ``use_terms_query``, this is the maximum number of terms returned per query. Default is 50.
 
-``query_key``: Counts of documents will be stored independently for each value of ``query_key``. Only ``num_events`` documents, 
+``query_key``: Counts of documents will be stored independently for each value of ``query_key``. Only ``num_events`` documents,
 all with the same value of ``query_key``, will trigger an alert.
 
 
@@ -573,7 +577,7 @@ use an aggregation query to gather all known terms for a list of fields.
 
 This rule requires one additional option:
 
-``fields``: A list of fields to monitor for new terms. 
+``fields``: A list of fields to monitor for new terms.
 
 Optional:
 
@@ -624,9 +628,9 @@ The field names whose values will be used as the arguments can be passed with ``
 
 It is mandatory to enclose the ``@timestamp`` field in quotes since in YAML format a token cannot begin with the ``@`` character. Not using the quotation marks will trigger a YAML parse error.
 
-In case the rule matches multiple objects in the index, only the first match is used to populate the arguments for the formatter. 
+In case the rule matches multiple objects in the index, only the first match is used to populate the arguments for the formatter.
 
-If the field(s) mentioned in the arguments list are missing, the email alert will have the text ``<MISSING VALUE>`` in place of its expected value. 
+If the field(s) mentioned in the arguments list are missing, the email alert will have the text ``<MISSING VALUE>`` in place of its expected value.
 
 Alert Content
 ~~~~~~~~~~~~~~~
@@ -682,7 +686,7 @@ Command
 ~~~~~~~
 
 The command alert allows you to execute an arbitrary command and pass arguments or stdin from the match. Arguments to the command can use
-Python format string syntax to access parts of the match. The alerter will open a subprocess and optionally pass the match, as JSON, to 
+Python format string syntax to access parts of the match. The alerter will open a subprocess and optionally pass the match, as JSON, to
 the stdin of the process.
 
 This alert requires one option:
@@ -704,7 +708,7 @@ Example usage::
 
 .. warning::
 
-    Executing commmands with untrusted data can make it vulnerable to shell injection! If you use formatted data in 
+    Executing commmands with untrusted data can make it vulnerable to shell injection! If you use formatted data in
     your command, it is highly recommended that you use a args list format instead of a shell string.
 
 
@@ -776,8 +780,8 @@ the two summaries must be exact matches. Defaults to false.
 ``jira_max_age``: If ``jira_bump_tickets`` is true, the maximum age of a ticket, in days, such that ElastAlert will comment on the ticket
 instead of opening a new one. Default is 30 days.
 
-``jira_bump_not_in_statuses``: If ``jira_bump_tickets`` is true, a list of statuses the ticket must **not** be in for ElastAlert to comment on 
-the ticket instead of opening a new one. For example, to prevent comments being added to resolved or closed tickets, set this to 'Resolved' 
+``jira_bump_not_in_statuses``: If ``jira_bump_tickets`` is true, a list of statuses the ticket must **not** be in for ElastAlert to comment on
+the ticket instead of opening a new one. For example, to prevent comments being added to resolved or closed tickets, set this to 'Resolved'
 and 'Closed'. This option should not be set if the ``jira_bump_in_statuses`` option is set.
 
 Example usage::
@@ -786,8 +790,8 @@ Example usage::
       - Resolved
       - Closed
 
-``jira_bump_in_statuses``: If ``jira_bump_tickets`` is true, a list of statuses the ticket *must be in* for ElastAlert to comment on 
-the ticket instead of opening a new one. For example, to only comment on 'Open' tickets  -- and thus not 'In Progress', 'Analyzing', 
+``jira_bump_in_statuses``: If ``jira_bump_tickets`` is true, a list of statuses the ticket *must be in* for ElastAlert to comment on
+the ticket instead of opening a new one. For example, to only comment on 'Open' tickets  -- and thus not 'In Progress', 'Analyzing',
 'Resolved', etc. tickets -- set this to 'Open'. This option should not be set if the ``jira_bump_not_in_statuses`` option is set.
 
 Example usage::

--- a/docs/source/running_elastalert.rst
+++ b/docs/source/running_elastalert.rst
@@ -40,6 +40,8 @@ Next, open up config.yaml.example. In it, you will find several configuration op
 
 ``es_password``: Optional; basic-auth password for connecting to ``es_host``.
 
+``es_url_prefix``: Optional; URL prefix for the Elasticsearch endpoint.
+
 ``writeback_index`` is the name of the index in which ElastAlert will store data. We will create this index later.
 
 ``alert_time_limit`` is the retry window for failed alerts.

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -15,6 +15,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--host', help='Elasticsearch host')
     parser.add_argument('--port', type=int, help='Elasticsearch port')
+    parser.add_argument('--url-prefix', help='Elasticsearch URL prefix')
     parser.add_argument('--no-auth', action='store_const', const=True, help='Suppress prompt for basic auth')
     parser.add_argument('--ssl', action='store_const', const=True, help='Use SSL')
     parser.add_argument('--no-ssl', action='store_const', const=True, help='Do not use SSL')
@@ -32,6 +33,7 @@ def main():
     username = None
     password = None
     use_ssl = None
+    url_prefix = None
     http_auth = None
 
     if filename:
@@ -41,6 +43,7 @@ def main():
         port = data.get('es_port')
         username = data.get('es_username')
         password = data.get('es_password')
+        url_prefix = data.get('es_url_prefix', '')
         use_ssl = data.get('use_ssl')
     else:
         host = args.host if args.host else raw_input('Enter elasticsearch host: ')
@@ -51,11 +54,13 @@ def main():
         if args.no_auth is None:
             username = raw_input('Enter optional basic-auth username: ')
             password = getpass.getpass('Enter optional basic-auth password: ')
+        url_prefix = (args.url_prefix if args.url_prefix is not None
+                      else raw_input('Enter optional Elasticsearch URL prefix: '))
 
     if username and password:
         http_auth = username + ':' + password
 
-    es = Elasticsearch(host=host, port=port, use_ssl=use_ssl, http_auth=http_auth)
+    es = Elasticsearch(host=host, port=port, use_ssl=use_ssl, http_auth=http_auth, url_prefix=url_prefix)
 
     silence_mapping = {'silence': {'properties': {'rule_name': {'index': 'not_analyzed', 'type': 'string'},
                                                   'until': {'type': 'date', 'format': 'dateOptionalTime'}}}}

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -113,6 +113,7 @@ class ElastAlerter():
         """ returns an Elasticsearch instance configured using an es_conn_config """
         return Elasticsearch(host=es_conn_conf['es_host'],
                              port=es_conn_conf['es_port'],
+                             url_prefix=es_conn_conf['es_url_prefix'],
                              use_ssl=es_conn_conf['use_ssl'],
                              http_auth=es_conn_conf['http_auth'],
                              timeout=es_conn_conf['es_conn_timeout'])
@@ -130,6 +131,7 @@ class ElastAlerter():
         parsed_conf['es_password'] = None
         parsed_conf['es_host'] = conf['es_host']
         parsed_conf['es_port'] = conf['es_port']
+        parsed_conf['es_url_prefix'] = ''
         parsed_conf['es_conn_timeout'] = 10
 
         if 'es_username' in conf:
@@ -144,6 +146,9 @@ class ElastAlerter():
 
         if 'es_conn_timeout' in conf:
             parsed_conf['es_conn_timeout'] = conf['es_conn_timeout']
+
+        if 'es_url_prefix' in conf:
+            parsed_conf['es_url_prefix'] = conf['es_url_prefix']
 
         return parsed_conf
 


### PR DESCRIPTION
Added support for providing a URL prefix to Elasticsearch for instances where Elasticsearch is behind a reverse proxy (by supplying the `url_prefix` parameter to [`elasticsearch.connection.Connection`](https://elasticsearch-py.readthedocs.org/en/master/transports.html#connection)).

All current tests pass in Python 2.6 and 2.7.