### PR TITLE
optional attach_related events to frequency alerts

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -100,6 +100,8 @@ Rule Configuration Cheat Sheet
 +----------------------------------------------------+-----+-----------+-----------+--------+-----------+-------+----------+--------+-----------+
 | ``num_events`` (int, no default)                   |     |           |           |        |    Req    |       |          |        |           |
 +----------------------------------------------------+-----+-----------+-----------+--------+-----------+-------+----------+--------+-----------+
+| ``attach_related`` (boolean, no default)           |     |           |           |        |    Opt    |       |          |        |           |
++----------------------------------------------------+-----+-----------+-----------+--------+-----------+-------+----------+--------+-----------+
 |``use_count_query`` (boolean, no default)           |     |           |           |        |     Opt   | Opt   | Opt      |        |           |
 |                                                    |     |           |           |        |           |       |          |        |           |
 |``doc_type`` (string, no default)                   |     |           |           |        |           |       |          |        |           |
@@ -588,6 +590,9 @@ default 50, unique terms.
 ``query_key``: Counts of documents will be stored independently for each value of ``query_key``. Only ``num_events`` documents,
 all with the same value of ``query_key``, will trigger an alert.
 
+
+``attach_related``: Will attach all the related events to the event that triggered the frequency alert. For example in an alert triggered with ``num_events``: 3,
+the 3rd event will trigger the alert on itself and add the other 2 events in a key named ``related_events`` that can be accessed in the alerter.
 
 Spike
 ~~~~~~

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -168,6 +168,7 @@ class FrequencyRule(RuleType):
         super(FrequencyRule, self).__init__(*args)
         self.ts_field = self.rules.get('timestamp_field', '@timestamp')
         self.get_ts = lambda event: event[0][self.ts_field]
+        self.attach_related = self.rules.get('attach_related', False)
 
     def add_count_data(self, data):
         """ Add count data to the rule. Data should be of the form {ts: count}. """
@@ -208,6 +209,8 @@ class FrequencyRule(RuleType):
         # Match if, after removing old events, we hit num_events
         if self.occurrences[key].count() >= self.rules['num_events']:
             event = self.occurrences[key].data[-1][0]
+            if self.attach_related:
+                event['related_events'] = [data[0] for data in self.occurrences[key].data[:-1]]
             self.add_match(event)
             self.occurrences.pop(key)
 

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -61,6 +61,7 @@ oneOf:
       doc_type: {type: string}
       use_terms_query: {type: boolean}
       terms_size: {type: integer}
+      attach_related: {type: boolean}
 
   - title: Spike
     required: [spike_height, spike_type, timeframe]


### PR DESCRIPTION
Add the other events in the bucket to the event that triggers the alert, allows us to better track the events that triggered the alert.