### PR TITLE
Fixed keyerror in aggregated alerts

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -578,6 +578,7 @@ class ElastAlerter():
 
         copy_properties = ['agg_matches',
                            'current_aggregate_id',
+                           'aggregate_alert_time',
                            'processed_hits',
                            'starttime',
                            'minimum_starttime']
@@ -1058,7 +1059,8 @@ class ElastAlerter():
 
     def add_aggregated_alert(self, match, rule):
         """ Save a match as a pending aggregate alert to elasticsearch. """
-        if not rule['current_aggregate_id'] or rule['aggregate_alert_time'] < ts_to_dt(match[rule['timestamp_field']]):
+        if (not rule['current_aggregate_id'] or
+                ('aggregate_alert_time' in rule and rule['aggregate_alert_time'] < ts_to_dt(match[rule['timestamp_field']]))):
             # First match, set alert_time
             match_time = ts_to_dt(match[rule['timestamp_field']])
             alert_time = match_time + rule['aggregation']


### PR DESCRIPTION
There was a bug in which modifying a rule which had a pending aggregation would cause it to KeyError.

When a new aggregation starts, ``current_aggregate_id`` and ``aggregate_alert_time`` are both set. These are always set together, and so if one is true, the other is assumed to exist. However, only ``current_aggregate_id`` is copied while a rule is reloaded, thus, causing a KeyError.

This prevents the KeyError by copying ``aggregate_alert_time`` and also double-checking that it exists in the conditional, which shouldn't be needed anymore anyway.