### PR TITLE
Added sleep to create_index

### DIFF
--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import getpass
 import json
 import os
+import time
 
 import argparse
 import yaml
@@ -84,6 +85,7 @@ def main():
         print('Got %s documents' % (len(res['hits']['hits'])))
 
     es.indices.create(index)
+    time.sleep(2)
     es.indices.put_mapping(index=index, doc_type='elastalert', body=es_mapping)
     es.indices.put_mapping(index=index, doc_type='elastalert_status', body=ess_mapping)
     es.indices.put_mapping(index=index, doc_type='silence', body=silence_mapping)

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -85,6 +85,7 @@ def main():
         print('Got %s documents' % (len(res['hits']['hits'])))
 
     es.indices.create(index)
+    # To avoid a race condition. TODO: replace this with a real check
     time.sleep(2)
     es.indices.put_mapping(index=index, doc_type='elastalert', body=es_mapping)
     es.indices.put_mapping(index=index, doc_type='elastalert_status', body=ess_mapping)


### PR DESCRIPTION
There was a race condition where the index would not be ready and a put_mapping call would error out. 2 seconds worked in testing but is arbitrary