### PR TITLE
Added more unicode support

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -3,11 +3,11 @@ import copy
 import datetime
 import json
 import logging
+import os
+import signal
 import sys
 import time
 import traceback
-import os
-import signal
 from email.mime.text import MIMEText
 from smtplib import SMTP
 from smtplib import SMTPException
@@ -239,7 +239,7 @@ class ElastAlerter():
             hit['_source'][rule['timestamp_field']] = rule['ts_to_dt'](hit['_source'][rule['timestamp_field']])
             if rule.get('compound_query_key'):
                 values = [lookup_es_key(hit['_source'], key) for key in rule['compound_query_key']]
-                hit['_source'][rule['query_key']] = ', '.join([str(value) for value in values])
+                hit['_source'][rule['query_key']] = ', '.join([unicode(value) for value in values])
 
     def get_hits(self, rule, starttime, endtime, index):
         """ Query elasticsearch for the given rule and return the results.

--- a/elastalert/opsgenie.py
+++ b/elastalert/opsgenie.py
@@ -24,7 +24,7 @@ class OpsGenieAlerter(Alerter):
     def alert(self, matches):
         body = ''
         for match in matches:
-            body += str(BasicMatchString(self.rule, match))
+            body += unicode(BasicMatchString(self.rule, match))
             # Separate text of aggregated alerts with dashes
             if len(matches) > 1:
                 body += '\n----------------------------------------\n'

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -343,12 +343,12 @@ def test_silence(ea):
 def test_compound_query_key(ea):
     ea.rules[0]['query_key'] = 'this,that,those'
     ea.rules[0]['compound_query_key'] = ['this', 'that', 'those']
-    hits = generate_hits([START_TIMESTAMP, END_TIMESTAMP], this='abc', that='def', those=4)
+    hits = generate_hits([START_TIMESTAMP, END_TIMESTAMP], this='abc', that=u'☃', those=4)
     ea.current_es.search.return_value = hits
     ea.run_query(ea.rules[0], START, END)
     call_args = ea.rules[0]['type'].add_data.call_args_list[0]
     assert 'this,that,those' in call_args[0][0][0]
-    assert call_args[0][0][0]['this,that,those'] == 'abc, def, 4'
+    assert call_args[0][0][0]['this,that,those'] == u'abc, ☃, 4'
 
 
 def test_silence_query_key(ea):


### PR DESCRIPTION
Fixes #286 

Adds unicode support. Previously, having unicode in the match would cause errors in several places, such as in the linked issue, or when formatting with alert_text_args, or when sending emails.

I've only directly tested this with email and Jira. I've verified from documentation that Slack, Pagerduty and SNS all accept UTF-8 encoding.