### PR TITLE
elastalert-test-rule should respect ES config

### DIFF
--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -19,7 +19,6 @@ import yaml
 from elastalert.config import load_modules
 from elastalert.config import load_options
 from elastalert.elastalert import ElastAlerter
-from elastalert.elastalert import Elasticsearch
 from elastalert.util import lookup_es_key
 from elastalert.util import ts_now
 from elastalert.util import ts_to_dt
@@ -51,7 +50,8 @@ class MockElastAlerter(object):
             return []
 
         # Set up elasticsearch client and query
-        es_client = Elasticsearch(host=conf['es_host'], port=conf['es_port'])
+        es_config = ElastAlerter.build_es_conn_config(conf)
+        es_client = ElastAlerter.new_elasticsearch(es_config)
         start_time = ts_now() - datetime.timedelta(days=args.days)
         end_time = ts_now()
         ts = conf.get('timestamp_field', '@timestamp')


### PR DESCRIPTION
Use ElastAlert's configuration builder to respect the ES options specified in the individual rule file, and use ElastAlert's factory to construct the client used to connect to ES.