### PR TITLE
Added minimum_starttime to new rule copied fields

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -576,9 +576,10 @@ class ElastAlerter():
         copy_properties = ['agg_matches',
                            'current_aggregate_id',
                            'processed_hits',
-                           'starttime']
+                           'starttime',
+                           'minimum_starttime']
         for prop in copy_properties:
-            if prop == 'starttime' and 'starttime' not in rule:
+            if prop not in rule:
                 continue
             new_rule[prop] = rule[prop]
 

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -61,14 +61,15 @@ def test_starttime(ea):
 
 def test_init_rule(ea):
     # Simulate state of a rule just loaded from a file
+    ea.rules[0]['minimum_starttime'] = datetime.datetime.now()
     new_rule = copy.copy(ea.rules[0])
-    map(new_rule.pop, ['agg_matches', 'current_aggregate_id', 'processed_hits'])
+    map(new_rule.pop, ['agg_matches', 'current_aggregate_id', 'processed_hits', 'minimum_starttime'])
 
     # Properties are copied from ea.rules[0]
     ea.rules[0]['starttime'] = '2014-01-02T00:11:22'
     ea.rules[0]['processed_hits'] = ['abcdefg']
     new_rule = ea.init_rule(new_rule, False)
-    for prop in ['starttime', 'agg_matches', 'current_aggregate_id', 'processed_hits']:
+    for prop in ['starttime', 'agg_matches', 'current_aggregate_id', 'processed_hits', 'minimum_starttime']:
         assert new_rule[prop] == ea.rules[0][prop]
 
     # Properties are fresh


### PR DESCRIPTION
Fixes #229 

Also adds a check to prevent keyerrors if the copy fields aren't present. The 3 others beside minimum_starttime and starttime should always be present anyway.