### PR TITLE
Changed max_query_size, run_every and buffer_time defaults

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -5,12 +5,12 @@ rules_folder: example_rules
 # How often ElastAlert will query elasticsearch
 # The unit can be anything from weeks to seconds
 run_every:
-  minutes: 5
+  minutes: 1
 
 # ElastAlert will buffer results from the most recent
 # period of time, in case some log sources are not in real time
 buffer_time:
-  minutes: 45
+  minutes: 15
 
 # The elasticsearch hostname for metadata writeback
 # Note that every rule can have it's own elasticsearch host

--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -129,7 +129,7 @@ configuration.
 ``writeback_index``: The index on ``es_host`` to use.
 
 ``max_query_size``: The maximum number of documents that will be downloaded from Elasticsearch in a single query. The
-default is 100,000, and if you expect to get near this number, consider using ``use_count_query`` for the rule. If this
+default is 10,000, and if you expect to get near this number, consider using ``use_count_query`` for the rule. If this
 limit is reached, a warning will be logged but ElastAlert will continue without downloading more results. This setting
 can be overridden by any individual rule.
 

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
+import copy
 import datetime
 import hashlib
 import logging
 import os
-import copy
 
 import alerts
 import enhancements
@@ -331,7 +331,7 @@ def load_rules(args):
     if required_globals - frozenset(conf.keys()):
         raise EAException('%s must contain %s' % (filename, ', '.join(required_globals - frozenset(conf.keys()))))
 
-    conf.setdefault('max_query_size', 100000)
+    conf.setdefault('max_query_size', 10000)
     conf.setdefault('disable_rules_on_error', True)
 
     # Convert run_every, buffer_time into a timedelta object

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -188,7 +188,7 @@ class MockElastAlerter(object):
                 'es_host': 'es',
                 'es_port': 14900,
                 'writeback_index': 'wb',
-                'max_query_size': 100000,
+                'max_query_size': 10000,
                 'old_query_limit': datetime.timedelta(weeks=1),
                 'disable_rules_on_error': False}
 


### PR DESCRIPTION
See https://github.com/Yelp/elastalert/issues/326

ES > 2.1 will not accept 100,000 size for queries. This will lower the default to 10,000. I also lowered the example buffer_time to just 15 minutes so that more documents can be effectively queried. The original intent of buffer_time was to compensate for latency in indexing, which I think 15 minutes still suffices as a default.

I also lowered run_every in config.yaml.example to 1 minute. I think most people care about faster latency and can adjust down if it's hammering Elasticsearch too hard.