### PR TITLE
Add capability to specify multiple indexes in a rule.

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -185,7 +185,7 @@ class ElastAlerter():
                         indexstring += ','
         else:
             indexstring = ",".join(indexes)
-            
+
         return indexstring
 
     @staticmethod

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -138,6 +138,7 @@ def format_index(index, start, end):
 
     return ','.join(indexes)
 
+
 def resolve_indexes(indexFromRule):
     """ Takes the index defined in the rule and resolves the list of indexes to use when
     talking to elasticsearch. The index can be a single string -when using one index- or
@@ -150,8 +151,9 @@ def resolve_indexes(indexFromRule):
             indexes.append(indexFromRule)
     else:
         indexes.extend(indexFromRule)
-    
+
     return indexes
+
 
 class EAException(Exception):
     pass

--- a/example_rules/example_frequency_multiple_indexes.yaml
+++ b/example_rules/example_frequency_multiple_indexes.yaml
@@ -49,10 +49,10 @@ timeframe:
 filter:
 - query:
     query_string:
-        query: "host:devsand*"
+        query: "host:some_host"
 - query:
     query_string:
-        query: "resolvedServiceId.raw:\"testService\""
+        query: "field_name:\"field_value\""
 
 # (Required)
 # The alert is use when a match is found

--- a/example_rules/example_frequency_string_multiple_indexes.yaml
+++ b/example_rules/example_frequency_string_multiple_indexes.yaml
@@ -46,10 +46,10 @@ timeframe:
 filter:
 - query:
     query_string:
-        query: "host:devsand*"
+        query: "host:some_host"
 - query:
     query_string:
-        query: "resolvedServiceId.raw:\"testService\""
+        query: "field_name:\"field_value\""
 
 # (Required)
 # The alert is use when a match is found

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 base_dir = os.path.dirname(__file__)
 setup(
     name='elastalert',
-    version='0.0.64',
+    version='0.0.65',
     description='Runs custom filters on Elasticsearch and alerts on matches',
     author='Quentin Long',
     author_email='qlo@yelp.com',


### PR DESCRIPTION
Within our company we are using multiple clusters in elastic search. As a result our rules needed to support defining multiple indexes so that they can aggregate information across multiple clusters. 

This change adds that capability. An index within a rule can be defined as a single index string, a comma delimited string, or a YAML list. 

Two examples have been added to the example_rules folders. 