### PR TITLE
Reset current_aggregate_id only if _id matches

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1021,7 +1021,8 @@ class ElastAlerter():
                 if aggregated_matches:
                     matches = [match_body] + [agg_match['match_body'] for agg_match in aggregated_matches]
                     self.alert(matches, rule, alert_time=alert_time)
-                    rule['current_aggregate_id'] = None
+                    if rule['current_aggregate_id'] == _id:
+                        rule['current_aggregate_id'] = None
                 else:
                     self.alert([match_body], rule, alert_time=alert_time)
 


### PR DESCRIPTION
In `send_pending_alerts`,  `rule['current_aggregate_id']` gets reset unconditionally when an pending alert is sent for a rule.
With this fix, the `current_aggregate_id` is only reset if the alert we just sent matches the current id.

Without this, we end up creating a new aggregation even if the current one hasn't reached its `alert_time`.