### PR TITLE
Standardize time formats for ISO 8601

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -344,7 +344,7 @@ class JiraAlerter(Alerter):
         # directly adjacent to words appear to be ok
         title = title.replace(' - ', ' ')
 
-        date = (datetime.datetime.now() - datetime.timedelta(days=self.max_age)).strftime('%Y/%m/%d')
+        date = (datetime.datetime.now() - datetime.timedelta(days=self.max_age)).strftime('%Y-%m-%d')
         jql = 'project=%s AND summary~"%s" and created >= "%s"' % (self.project, title, date)
         if self.bump_in_statuses:
             jql = '%s and status in (%s)' % (jql, ','.join(self.bump_in_statuses))

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -97,17 +97,13 @@ def inc_ts(timestamp, milliseconds=1):
 def pretty_ts(timestamp, tz=True):
     """Pretty-format the given timestamp (to be printed or logged hereafter).
     If tz, the timestamp will be converted to local time.
-    Format: MM-DD HH:MM TZ"""
+    Format: YYYY-MM-DD HH:MM TZ"""
     dt = timestamp
     if not isinstance(timestamp, datetime.datetime):
         dt = ts_to_dt(timestamp)
     if tz:
         dt = dt.astimezone(dateutil.tz.tzlocal())
-    padding = ''
-    if dt.minute < 10:
-        padding = '0'
-    return '%d-%d %d:%s%d %s' % (dt.month, dt.day,
-                                 dt.hour, padding, dt.minute, dt.tzname())
+    return dt.strftime('%Y-%m-%d %H:%M %Z')
 
 
 def ts_add(ts, td):


### PR DESCRIPTION
I noticed some odd date formats in JIRA tickets being filed by ElastAlert and I wanted to fix 'em up.

* `2015/12/03` should be `2015-12-03`
* `12-2 4:05 PDT` should be `2015-12-02 04:05 PDT`

`make test` passes.