### PR TITLE
Fix message for Cardinality rule type

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -621,11 +621,11 @@ class CardinalityRule(RuleType):
         lt = self.rules.get('use_local_time')
         starttime = pretty_ts(dt_to_ts(ts_to_dt(match[self.ts_field]) - self.rules['timeframe']), lt)
         endtime = pretty_ts(match[self.ts_field], lt)
-	if 'max_cardinality' in self.rules:
+        if 'max_cardinality' in self.rules:
             message = ('A maximum of %d unique %s(s) occurred since last alert or between %s and %s\n\n' % (self.rules['max_cardinality'],
                                                                                                             self.rules['cardinality_field'],
                                                                                                             starttime, endtime))
-	else:
+        else:
             message = ('Less than %d unique %s(s) occurred since last alert or between %s and %s\n\n' % (self.rules['min_cardinality'],
                                                                                                          self.rules['cardinality_field'],
                                                                                                          starttime, endtime))

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -622,13 +622,11 @@ class CardinalityRule(RuleType):
         starttime = pretty_ts(dt_to_ts(ts_to_dt(match[self.ts_field]) - self.rules['timeframe']), lt)
         endtime = pretty_ts(match[self.ts_field], lt)
 	if 'max_cardinality' in self.rules:
-        	message = ('A maximum of %d unique %s(s) occurred since last alert or '
-                   	'between %s and %s\n\n' % (self.rules['max_cardinality'],
-                        self.rules['cardinality_field'],
-                        starttime, endtime))
+            message = ('A maximum of %d unique %s(s) occurred since last alert or between %s and %s\n\n' % (self.rules['max_cardinality'],
+                                                                                                            self.rules['cardinality_field'],
+                                                                                                            starttime, endtime))
 	else:
-		message = ('Less than %d unique %s(s) occurred since last alert or '
-                       	'between %s and %s\n\n' % (self.rules['min_cardinality'],
-                        self.rules['cardinality_field'],
-                        starttime, endtime))
+            message = ('Less than %d unique %s(s) occurred since last alert or between %s and %s\n\n' % (self.rules['min_cardinality'],
+                                                                                                         self.rules['cardinality_field'],
+                                                                                                         starttime, endtime))
         return message

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -621,8 +621,14 @@ class CardinalityRule(RuleType):
         lt = self.rules.get('use_local_time')
         starttime = pretty_ts(dt_to_ts(ts_to_dt(match[self.ts_field]) - self.rules['timeframe']), lt)
         endtime = pretty_ts(match[self.ts_field], lt)
-        message = ('A maximum of %d unique %s(s) occurred since last alert or '
-                   'between %s and %s\n\n' % (self.rules['max_cardinality'],
-                                              self.rules['cardinality_field'],
-                                              starttime, endtime))
+	if 'max_cardinality' in self.rules:
+        	message = ('A maximum of %d unique %s(s) occurred since last alert or '
+                   	'between %s and %s\n\n' % (self.rules['max_cardinality'],
+                        self.rules['cardinality_field'],
+                        starttime, endtime))
+	else:
+		message = ('Less than %d unique %s(s) occurred since last alert or '
+                       	'between %s and %s\n\n' % (self.rules['min_cardinality'],
+                        self.rules['cardinality_field'],
+                        starttime, endtime))
         return message


### PR DESCRIPTION
If Cardinality rule is used with min_cardinality, an exception is raised because the alert message only refers to max_cardinality.

With this check at get_match_str function from CardinalityRule class, message is customised depending on the term used