### PR TITLE
Entry point for elastalert main with SIGINT handler

### DIFF
--- a/docs/source/running_elastalert.rst
+++ b/docs/source/running_elastalert.rst
@@ -123,7 +123,7 @@ Running ElastAlert
 
 There are two ways of invoking ElastAlert. As a daemon, through Supervisor (http://supervisord.org/), or directly with Python. For easier debugging purposes in this tutorial, we will invoke it directly::
 
-    $ python -m elastalert.elastalert --verbose --rule example_frequency.yaml
+    $ python -m elastalert.elastalert --verbose --rule example_frequency.yaml  # or use the entry point: elastalert --verbose --rule ...
     No handlers could be found for logger "elasticsearch"
     INFO:root:Queried rule Example rule from 1-15 14:22 PST to 1-15 15:07 PST: 5 hits
     INFO:elasticsearch:POST http://elasticsearch.example.com:14900/elastalert_status/elastalert_status?op_type=create [status:201 request:0.025s]

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -6,6 +6,8 @@ import logging
 import sys
 import time
 import traceback
+import os
+import signal
 from email.mime.text import MIMEText
 from smtplib import SMTP
 from smtplib import SMTPException
@@ -1259,7 +1261,19 @@ class ElastAlerter():
         return timestamp + wait, exponent
 
 
-if __name__ == '__main__':
-    client = ElastAlerter(sys.argv[1:])
+def handle_signal(signal, frame):
+    elastalert_logger.info('SIGINT received, stopping ElastAlert...')
+    # use os._exit to exit immediately and avoid someone catching SystemExit
+    os._exit(0)
+
+
+def main(args=None):
+    signal.signal(signal.SIGINT, handle_signal)
+    if not args:
+        args = sys.argv[1:]
+    client = ElastAlerter(args)
     if not client.args.silence:
         client.start()
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
     entry_points={
         'console_scripts': ['elastalert-create-index=elastalert.create_index:main',
                             'elastalert-test-rule=elastalert.test_rule:main',
-                            'elastalert-rule-from-kibana=elastalert.rule_from_kibana:main']},
+                            'elastalert-rule-from-kibana=elastalert.rule_from_kibana:main',
+                            'elastalert=elastalert.elastalert:main']},
     packages=find_packages(),
     package_data={'elastalert': ['schema.yaml']},
     install_requires=[

--- a/supervisord.conf.example
+++ b/supervisord.conf.example
@@ -16,9 +16,12 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 serverurl=unix:///var/run/elastalert_supervisor.sock
 
 [program:elastalert]
+# running globally
 command =
         python elastalert.py
                --verbose
+# (alternative) using virtualenv
+# command=/path/to/venv/bin/elastalert --config /path/to/config.yaml --verbose 
 process_name=elastalert
 autorestart=true
 startsecs=15
@@ -27,4 +30,3 @@ stopasgroup=true
 killasgroup=true
 stderr_logfile=/var/log/elastalert_stderr.log
 stderr_logfile_maxbytes=5MB
-


### PR DESCRIPTION
Add the main entry point to the list of console scripts on setup.py, make it the same as the other commands like rule tester and index creator.

Also add a SIGINT signal handler to exit cleanly on ctrl-c and supervisor stop.