### PR TITLE
Add description field to rules.

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -38,6 +38,8 @@ Rule Configuration Cheat Sheet
 +--------------------------------------------------------------+           |
 | ``aggregation`` (time, no default)                           |           |
 +--------------------------------------------------------------+           |
+| ``description`` (string, default empty string)               |           |
++--------------------------------------------------------------+           |
 | ``generate_kibana_link`` (boolean, default False)            |           |
 +--------------------------------------------------------------+           |
 |``use_kibana_dashboard`` (string, no default)                 |           |
@@ -306,6 +308,12 @@ raw_count_keys
 ^^^^^^^^^^^^^^
 
 ``raw_count_keys``: If true, all fields in ``top_count_keys`` will have ``.raw`` appended to them. (Optional, boolean, default true)
+
+description
+^^^^^^^^^^^
+
+``description``: text describing the purpose of rule. (Optional, string, default empty string)
+Can be referenced in custom alerters to provide context as to why a rule might trigger.
 
 generate_kibana_link
 ^^^^^^^^^^^^^^^^^^^^

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -132,6 +132,7 @@ def load_options(rule, conf, args=None):
     rule.setdefault('use_local_time', True)
     rule.setdefault('es_port', conf.get('es_port'))
     rule.setdefault('es_host', conf.get('es_host'))
+    rule.setdefault('description', "")
 
     # Set timestamp_type conversion function, used when generating queries and processing hits
     rule['timestamp_type'] = rule['timestamp_type'].strip().lower()


### PR DESCRIPTION
Defaults to an empty string.
It is not currently used by the builtin alerters, but custom alerters could make use of it to include a description or some context as to why a rule might trigger.