### PR TITLE
Change timeout to string in new_term rule for ES 2.0

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -527,7 +527,7 @@ class NewTermsRule(RuleType):
 
         for field in self.fields:
             field_name['field'] = field
-            res = self.es.search(body=query, index=index, ignore_unavailable=True, timeout=50)
+            res = self.es.search(body=query, index=index, ignore_unavailable=True, timeout='50s')
             if 'aggregations' in res:
                 buckets = res['aggregations']['filtered']['values']['buckets']
                 keys = [bucket['key'] for bucket in buckets]


### PR DESCRIPTION
People have reported that this fixes new_term rule in ES 2.0. I have confirmed that this does not break compatibility with ES < 2.0.