### PR TITLE
Skipping bad rules and duplicate rules at startup, instead of exceptions.

### DIFF
--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -361,7 +361,7 @@ def load_rules(args):
                 rules.append(rule)
                 names.append(rule['name'])
         except EAException as e:
-            logging.error("Rule file %s skipped due to error loading file: %s", (rule_file, e))
+            logging.error("Rule file %s skipped due to error loading file: %s", rule_file, e)
 
     if not rules:
         logging.exception('No rules loaded. Exiting')

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -356,12 +356,12 @@ def load_rules(args):
         try:
             rule = load_configuration(rule_file, conf, args)
             if rule['name'] in names:
-                raise EAException('Duplicate rule named %s' % (rule['name']))
+                logging.error("Duplicate rule named %s - skipping rule in file %s" % (rule['name'], str(rule_file)))
+            else:
+                rules.append(rule)
+                names.append(rule['name'])
         except EAException as e:
-            raise EAException('Error loading file %s: %s' % (rule_file, e))
-
-        rules.append(rule)
-        names.append(rule['name'])
+            logging.error("Rule file %s skipped due to error loading file: %s", (rule_file, e))
 
     if not rules:
         logging.exception('No rules loaded. Exiting')


### PR DESCRIPTION
Skipping bad rules and duplicate rules at startup with error log, instead of throwing exceptions which caused termination of Elastalert.