### PR TITLE
OpsGenie Alerter 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Currently, we have support built in for three alert types:
 
 - Email
 - JIRA
+- OpsGenie
 - Commands
 
 Additional rule types and alerts can be easily imported or written.

--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -29,10 +29,11 @@ Several rule types with common monitoring paradigms are included with ElastAlert
 - "Match on any event matching a given filter" (``any`` type)
 - "Match when a field has two different values within some time" (``change`` type)
 
-Currently, we have support built in for two alert types:
+Currently, we have support built in for three alert types:
 
 - Email
 - JIRA
+- OpsGenie
 
 Additional rule types and alerts can be easily imported or written. (See :ref:`Writing rule types <writingrules>` and :ref:`Writing alerts <writingalerts>`)
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1015,8 +1015,6 @@ The OpsGenie alert requires four options:
 
 ``opsgenie_recipients``: An optional filled list OpsGenie recipients who will be notified by the alerts
 
-``opsgenie_addr``: Potentially unnecessary variable to configure the URL to POST alert requests to. It hasn't changed yet, but if it does not having it hardcoded seems advantageous.
-
 Debug
 ~~~~~~
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -789,17 +789,19 @@ Example usage::
 OpsGenie
 ~~~~~~~~
 
-OpsGenie alerter will create an alert which can be used to notify Operations people of issues or log information. An OpsGenie ``API`` integration must be created in order to acquire the necessary ``opsgenie_key`` rule variable. Currently the OpsGenieAlerter only creates an alert, however it could be extended to update or close existing alerts.
+OpsGenie alerter will create an alert which can be used to notify Operations people of issues or log information. An OpsGenie ``API``
+integration must be created in order to acquire the necessary ``opsgenie_key`` rule variable. Currently the OpsGenieAlerter only creates 
+an alert, however it could be extended to update or close existing alerts.
 
-The alert requires four options:
+The OpsGenie alert requires four options:
 
-``opsgenie_key``: The randomly generated API Integration key create by OpsGenie.
+``opsgenie_key``: The randomly generated API Integration key created by OpsGenie.
 
 ``opsgenie_account``: The OpsGenie account to integrate with.
 
 ``opsgenie_recipients``: An optional filled list OpsGenie recipients who will be notified by the alerts
 
-``opsgenie_addr``: Potentially unnecessary variable to configure the URL to POST alert requests to. It hasn't changed yet, but if it does not having it hardcoded seems adventageous.
+``opsgenie_addr``: Potentially unnecessary variable to configure the URL to POST alert requests to. It hasn't changed yet, but if it does not having it hardcoded seems advantageous.
 
 Debug
 ~~~~~~

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1007,7 +1007,7 @@ OpsGenie alerter will create an alert which can be used to notify Operations peo
 integration must be created in order to acquire the necessary ``opsgenie_key`` rule variable. Currently the OpsGenieAlerter only creates 
 an alert, however it could be extended to update or close existing alerts.
 
-It is necessary for the user to create an OpsGenie Rest HTTPS API `integration page <https://app.opsgenie.com/integration> _` in order to create alerts.  
+It is necessary for the user to create an OpsGenie Rest HTTPS API `integration page <https://app.opsgenie.com/integration>`_ in order to create alerts.  
 
 The OpsGenie alert requires three options:
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -786,6 +786,21 @@ Example usage::
     jira_bump_in_statuses:
       - Open
 
+OpsGenie
+~~~~~~~~
+
+OpsGenie alerter will create an alert which can be used to notify Operations people of issues or log information. An OpsGenie ``API`` integration must be created in order to acquire the necessary ``opsgenie_key`` rule variable. Currently the OpsGenieAlerter only creates an alert, however it could be extended to update or close existing alerts.
+
+The alert requires four options:
+
+``opsgenie_key``: The randomly generated API Integration key create by OpsGenie.
+
+``opsgenie_account``: The OpsGenie account to integrate with.
+
+``opsgenie_recipients``: An optional filled list OpsGenie recipients who will be notified by the alerts
+
+``opsgenie_addr``: Potentially unnecessary variable to configure the URL to POST alert requests to. It hasn't changed yet, but if it does not having it hardcoded seems adventageous.
+
 Debug
 ~~~~~~
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1007,13 +1007,15 @@ OpsGenie alerter will create an alert which can be used to notify Operations peo
 integration must be created in order to acquire the necessary ``opsgenie_key`` rule variable. Currently the OpsGenieAlerter only creates 
 an alert, however it could be extended to update or close existing alerts.
 
