### PR TITLE
Pass alert_time to alerters via pipeline

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -111,6 +111,8 @@ class Alerter(object):
 
     def __init__(self, rule):
         self.rule = rule
+        # pipeline object is created by ElastAlerter.send_alert()
+        # and attached to each alerters used by a rule before calling alert()
         self.pipeline = None
 
     def alert(self, match):

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -841,7 +841,7 @@ class ElastAlerter():
     def alert(self, matches, rule, alert_time=None):
         """ Wraps alerting, kibana linking and enhancements in an exception handler """
         try:
-            return self.send_alert(matches, rule, alert_time=None)
+            return self.send_alert(matches, rule, alert_time=alert_time)
         except Exception as e:
             self.handle_uncaught_exception(e, rule)
 
@@ -908,10 +908,10 @@ class ElastAlerter():
         # Run the alerts
         alert_sent = False
         alert_exception = None
-        alert_pipeline = {}
+        # Alert.pipeline is a single object shared between every alerter
+        # This allows alerters to pass objects and data between themselves
+        alert_pipeline = {"alert_time": alert_time}
         for alert in rule['alert']:
-            # Alert.pipeline is a single object shared between every alerter
-            # This allows alerters to pass objects and data between themselves
             alert.pipeline = alert_pipeline
             try:
                 alert.alert(matches)


### PR DESCRIPTION
This allows the alerters to use `alert_time` to display it or to calculate the timerange which the current alert covers.

It doesn't seem very 'clean' to pass alert metadata via a parameter named `pipeline`.
In fact, I was about to add a `metadata` object to the alerters when I saw that `pipeline`  did exactly what I wanted.

From my point of view, the `pipeline` object's purpose is to pass alert metadata from one alerter to the next, and we might as well use it if we want to pass more info from ElastAlerter.
With that in mind, what would you think of renaming that parameter to `metadata` ?