### PR TITLE
notify_email now accepts array of strings

### DIFF
--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -167,7 +167,7 @@ properties:
   ### Email
   email: *arrayOfString
   email_reply_to: {type: string}
-  notify_email: {type: string} # if rule is slow or erroring, send to this email
+  notify_email: *arrayOfString # if rule is slow or erroring, send to this email
   smtp_host: {type: string}
   from_addr: {type: string}
 


### PR DESCRIPTION
Issue where notify_email should be able to send to multiple recipients but doesn't due to lack of schema update.