### PR TITLE
Add pagerduty

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -81,7 +81,7 @@ Rule Configuration Cheat Sheet
 | ``_source_enabled`` (boolean, default True)                  |           |
 +--------------------------------------------------------------+-----------+
 
-| 
+|
 
 +----------------------------------------------------+-----+-----------+-----------+--------+-----------+-------+----------+--------+-----------+
 |      RULE TYPE                                     | Any | Blacklist | Whitelist | Change | Frequency | Spike | Flatline |New_term|Cardinality|
@@ -284,7 +284,7 @@ include
 ^^^^^^^
 
 ``include``: A list of terms that should be included in query results and passed to rule types and alerts. When set, only those
-fields, along with '@timestamp', ``query_key``, ``compare_key``, and ``top_count_keys``  are included, if present. 
+fields, along with '@timestamp', ``query_key``, ``compare_key``, and ``top_count_keys``  are included, if present.
 (Optional, list of strings, default all fields)
 
 top_count_keys
@@ -772,7 +772,7 @@ Cardinality
 ~~~~~~~~
 
 ``cardinality``: This rule matches when a the total number of unique values for a certain field within a time frame is higher or lower
-than a threshold. 
+than a threshold.
 
 This rule requires:
 
@@ -1012,10 +1012,10 @@ OpsGenie
 ~~~~~~~~
 
 OpsGenie alerter will create an alert which can be used to notify Operations people of issues or log information. An OpsGenie ``API``
-integration must be created in order to acquire the necessary ``opsgenie_key`` rule variable. Currently the OpsGenieAlerter only creates 
+integration must be created in order to acquire the necessary ``opsgenie_key`` rule variable. Currently the OpsGenieAlerter only creates
 an alert, however it could be extended to update or close existing alerts.
 
-It is necessary for the user to create an OpsGenie Rest HTTPS API `integration page <https://app.opsgenie.com/integration>`_ in order to create alerts.  
+It is necessary for the user to create an OpsGenie Rest HTTPS API `integration page <https://app.opsgenie.com/integration>`_ in order to create alerts.
 
 The OpsGenie alert requires three options:
 
@@ -1029,7 +1029,7 @@ SNS
 ~~~
 
 The SNS alerter will send an SNS notification. The body of the notification is formatted the same as with other alerters. The SNS alerter
-uses boto and can use credentials in the rule yaml or in a standard boto credential file. 
+uses boto and can use credentials in the rule yaml or in a standard boto credential file.
 See http://boto.readthedocs.org/en/latest/boto_config_tut.html#details for details.
 
 SNS requires one option:
@@ -1076,6 +1076,17 @@ Optional:
 Elastalert rule. Any Apple emoji can be used, see http://emojipedia.org/apple/
 
 ``slack_msg_color``: By default the alert will be posted with the 'danger' color. You can also use 'good' or 'warning' colors.
+
+PagerDuty
+~~~~~~~~~
+
+PagerDuty alerter will trigger an incident to a predefined PagerDuty service. The body of the notification is formatted the same as with other alerters.
+
+The alerter requires the following option:
+
+``pagerduty_service_key``: Integration Key generated after creating a service with the 'Use our API directly' option at Integration Settings
+
+``pagerduty_client_name``: The name of the monitoring client that is triggering this event.
 
 Debug
 ~~~~~~

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -573,8 +573,8 @@ class PagerDutyAlerter(Alerter):
 
     def __init__(self, rule):
         super(PagerDutyAlerter, self).__init__(rule)
-        self.service_key = self.rule['pagerduty_service_key']
-        self.client_name = self.rule['pagerduty_client_name']
+        self.pagerduty_service_key = self.rule['pagerduty_service_key']
+        self.pagerduty_client_name = self.rule['pagerduty_client_name']
         self.url = 'https://events.pagerduty.com/generic/2010-04-15/create_event.json'
 
     def alert(self, matches):

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -566,3 +566,45 @@ class SlackAlerter(Alerter):
         return {'type': 'slack',
                 'slack_username_override': self.slack_username_override,
                 'slack_webhook_url': self.slack_webhook_url}
+
+class PagerDutyAlerter(Alerter):
+    """ Create an incident on PagerDuty for each alert """
+    required_options = frozenset(['pagerduty_service_key', 'pagerduty_client_name'])
+
+    def __init__(self, rule):
+        super(PagerDutyAlerter, self).__init__(rule)
+        self.service_key = self.rule['pagerduty_service_key']
+        self.client_name = self.rule['pagerduty_client_name']
+        self.url = 'https://events.pagerduty.com/generic/2010-04-15/create_event.json'
+
+    def alert(self, matches):
+        body = ''
+        for match in matches:
+            body += str(BasicMatchString(self.rule, match))
+            # Separate text of aggregated alerts with dashes
+            if len(matches) > 1:
+                body += '\n----------------------------------------\n'
+
+        # post to pagerduty
+        headers = {'content-type': 'application/json'}
+        payload = {
+            'service_key': self.pagerduty_service_key,
+            'description': self.rule['name'],
+            'event_type': 'trigger',
+            'client': self.pagerduty_client_name,
+            'details': {
+                "information": body,
+            },
+        }
+
+        try:
+            response = requests.post(self.url, data=json.dumps(payload), headers=headers)
+            response.raise_for_status()
+        except RequestException as e:
+            raise EAException("Error posting to pagerduty: %s" % e)
+        elastalert_logger.info("Trigger sent to PagerDuty")
+
+    def get_info(self):
+        return {'type': 'pagerduty',
+                'pagerduty_service_key': self.pagerduty_service_key,
+                'pagerduty_client_name': self.pagerduty_client_name}

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -567,6 +567,7 @@ class SlackAlerter(Alerter):
                 'slack_username_override': self.slack_username_override,
                 'slack_webhook_url': self.slack_webhook_url}
 
+
 class PagerDutyAlerter(Alerter):
     """ Create an incident on PagerDuty for each alert """
     required_options = frozenset(['pagerduty_service_key', 'pagerduty_client_name'])

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -50,7 +50,8 @@ alerts_mapping = {
     'command': alerts.CommandAlerter,
     'sns': alerts.SnsAlerter,
     'hipchat': alerts.HipChatAlerter,
-    'slack': alerts.SlackAlerter
+    'slack': alerts.SlackAlerter,
+    'pagerduty': alerts.PagerDutyAlerter
 }
 
 

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -186,3 +186,7 @@ properties:
   slack_username_override: {type: string}
   slack_emoji_override: {type: string}
   slack_msg_color: {enum: [good, warning, danger]}
+
+  ### PagerDuty
+  pagerduty_service_key: {type: string}
+  pagerduty_client_name: {type: string}


### PR DESCRIPTION
Added pagerduty as an alerter.

It needs the following config options to be set at alert configuration file:
- pagerduty_client_name: Integration Key generated after creating a service with the 'Use our API directly' option at Integration Settings
- pagerduty_client_name: The name of the monitoring client that is triggering this event.