-The OpsGenie alert requires four options:
+It is necessary for the user to create an OpsGenie Rest HTTPS API `integration page <https://app.opsgenie.com/integration> _` in order to create alerts.  
+
+The OpsGenie alert requires three options:
 
 ``opsgenie_key``: The randomly generated API Integration key created by OpsGenie.
 
 ``opsgenie_account``: The OpsGenie account to integrate with.
 
-``opsgenie_recipients``: An optional filled list OpsGenie recipients who will be notified by the alerts
+``opsgenie_recipients``: A list OpsGenie recipients who will be notified by the alert.
 
 Debug
 ~~~~~~

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -2,7 +2,6 @@
 import datetime
 import json
 import logging
-import requests
 import subprocess
 from email.mime.text import MIMEText
 from smtplib import SMTP
@@ -244,65 +243,6 @@ class EmailAlerter(Alerter):
     def get_info(self):
         return {'type': 'email',
                 'recipients': self.rule['email']}
-
-
-class OpsGenieAlerter(Alerter):
-    '''Sends a http request to the OpsGenie API to signal for an alert'''
-    required_options = frozenset(['opsgenie_key', 'opsgenie_account', 'opsgenie_recipients'])
-
-    def __init__(self, *args):
-        super(OpsGenieAlerter, self).__init__(*args)
-
-        self.account = self.rule.get('opsgenie_account', 'genie')
-        self.api_key = self.rule.get('opsgenie_key', 'key')
-        self.recipients = self.rule.get('opsgenie_recipients', ['genies'])
-        self.to_addr = self.rule.get('opsgenie_addr', 'example.opsgenie.net')
-
-    def alert(self, matches):
-        body = ''
-        logging.warning(str(matches))
-        for match in matches:
-            body += str(BasicMatchString(self.rule, match))
-            # Separate text of aggregated alerts with dashes
-            if len(matches) > 1:
-                body += '\n----------------------------------------\n'
-
-        post = {}
-        post['apiKey'] = self.api_key
-        post['message'] = self.create_default_title(matches)
-        post['recipients'] = self.recipients
-        post['description'] = body
-        post['source'] = 'ElastAlert'
-        post['tags'] = ['ElastAlert', self.rule['name']]
-        logging.debug(json.dumps(post))
-
-        try:
-            r = requests.post(self.to_addr, json=post)
-
-            logging.warning(dir(r))
-            logging.debug('request response: {}'.format(r))
-            if r.status_code != 200:
-                logging.error("Error sending alert request to OpsGenie! {}".format(r.json()))
-                r.raise_for_status()
-            logging.info("Alert sent to OpsGenie")
-        except Exception as err:
-            logging.error("Error sending alert to OpsGenie: {}".format(err))
-            return
-
-    def create_default_title(self, matches):
-        subject = 'ElastAlert: %s' % (self.rule['name'])
-
-        # If the rule has a query_key, add that value plus timestamp to subject
-        if 'query_key' in self.rule:
-            qk = matches[0].get(self.rule['query_key'])
-            if qk:
-                subject += ' - %s' % (qk)
-
-        return subject
-
-    def get_info(self):
-        return {'type': 'opsgenie',
-                'recipients': self.recipients}
 
 
 class JiraAlerter(Alerter):

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -245,6 +245,7 @@ class EmailAlerter(Alerter):
         return {'type': 'email',
                 'recipients': self.rule['email']}
 
+
 class OpsGenieAlerter(Alerter):
     '''Sends a http request to the OpsGenie API to signal for an alert'''
     required_options = frozenset(['opsgenie_key', 'opsgenie_account', 'opsgenie_recipients'])
@@ -257,7 +258,6 @@ class OpsGenieAlerter(Alerter):
         self.recipients = self.rule.get('opsgenie_recipients', ['genies'])
         self.to_addr = self.rule.get('opsgenie_addr', 'example.opsgenie.net')
 
-
     def alert(self, matches):
         body = ''
         logging.warning(str(matches))
