### PR TITLE
Added newline to cmd json pipe

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -434,7 +434,7 @@ class CommandAlerter(Alerter):
             subp = subprocess.Popen(command, stdin=subprocess.PIPE)
 
             if self.rule.get('pipe_match_json'):
-                match_json = json.dumps(matches)
+                match_json = json.dumps(matches) + '\n'
                 stdout, stderr = subp.communicate(input=match_json)
         except OSError as e:
             raise EAException("Error while running command %s: %s" % (' '.join(command), e))


### PR DESCRIPTION
Fixes #225 

Without the newline, some commands would fail to read the json. An example of this is in the issue.