### PR TITLE
Allow notify_email to be a list

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1196,10 +1196,11 @@ class ElastAlerter():
         email = MIMEText(email_body)
         email['Subject'] = subject if subject else 'ElastAlert notification'
         recipients = self.notify_email
-        if rule and rule.get('notify_email') and not rule['notify_email'] in self.notify_email:
+        if rule and rule.get('notify_email'):
             if isinstance(rule['notify_email'], basestring):
                 rule['notify_email'] = [rule['notify_email']]
             recipients = recipients + rule['notify_email']
+        recipients = list(set(recipients))
         email['To'] = ', '.join(recipients)
         email['From'] = self.from_addr
         email['Reply-To'] = self.conf.get('email_reply_to', email['To'])

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -89,7 +89,7 @@ class ElastAlerter():
         self.alert_time_limit = self.conf['alert_time_limit']
         self.old_query_limit = self.conf['old_query_limit']
         self.disable_rules_on_error = self.conf['disable_rules_on_error']
-        self.notify_email = self.conf.get('notify_email')
+        self.notify_email = self.conf.get('notify_email', [])
         self.from_addr = self.conf.get('from_addr', 'ElastAlert')
         self.smtp_host = self.conf.get('smtp_host', 'localhost')
         self.max_aggregation = self.conf.get('max_aggregation', 10000)
@@ -1197,7 +1197,9 @@ class ElastAlerter():
         email['Subject'] = subject if subject else 'ElastAlert notification'
         recipients = self.notify_email
         if rule and rule.get('notify_email') and not rule['notify_email'] in self.notify_email:
-            recipients.append(rule['notify_email'])
+            if isinstance(rule['notify_email'], basestring):
+                rule['notify_email'] = [rule['notify_email']]
+            recipients = recipients + rule['notify_email']
         email['To'] = ', '.join(recipients)
         email['From'] = self.from_addr
         email['Reply-To'] = self.conf.get('email_reply_to', email['To'])

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -776,6 +776,32 @@ def test_stop(ea):
             assert mock_run.call_count == 4
 
 
+def test_notify_email(ea):
+    mock_smtp = mock.Mock()
+    ea.rules[0]['notify_email'] = ['foo@foo.foo', 'bar@bar.bar']
+    with mock.patch('elastalert.elastalert.SMTP') as mock_smtp_f:
+        mock_smtp_f.return_value = mock_smtp
+
+        # Notify_email from rules, array
+        ea.send_notification_email('omg', rule=ea.rules[0])
+        assert mock_smtp.sendmail.call_args_list[0][0][1] == ea.rules[0]['notify_email']
+
+        # With ea.notify_email
+        ea.notify_email = ['baz@baz.baz']
+        ea.send_notification_email('omg', rule=ea.rules[0])
+        assert mock_smtp.sendmail.call_args_list[1][0][1] == ['baz@baz.baz'] + ea.rules[0]['notify_email']
+
+        # With ea.notify email but as single string
+        ea.rules[0]['notify_email'] = 'foo@foo.foo'
+        ea.send_notification_email('omg', rule=ea.rules[0])
+        assert mock_smtp.sendmail.call_args_list[2][0][1] == ['baz@baz.baz', 'foo@foo.foo']
+
+        # None from rule
+        ea.rules[0].pop('notify_email')
+        ea.send_notification_email('omg', rule=ea.rules[0])
+        assert mock_smtp.sendmail.call_args_list[3][0][1] == ['baz@baz.baz']
+
+
 def test_uncaught_exceptions(ea):
     e = Exception("Errors yo!")
 

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -784,22 +784,22 @@ def test_notify_email(ea):
 
         # Notify_email from rules, array
         ea.send_notification_email('omg', rule=ea.rules[0])
-        assert mock_smtp.sendmail.call_args_list[0][0][1] == ea.rules[0]['notify_email']
+        assert set(mock_smtp.sendmail.call_args_list[0][0][1]) == set(ea.rules[0]['notify_email'])
 
         # With ea.notify_email
         ea.notify_email = ['baz@baz.baz']
         ea.send_notification_email('omg', rule=ea.rules[0])
-        assert mock_smtp.sendmail.call_args_list[1][0][1] == ['baz@baz.baz'] + ea.rules[0]['notify_email']
+        assert set(mock_smtp.sendmail.call_args_list[1][0][1]) == set(['baz@baz.baz'] + ea.rules[0]['notify_email'])
 
         # With ea.notify email but as single string
         ea.rules[0]['notify_email'] = 'foo@foo.foo'
         ea.send_notification_email('omg', rule=ea.rules[0])
-        assert mock_smtp.sendmail.call_args_list[2][0][1] == ['baz@baz.baz', 'foo@foo.foo']
+        assert set(mock_smtp.sendmail.call_args_list[2][0][1]) == set(['baz@baz.baz', 'foo@foo.foo'])
 
         # None from rule
         ea.rules[0].pop('notify_email')
         ea.send_notification_email('omg', rule=ea.rules[0])
-        assert mock_smtp.sendmail.call_args_list[3][0][1] == ['baz@baz.baz']
+        assert set(mock_smtp.sendmail.call_args_list[3][0][1]) == set(['baz@baz.baz'])
 
 
 def test_uncaught_exceptions(ea):


### PR DESCRIPTION
Allow notify_email to be a list in the rules. Also adds tests.