### PR TITLE
add a signal handler for SIGINT to exit cleanly

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1267,8 +1267,13 @@ def handle_signal(signal, frame):
     os._exit(0)
 
 
-if __name__ == '__main__':
+def main(args=None):
     signal.signal(signal.SIGINT, handle_signal)
-    client = ElastAlerter(sys.argv[1:])
+    if not args:
+        args = sys.argv[1:]
+    client = ElastAlerter(args)
     if not client.args.silence:
         client.start()
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -168,6 +168,7 @@ class FrequencyRule(RuleType):
         super(FrequencyRule, self).__init__(*args)
         self.ts_field = self.rules.get('timestamp_field', '@timestamp')
         self.get_ts = lambda event: event[0][self.ts_field]
+        self.attach_all_events = self.rules.get('attach_all_events', False)
 
     def add_count_data(self, data):
         """ Add count data to the rule. Data should be of the form {ts: count}. """
@@ -208,6 +209,8 @@ class FrequencyRule(RuleType):
         # Match if, after removing old events, we hit num_events
         if self.occurrences[key].count() >= self.rules['num_events']:
             event = self.occurrences[key].data[-1][0]
+            if self.attach_all_events:
+                event['related_events'] = [data[0] for data in self.occurrences[key].data[:-1]]
             self.add_match(event)
             self.occurrences.pop(key)
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
     entry_points={
         'console_scripts': ['elastalert-create-index=elastalert.create_index:main',
                             'elastalert-test-rule=elastalert.test_rule:main',
-                            'elastalert-rule-from-kibana=elastalert.rule_from_kibana:main']},
+                            'elastalert-rule-from-kibana=elastalert.rule_from_kibana:main',
+                            'elastalert=elastalert.elastalert:main']},
     packages=find_packages(),
     package_data={'elastalert': ['schema.yaml']},
     install_requires=[


### PR DESCRIPTION
This will just make a ctrl-c or a kill -SIGINT to exit cleanly instead of throwing an exception, doesn't really provide much other than that, feel free to reject it.