### PR TITLE
Allow alert text, subject and spike query key to be nested fields

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -15,6 +15,7 @@ from jira.client import JIRA
 from jira.exceptions import JIRAError
 from staticconf.loader import yaml_loader
 from util import EAException
+from util import lookup_es_key
 from util import pretty_ts
 
 
@@ -34,7 +35,8 @@ class BasicMatchString(object):
         alert_text = self.rule.get('alert_text', '')
         if 'alert_text_args' in self.rule:
             alert_text_args = self.rule.get('alert_text_args')
-            alert_text_values = [self.match.get(arg, '<MISSING VALUE>') for arg in alert_text_args]
+            alert_text_values = [lookup_es_key(self.match, arg) for arg in alert_text_args]
+            alert_text_values = ['<MISSING VALUE>' if val is None else val for val in alert_text_values]
             alert_text = alert_text.format(*alert_text_values)
         self.text += alert_text
 
@@ -130,7 +132,8 @@ class Alerter(object):
 
         if 'alert_subject_args' in self.rule:
             alert_subject_args = self.rule['alert_subject_args']
-            alert_subject_values = [matches[0].get(arg, '<MISSING VALUE>') for arg in alert_subject_args]
+            alert_subject_values = [lookup_es_key(matches[0], arg) for arg in alert_subject_args]
+            alert_subject_values = ['<MISSING VALUE>' if val is None else val for val in alert_subject_values]
             return alert_subject.format(*alert_subject_values)
 
         return alert_subject

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -342,7 +342,7 @@ class SpikeRule(RuleType):
         for event in data:
             qk = self.rules.get('query_key', 'all')
             if qk != 'all':
-                qk = event.get(qk, 'other')
+                qk = hashable(lookup_es_key(event, qk))
                 if qk is None:
                     qk = 'other'
             self.handle_event(event, 1, qk)

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -200,13 +200,13 @@ def test_email_with_cc_and_bcc():
 def test_email_with_args():
     rule = {'name': 'test alert', 'email': ['testing@test.test', 'test@test.test'], 'from_addr': 'testfrom@test.test',
             'type': mock_rule(), 'timestamp_field': '@timestamp', 'email_reply_to': 'test@example.com',
-            'alert_subject': 'Test alert for {0}', 'alert_subject_args': ['test_term'], 'alert_text': 'Test alert for {0} and {1}',
-            'alert_text_args': ['test_arg1', 'test_arg2']}
+            'alert_subject': 'Test alert for {0} {1}', 'alert_subject_args': ['test_term', 'test.term'], 'alert_text': 'Test alert for {0} and {1} {2}',
+            'alert_text_args': ['test_arg1', 'test_arg2', 'test.arg3']}
     with mock.patch('elastalert.alerts.SMTP') as mock_smtp:
         mock_smtp.return_value = mock.Mock()
 
         alert = EmailAlerter(rule)
-        alert.alert([{'test_term': 'test_value', 'test_arg1': 'testing'}])
+        alert.alert([{'test_term': 'test_value', 'test_arg1': 'testing', 'test': {'term': ':)', 'arg3': ':('}}])
         expected = [mock.call('localhost'),
                     mock.call().ehlo(),
                     mock.call().has_extn('STARTTLS'),
@@ -219,11 +219,12 @@ def test_email_with_args():
 
         assert 'testing' in body
         assert '<MISSING VALUE>' in body
+        assert ':(' in body
 
         assert 'Reply-To: test@example.com' in body
         assert 'To: testing@test.test' in body
         assert 'From: testfrom@test.test' in body
-        assert 'Subject: Test alert for test_value' in body
+        assert 'Subject: Test alert for test_value :)' in body
 
 
 def test_email_query_key_in_subject():

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -202,6 +202,18 @@ def test_spike_count():
     assert len(rule.matches) == 1
 
 
+def test_spike_deep_key():
+    rules = {'threshold_ref': 10,
+             'spike_height': 2,
+             'timeframe': datetime.timedelta(seconds=10),
+             'spike_type': 'both',
+             'timestamp_field': '@timestamp',
+             'query_key': 'foo.bar.baz'}
+    rule = SpikeRule(rules)
+    rule.add_data([{'@timestamp': ts_to_dt('2015'), 'foo': {'bar': {'baz': 'LOL'}}}])
+    assert 'LOL' in rule.cur_windows
+
+
 def test_spike():
     # Events are 1 per second
     events = hits(100, timestamp_field='ts')


### PR DESCRIPTION
Use lookup_es_key instead of document.get