@@ -266,15 +266,15 @@ class OpsGenieAlerter(Alerter):
             # Separate text of aggregated alerts with dashes
             if len(matches) > 1:
                 body += '\n----------------------------------------\n'
-        
+
         post = {}
-        post['apiKey']      = self.api_key
-        post['message']     = self.create_default_title(matches) 
-        post['recipients']  = self.recipients
+        post['apiKey'] = self.api_key
+        post['message'] = self.create_default_title(matches)
+        post['recipients'] = self.recipients
         post['description'] = body
-        post['source']      = 'ElastAlert'
-        post['tags']        = ['ElastAlert', self.rule['name']]
-        #logging.debug(json.dumps(post))
+        post['source'] = 'ElastAlert'
+        post['tags'] = ['ElastAlert', self.rule['name']]
+        logging.debug(json.dumps(post))
 
         try:
             r = requests.post(self.to_addr, json=post)
@@ -288,7 +288,6 @@ class OpsGenieAlerter(Alerter):
         except Exception as err:
             logging.error("Error sending alert to OpsGenie: {}".format(err))
             return
-        
 
     def create_default_title(self, matches):
         subject = 'ElastAlert: %s' % (self.rule['name'])
@@ -304,6 +303,7 @@ class OpsGenieAlerter(Alerter):
     def get_info(self):
         return {'type': 'opsgenie',
                 'recipients': self.recipients}
+
 
 class JiraAlerter(Alerter):
     """ Creates a Jira ticket for each alert """

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -2,6 +2,7 @@
 import datetime
 import json
 import logging
+import requests
 import subprocess
 from email.mime.text import MIMEText
 from smtplib import SMTP
@@ -244,6 +245,63 @@ class EmailAlerter(Alerter):
         return {'type': 'email',
                 'recipients': self.rule['email']}
 
