### PR TITLE
Set current_es for pending alerts

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -986,6 +986,11 @@ class ElastAlerter():
                 # Original rule is missing, drop alert
                 continue
 
+            # Set current_es for top_count_keys query
+            rule_es_conn_config = self.build_es_conn_config(rule)
+            self.current_es = self.new_elasticsearch(rule_es_conn_config)
+            self.current_es_addr = (rule['es_host'], rule['es_port'])
+
             # Retry the alert unless it's a future alert
             if ts_now() > ts_to_dt(alert_time):
                 aggregated_matches = self.get_aggregated_matches(_id)

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -267,7 +267,12 @@ def test_agg(ea):
                                                              {'_id': 'CDEF', '_source': call3}]}},
                                           {'hits': {'hits': [{'_id': 'BCDE', '_source': call2}]}},
                                           {'hits': {'hits': []}}]
-    ea.send_pending_alerts()
+
+    with mock.patch('elastalert.elastalert.Elasticsearch') as mock_es:
+        ea.send_pending_alerts()
+        # Assert that current_es was refreshed from the aggregate rules
+        assert mock_es.called_with(host='', port='')
+        assert mock_es.call_count == 2
     assert_alerts(ea, [hits_timestamps[:2], hits_timestamps[2:]])
 
     call1 = ea.writeback_es.search.call_args_list[6][1]['body']


### PR DESCRIPTION
send_pending_alerts is called before run_rule. What this means is that if ElastAlert starts and an aggregation alert is ready to be sent, and it contains top_count_keys, an exception will occur when it tries to search via self.current_es. This sets current_es as it does in run_rule.