### PR TITLE
Fixed bug where changed rule woudlnt load if it failed to load previo…

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -613,6 +613,10 @@ class ElastAlerter():
                 # Initialize the rule that matches rule_file
                 self.rules = [rule if rule['rule_file'] != rule_file else self.init_rule(new_rule, False) for rule in self.rules]
 
+                # If the rule failed to load previously, it needs to be added to self.rules
+                if new_rule['name'] not in [rule['name'] for rule in self.rules]:
+                    self.rules.append(self.init_rule(new_rule))
+
         # Load new rules
         if not self.args.rule:
             for rule_file in set(rule_hashes.keys()) - set(self.rule_hashes.keys()):

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -635,7 +635,8 @@ def test_rule_changes(ea):
 
     with mock.patch('elastalert.elastalert.get_rule_hashes') as mock_hashes:
         with mock.patch('elastalert.elastalert.load_configuration') as mock_load:
-            mock_load.side_effect = [{'filter': [], 'name': 'rule2'}, {'filter': [], 'name': 'rule3'}]
+            mock_load.side_effect = [{'filter': [], 'name': 'rule2', 'rule_file': 'rules/rule2.yaml'},
+                                     {'filter': [], 'name': 'rule3', 'rule_file': 'rules/rule3.yaml'}]
             mock_hashes.return_value = new_hashes
             ea.load_rule_changes()
 
@@ -652,14 +653,24 @@ def test_rule_changes(ea):
 
     # A new rule with a conflicting name wont load
     new_hashes = copy.copy(new_hashes)
-    new_hashes.update({'rule4.yaml': 'asdf'})
+    new_hashes.update({'rules/rule4.yaml': 'asdf'})
     with mock.patch('elastalert.elastalert.get_rule_hashes') as mock_hashes:
         with mock.patch('elastalert.elastalert.load_configuration') as mock_load:
-            mock_load.return_value = {'filter': [], 'name': 'rule3', 'new': 'stuff'}
+            mock_load.return_value = {'filter': [], 'name': 'rule3', 'new': 'stuff', 'rule_file': 'rules/rule4.yaml'}
             mock_hashes.return_value = new_hashes
             ea.load_rule_changes()
     assert len(ea.rules) == 3
     assert not any(['new' in rule for rule in ea.rules])
+
+    # An old rule which didn't load gets reloaded
+    new_hashes = copy.copy(new_hashes)
+    new_hashes['rules/rule4.yaml'] = 'qwerty'
+    with mock.patch('elastalert.elastalert.get_rule_hashes') as mock_hashes:
+        with mock.patch('elastalert.elastalert.load_configuration') as mock_load:
+            mock_load.return_value = {'filter': [], 'name': 'rule4', 'new': 'stuff', 'rule_file': 'rules/rule4.yaml'}
+            mock_hashes.return_value = new_hashes
+            ea.load_rule_changes()
+    assert len(ea.rules) == 4
 
 
 def test_strf_index(ea):


### PR DESCRIPTION
Fixes a bug where if a rule gets added, and its initialization throws an exception, it is in self.rule_hashes but not self.rules. So if it changes, it will be "reloaded" but then it doesn't exist in self.rules so it doesn't get added (It normally replaces the old version with the new).

This also adds a test for this case and fixes the mock rules which were incomplete but weren't causing errors until I hit the bugged code.