+class OpsGenieAlerter(Alerter):
+    '''Sends a http request to the OpsGenie API to signal for an alert'''
+    required_options = frozenset(['opsgenie_key', 'opsgenie_account', 'opsgenie_recipients'])
+
+    def __init__(self, *args):
+        super(OpsGenieAlerter, self).__init__(*args)
+
+        self.account = self.rule.get('opsgenie_account', 'genie')
+        self.api_key = self.rule.get('opsgenie_key', 'key')
+        self.recipients = self.rule.get('opsgenie_recipients', ['genies'])
+        self.to_addr = self.rule.get('opsgenie_addr', 'example.opsgenie.net')
+
+
+    def alert(self, matches):
+        body = ''
+        for match in matches:
+            body += str(BasicMatchString(self.rule, match))
+            # Separate text of aggregated alerts with dashes
+            if len(matches) > 1:
+                body += '\n----------------------------------------\n'
+        
+        post = {}
+        post['apiKey']      = self.api_key
+        post['notes']       = "ElastAlert message"
+        post['note']        = body
+        post['message']     = body
+        post['teams']       = self.recipients 
+        post['recipients']  = self.recipients
+        post['description'] = 'ElastAlert to OpsGenie'
+        post['source']      = 'ElastAlert'
+        post['tags']        = ['ElastAlert, logs']
+        logging.warning(json.dumps(post))
+        logging.warning('Addr: {}'.format(self.to_addr))
+
+        try:
+            r = requests.post(self.to_addr, json=post)
+            logging.debug('request response: {}'.format(r))
+            if r.status_code != 200:
+                logging.error("Error sending alert request to OpsGenie! {}".format(r.json()))
+                r.raise_for_status()
+        except Exception as err:
+            logging.error("Error sending alert to OpsGenie: {}".format(err))
+
+    def create_default_title(self, matches):
+        subject = 'ElastAlert: %s' % (self.rule['name'])
+
+        # If the rule has a query_key, add that value plus timestamp to subject
+        if 'query_key' in self.rule:
+            qk = matches[0].get(self.rule['query_key'])
+            if qk:
+                subject += ' - %s' % (qk)
+
+        return subject
+
+    def get_info(self):
+        return {'type': 'opsgenie',
+                'recipients': self.rule['opsgenie_addr']}
 
 class JiraAlerter(Alerter):
     """ Creates a Jira ticket for each alert """

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -37,6 +37,7 @@ rules_mapping = {
 alerts_mapping = {
     'email': alerts.EmailAlerter,
     'jira': alerts.JiraAlerter,
+    'opsgenie': alerts.OpsGenieAlerter,
     'debug': alerts.DebugAlerter,
     'command': alerts.CommandAlerter
 }
@@ -47,6 +48,7 @@ def get_module(module_name):
     module_name should 'module.file.object'.
     Returns object or raises EAException on error. """
     try:
+        print("ModulePath: {}".format(module_path))
         module_path, module_class = module_name.rsplit('.', 1)
         base_module = __import__(module_path, globals(), locals(), [module_class])
         module = getattr(base_module, module_class)

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -13,6 +13,7 @@ import yaml.scanner
 from staticconf.loader import yaml_loader
 from util import EAException
 
+from modules.opsgenie import OpsGenieAlerter
 
 # schema for rule yaml
 rule_schema = jsonschema.Draft4Validator(yaml.load(open(os.path.join(os.path.dirname(__file__), 'schema.yaml'))))
@@ -37,7 +38,7 @@ rules_mapping = {
 alerts_mapping = {
     'email': alerts.EmailAlerter,
     'jira': alerts.JiraAlerter,
-    'opsgenie': alerts.OpsGenieAlerter,
+    'opsgenie': OpsGenieAlerter,
     'debug': alerts.DebugAlerter,
     'command': alerts.CommandAlerter
 }

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -48,7 +48,6 @@ def get_module(module_name):
     module_name should 'module.file.object'.
     Returns object or raises EAException on error. """
     try:
-        print("ModulePath: {}".format(module_path))
         module_path, module_class = module_name.rsplit('.', 1)
         base_module = __import__(module_path, globals(), locals(), [module_class])
         module = getattr(base_module, module_class)

--- a/example_rules/example_opsgenie_frequency.yaml
+++ b/example_rules/example_opsgenie_frequency.yaml
@@ -8,11 +8,12 @@ es_host: localhost
 # Elasticsearch port
 es_port: 9200
 
+# (Required)
+# OpsGenie credentials and recipient targeting configuration
 opsgenie_key: ogkey
 opsgenie_account: neh
 opsgenie_recipients: 
   - "neh"
-
 
 # (OptionaL) Connect with SSL to elasticsearch
 #use_ssl: True

--- a/example_rules/example_opsgenie_frequency.yaml
+++ b/example_rules/example_opsgenie_frequency.yaml
@@ -10,7 +10,6 @@ es_port: 9200
 
 opsgenie_key: ogkey
 opsgenie_account: neh
-opsgenie_addr: https://api.opsgenie.com/v1/json/alert
 opsgenie_recipients: 
   - "neh"
 
@@ -59,9 +58,3 @@ filter:
 # The alert is use when a match is found
 alert:
 - "opsgenie"
-
-# (required, email specific)
-# a list of email addresses to send alerts to
-email:
-- "monit-alerts@lytics.opsgenie.net"
-

--- a/example_rules/example_opsgenie_frequency.yaml
+++ b/example_rules/example_opsgenie_frequency.yaml
@@ -1,0 +1,67 @@
+# Alert when the rate of events exceeds a threshold
+
+# (Optional)
+# Elasticsearch host
+es_host: localhost
+
+# (Optional)
+# Elasticsearch port
+es_port: 9200
+
+opsgenie_key: ogkey
+opsgenie_account: neh
+opsgenie_addr: https://api.opsgenie.com/v1/json/alert
+opsgenie_recipients: 
+  - "neh"
+
+
+# (OptionaL) Connect with SSL to elasticsearch
+#use_ssl: True
+
+# (Optional) basic-auth username and password for elasticsearch
+#es_username: someusername
+#es_password: somepassword
+
+# (Required)
+# Rule name, must be unique
+name: opsgenie_rule
+
+# (Required)
+# Type of alert.
+# the frequency rule type alerts when num_events events occur with timeframe time
+type: frequency
+
+# (Required)
+# Index to search, wildcard supported
+index: logstash-*
+
+#doc_type: "golog"
+
+# (Required, frequency specific)
+# Alert when this many documents matching the query occur within a timeframe
+num_events: 50
+
+# (Required, frequency specific)
+# num_events must occur within this amount of time to trigger an alert
+timeframe:
+  hours: 2
+
+# (Required)
+# A list of elasticsearch filters used for find events
+# These filters are joined with AND and nested in a filtered query
+# For more info: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html
+filter:
+- query:
+    query_string:
+      query: "@message: *hihi*"
+
+# (Required)
+# The alert is use when a match is found
+alert:
+- "opsgenie"
+
+# (required, email specific)
+# a list of email addresses to send alerts to
+email:
+- "monit-alerts@lytics.opsgenie.net"
+

--- a/modules/opsgenie.py
+++ b/modules/opsgenie.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+import json
+import logging
+import requests
+
+from elastalert.alerts import Alerter
+from elastalert.alerts import BasicMatchString
+
+
+class OpsGenieAlerter(Alerter):
+    '''Sends a http request to the OpsGenie API to signal for an alert'''
+    required_options = frozenset(['opsgenie_key', 'opsgenie_account', 'opsgenie_recipients'])
+
+    def __init__(self, *args):
+        super(OpsGenieAlerter, self).__init__(*args)
+
+        self.account = self.rule.get('opsgenie_account', 'genie')
+        self.api_key = self.rule.get('opsgenie_key', 'key')
+        self.recipients = self.rule.get('opsgenie_recipients', ['genies'])
+        self.to_addr = self.rule.get('opsgenie_addr', 'example.opsgenie.net')
+
+    def alert(self, matches):
+        body = ''
+        for match in matches:
+            body += str(BasicMatchString(self.rule, match))
+            # Separate text of aggregated alerts with dashes
+            if len(matches) > 1:
+                body += '\n----------------------------------------\n'
+
+        post = {}
+        post['apiKey'] = self.api_key
+        post['message'] = self.create_default_title(matches)
+        post['recipients'] = self.recipients
+        post['description'] = body
+        post['source'] = 'ElastAlert'
+        post['tags'] = ['ElastAlert', self.rule['name']]
+        logging.debug(json.dumps(post))
+
+        try:
+            r = requests.post(self.to_addr, json=post)
+
+            logging.debug('request response: {}'.format(r))
+            if r.status_code != 200:
+                logging.error("Error sending alert request to OpsGenie! {}".format(r.json()))
+                r.raise_for_status()
+            logging.info("Alert sent to OpsGenie")
+        except Exception as err:
+            logging.error("Error sending alert to OpsGenie: {}".format(err))
+            return
+
+    def create_default_title(self, matches):
+        subject = 'ElastAlert: %s' % (self.rule['name'])
+
+        # If the rule has a query_key, add that value plus timestamp to subject
+        if 'query_key' in self.rule:
+            qk = matches[0].get(self.rule['query_key'])
+            if qk:
+                subject += ' - %s' % (qk)
+
+        return subject
+
+    def get_info(self):
+        return {'type': 'opsgenie',
+                'recipients': self.recipients}

--- a/modules/opsgenie.py
+++ b/modules/opsgenie.py
@@ -3,6 +3,7 @@ import json
 import logging
 import requests
 
+from elastalert.util import EAException
 from elastalert.alerts import Alerter
 from elastalert.alerts import BasicMatchString
 
@@ -41,12 +42,11 @@ class OpsGenieAlerter(Alerter):
 
             logging.debug('request response: {0}'.format(r))
             if r.status_code != 200:
-                logging.error("Error sending alert request to OpsGenie! {0}".format(r.json()))
+                logging.info("Error sending alert request to OpsGenie: {0}".format(r.json()))
                 r.raise_for_status()
             logging.info("Alert sent to OpsGenie")
         except Exception as err:
-            logging.error("Error sending alert to OpsGenie: {0}".format(err))
-            return
+            raise EAException(err)
 
     def create_default_title(self, matches):
         subject = 'ElastAlert: %s' % (self.rule['name'])

--- a/modules/opsgenie.py
+++ b/modules/opsgenie.py
@@ -17,7 +17,7 @@ class OpsGenieAlerter(Alerter):
         self.account = self.rule.get('opsgenie_account', 'genie')
         self.api_key = self.rule.get('opsgenie_key', 'key')
         self.recipients = self.rule.get('opsgenie_recipients', ['genies'])
-        self.to_addr = self.rule.get('opsgenie_addr', 'example.opsgenie.net')
+        self.to_addr = self.rule.get('opsgenie_addr', 'https://api.opsgenie.com/v1/json/alert')
 
     def alert(self, matches):
         body = ''

--- a/modules/opsgenie.py
+++ b/modules/opsgenie.py
@@ -39,13 +39,13 @@ class OpsGenieAlerter(Alerter):
         try:
             r = requests.post(self.to_addr, json=post)
 
-            logging.debug('request response: {}'.format(r))
+            logging.debug('request response: {0}'.format(r))
             if r.status_code != 200:
-                logging.error("Error sending alert request to OpsGenie! {}".format(r.json()))
+                logging.error("Error sending alert request to OpsGenie! {0}".format(r.json()))
                 r.raise_for_status()
             logging.info("Alert sent to OpsGenie")
         except Exception as err:
-            logging.error("Error sending alert to OpsGenie: {}".format(err))
+            logging.error("Error sending alert to OpsGenie: {0}".format(err))
             return
 
     def create_default_title(self, matches):

--- a/modules/opsgenie.py
+++ b/modules/opsgenie.py
@@ -6,6 +6,7 @@ import requests
 from elastalert.util import EAException
 from elastalert.alerts import Alerter
 from elastalert.alerts import BasicMatchString
+from elastalert.util import elastalert_logger
 
 
 class OpsGenieAlerter(Alerter):
@@ -42,11 +43,12 @@ class OpsGenieAlerter(Alerter):
 
             logging.debug('request response: {0}'.format(r))
             if r.status_code != 200:
-                logging.info("Error sending alert request to OpsGenie: {0}".format(r.json()))
+                elastalert_logger.info("Error response from {0}\n API Response: {1}"\
+                                                            .format(self.to_addr, r))
                 r.raise_for_status()
             logging.info("Alert sent to OpsGenie")
         except Exception as err:
-            raise EAException(err)
+            raise EAException("Error sending alert: {0}".format(err))
 
     def create_default_title(self, matches):
         subject = 'ElastAlert: %s' % (self.rule['name'])

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -229,10 +229,34 @@ def test_email_query_key_in_subject():
                 found_subject = True
         assert found_subject
 
+
 def test_opsgenie_basic():
     rule = {'name': 'testOGalert', 'opsgenie_key': 'ogkey',
             'opsgenie_account': 'genies', 'opsgenie_addr': 'https://api.opsgenie.com/v1/json/alert',
             'opsgenie_recipients': ['lytics'], 'type': mock_rule()}
+    with mock.patch('requests.post') as mock_post:
+
+        alert = OpsGenieAlerter(rule)
+        alert.alert([{'@timestamp': '2014-10-31T00:00:00'}])
+        print("mock_post: {}".format(mock_post._mock_call_args_list))
+        mcal = mock_post._mock_call_args_list
+        print('mcal: {}'.format(mcal[0]))
+        assert mcal[0][0][0] == ('https://api.opsgenie.com/v1/json/alert')
+
+        assert mock_post.called
+
+        assert mcal[0][1]['json']['apiKey'] == 'ogkey'
+        assert mcal[0][1]['json']['source'] == 'ElastAlert'
+        assert mcal[0][1]['json']['recipients'] == ['lytics']
+        assert mcal[0][1]['json']['source'] == 'ElastAlert'
+
+
+def test_opsgenie_frequency():
+    rule = {'name': 'testOGalert', 'opsgenie_key': 'ogkey',
+            'opsgenie_account': 'genies', 'opsgenie_addr': 'https://api.opsgenie.com/v1/json/alert',
+            'opsgenie_recipients': ['lytics'], 'type': mock_rule(),
+            'filter': [{'query': {'query_string': {'query': '*hihi*'}}}],
+            'alert': 'opsgenie'}
     with mock.patch('requests.post') as mock_post:
 
         alert = OpsGenieAlerter(rule)

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import subprocess
 
+
 import mock
 from jira.exceptions import JIRAError
 
@@ -11,6 +12,7 @@ from elastalert.alerts import CommandAlerter
 from elastalert.alerts import EmailAlerter
 from elastalert.alerts import JiraAlerter
 from elastalert.alerts import JiraFormattedMatchString
+from elastalert.alerts import OpsGenieAlerter
 from elastalert.util import ts_add
 
 
@@ -226,6 +228,27 @@ def test_email_query_key_in_subject():
                 assert 'werbenjagermanjensen' in line
                 found_subject = True
         assert found_subject
+
+def test_opsgenie_basic():
+    rule = {'name': 'testOGalert', 'opsgenie_key': 'ogkey',
+            'opsgenie_account': 'genies', 'opsgenie_addr': 'https://api.opsgenie.com/v1/json/alert',
+            'opsgenie_recipients': ['lytics'], 'type': mock_rule()}
+    with mock.patch('requests.post') as mock_post:
+
+        alert = OpsGenieAlerter(rule)
+        alert.alert([{'@timestamp': '2014-10-31T00:00:00'}])
+        print("mock_post: {}".format(mock_post._mock_call_args_list))
+        mcal = mock_post._mock_call_args_list
+        print('mcal: {}'.format(mcal[0]))
+        assert mcal[0][0][0] == ('https://api.opsgenie.com/v1/json/alert')
+
+        assert mock_post.called
+
+        assert mcal[0][1]['json']['apiKey'] == 'ogkey'
+        assert mcal[0][1]['json']['source'] == 'ElastAlert'
+        assert mcal[0][1]['json']['recipients'] == ['lytics']
+        assert mcal[0][1]['json']['source'] == 'ElastAlert'
+        assert mcal[0][1]['json']['source'] == 'ElastAlert'
 
 
 def test_jira():

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -258,9 +258,9 @@ def test_opsgenie_basic():
 
         alert = OpsGenieAlerter(rule)
         alert.alert([{'@timestamp': '2014-10-31T00:00:00'}])
-        print("mock_post: {}".format(mock_post._mock_call_args_list))
+        print("mock_post: {0}".format(mock_post._mock_call_args_list))
         mcal = mock_post._mock_call_args_list
-        print('mcal: {}'.format(mcal[0]))
+        print('mcal: {0}'.format(mcal[0]))
         assert mcal[0][0][0] == ('https://api.opsgenie.com/v1/json/alert')
 
         assert mock_post.called
@@ -284,9 +284,9 @@ def test_opsgenie_frequency():
 
         assert alert.get_info()['recipients'] == rule['opsgenie_recipients']
 
-        print("mock_post: {}".format(mock_post._mock_call_args_list))
+        print("mock_post: {0}".format(mock_post._mock_call_args_list))
         mcal = mock_post._mock_call_args_list
-        print('mcal: {}'.format(mcal[0]))
+        print('mcal: {0}'.format(mcal[0]))
         assert mcal[0][0][0] == ('https://api.opsgenie.com/v1/json/alert')
 
         assert mock_post.called

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -12,7 +12,7 @@ from elastalert.alerts import CommandAlerter
 from elastalert.alerts import EmailAlerter
 from elastalert.alerts import JiraAlerter
 from elastalert.alerts import JiraFormattedMatchString
-from elastalert.alerts import OpsGenieAlerter
+from modules.opsgenie import OpsGenieAlerter
 from elastalert.util import ts_add
 
 
@@ -261,6 +261,9 @@ def test_opsgenie_frequency():
 
         alert = OpsGenieAlerter(rule)
         alert.alert([{'@timestamp': '2014-10-31T00:00:00'}])
+
+        assert alert.get_info()['recipients'] == rule['opsgenie_recipients']
+
         print("mock_post: {}".format(mock_post._mock_call_args_list))
         mcal = mock_post._mock_call_args_list
         print('mcal: {}'.format(mcal[0]))


### PR DESCRIPTION
This PR adds a simple [OpsGenie](https://www.opsgenie.com/) Alerter in `modules/opsgenie.py`. It is a simple alerter which if matched by a rule sends an https request to [OpsGenie's API to create](https://www.opsgenie.com/docs/web-api/alert-api#createAlertRequest) an alert which can be directed at recipients for notification. Our use case is roughly; a log message that we don't like appears in Elasticsearch, notify team X that there might be an issue to investigate.

I think I updated the documentation in the relevant places but I might have missed something.

I've primarily been testing with a frequency rule, however once we get it deployed to staging more might find issues but the OGAlerter is pretty stupid simple. I did create a couple unit tests for the OpsGenieAlerter, however my python chops aren't what they used to be so critique welcome.

`tox` passes all tests on my end :four_leaf_clover: 