### PR TITLE
find_recent_pending_alerts: ignore aggregates

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -977,8 +977,7 @@ class ElastAlerter():
         query = {'query': {'query_string': {'query': '!_exists_:aggregate_id AND alert_sent:false'}},
                  'filter': {'range': {'alert_time': {'from': dt_to_ts(ts_now() - time_limit),
                                                      'to': dt_to_ts(ts_now())}}},
-                 'sort': { 'alert_time': {'order': 'asc'}},
-                }
+                 'sort': {'alert_time': {'order': 'asc'}}}
         if self.writeback_es:
             try:
                 res = self.writeback_es.search(index=self.writeback_index,

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -969,9 +969,16 @@ class ElastAlerter():
     def find_recent_pending_alerts(self, time_limit):
         """ Queries writeback_es to find alerts that did not send
         and are newer than time_limit """
-        query = {'query': {'query_string': {'query': 'alert_sent:false'}},
+
+        # XXX only fetches 1000 results. If limit is reached, next loop will catch them
+        # unless there is constantly more than 1000 alerts to send.
+
+        # Fetch recent, unsent alerts that aren't part of an aggregate, earlier alerts first.
+        query = {'query': {'query_string': {'query': '!_exists_:aggregate_id AND alert_sent:false'}},
                  'filter': {'range': {'alert_time': {'from': dt_to_ts(ts_now() - time_limit),
-                                                     'to': dt_to_ts(ts_now())}}}}
+                                                     'to': dt_to_ts(ts_now())}}},
+                 'sort': { 'alert_time': {'order': 'asc'}},
+                }
         if self.writeback_es:
             try:
                 res = self.writeback_es.search(index=self.writeback_index,
@@ -997,17 +1004,12 @@ class ElastAlerter():
                 # Malformed alert, drop it
                 continue
 
-            agg_id = alert.get('aggregate_id', None)
-            if agg_id:
-                # Aggregated alerts will be taken care of by get_aggregated_matches
-                continue
-
             # Find original rule
             for rule in self.rules:
                 if rule['name'] == rule_name:
                     break
             else:
-                # Original rule is missing, drop alert
+                # Original rule is missing, keep alert for later if rule reappears
                 continue
 
             # Set current_es for top_count_keys query
@@ -1015,7 +1017,7 @@ class ElastAlerter():
             self.current_es = self.new_elasticsearch(rule_es_conn_config)
             self.current_es_addr = (rule['es_host'], rule['es_port'])
 
-            # Retry the alert unless it's a future alert
+            # Send the alert unless it's a future alert
             if ts_now() > ts_to_dt(alert_time):
                 aggregated_matches = self.get_aggregated_matches(_id)
                 if aggregated_matches:
@@ -1042,6 +1044,8 @@ class ElastAlerter():
 
     def get_aggregated_matches(self, _id):
         """ Removes and returns all matches from writeback_es that have aggregate_id == _id """
+
+        # XXX if there are more than self.max_aggregation matches, you have big alerts and we will leave entries in ES.
         query = {'query': {'query_string': {'query': 'aggregate_id:%s' % (_id)}}}
         matches = []
         if self.writeback_es:
@@ -1068,11 +1072,12 @@ class ElastAlerter():
             alert_time = match_time + rule['aggregation']
             rule['aggregate_alert_time'] = alert_time
             agg_id = None
+            elastalert_logger.info('New aggregation for %s. next alert at %s.' % (rule['name'], alert_time))
         else:
             # Already pending aggregation, use existing alert_time
             alert_time = rule['aggregate_alert_time']
             agg_id = rule['current_aggregate_id']
-            elastalert_logger.info('Adding alert for %s to aggregation, next alert at %s' % (rule['name'], alert_time))
+            elastalert_logger.info('Adding alert for %s to aggregation(id: %s), next alert at %s' % (rule['name'], agg_id, alert_time))
 
         alert_body = self.get_alert_body(match, rule, False, alert_time)
         if agg_id:

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -261,11 +261,10 @@ def test_agg(ea):
     assert not call3['alert_sent']
     assert 'aggregate_id' not in call3
 
-    # First call - Find all pending alerts
+    # First call - Find all pending alerts (only entries without agg_id)
     # Second call - Find matches with agg_id == 'ABCD'
     # Third call - Find matches with agg_id == 'CDEF'
     ea.writeback_es.search.side_effect = [{'hits': {'hits': [{'_id': 'ABCD', '_source': call1},
-                                                             {'_id': 'BCDE', '_source': call2},
                                                              {'_id': 'CDEF', '_source': call3}]}},
                                           {'hits': {'hits': [{'_id': 'BCDE', '_source': call2}]}},
                                           {'hits': {'hits': []}}]


### PR DESCRIPTION
There's a few changes to `find_recent_pending_alerts` and `send_pending_alerts` in this PR:
 - Only fetch unsent alerts that do not have an `aggregate_id`.  (such entries were ignored in `send_pending_alerts` anyways)
 - force ordering of alerts by `alert_time`,  ascending. So we process earlier alerts first.
 - Stop skipping over entries that have an `aggregate_id` in `send_pending_alerts`. They are now filtered  by ES.
 - changed some comments and tweaked some log messages to help debugging.

All of this is to avoid some strange conditions when there are more than 1000 entries matching `alert_sent:false` when `find_recent_pending_alerts` is called.

Since `find_recent_pending_alerts` limits its search to 1000 entries and because it was using the default sort (`score` + `_id`), the search could return an incomplete and somewhat invalid set of result.
Some alerts could be forever delayed because the search would never return them and some alert could be incomplete since more matches might exist beyond the 1000 limit.

With this, I think most case are covered, unless you have more than 1000 rules.
I've left a comment regarding `max_aggregation`. If there's more entries than this limit, we're leaving cruft in ES.

There's another tweak that could be done when deleting sent alerts from ES,  I think it would be more efficient to do those delete a bulk call, but I'll test it and leave it for another PR.