### PR TITLE
SlackAlerter request fix

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -557,7 +557,7 @@ class SlackAlerter(Alerter):
         }
 
         try:
-            response = requests.post(self.slack_webhook_url, json=payload, headers=headers)
+            response = requests.post(self.slack_webhook_url, data=json.dumps(payload), headers=headers)
             response.raise_for_status()
         except RequestException as e:
             raise EAException("Error posting to slack: %s" % e)


### PR DESCRIPTION
SlackAlerter request fails due to incorrect parameters.

Stacktrace:
```
ERROR:root:Traceback (most recent call last):
  File "/home/xxx/elastalert/elastalert/elastalert.py", line 841, in alert
    return self.send_alert(matches, rule, alert_time=None)
  File "/home/xxx/elastalert/elastalert/elastalert.py", line 914, in send_alert
    alert.alert(matches)
  File "elastalert/alerts.py", line 558, in alert
    response = requests.post(self.slack_webhook_url, json=payload, headers=headers)
  File "/usr/lib/python2.7/dist-packages/requests/api.py", line 88, in post
    return request('post', url, data=data, **kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/api.py", line 44, in request
    return session.request(method=method, url=url, **kwargs)
TypeError: request() got an unexpected keyword argument 'json'
```