### PR TITLE
Replace match all + post filter by filtered query

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -190,10 +190,11 @@ class ElastAlerter():
         starttime = to_ts_func(starttime)
         endtime = to_ts_func(endtime)
         filters = copy.copy(filters)
-        query = {'filter': {'bool': {'must': filters}}}
+        es_filters = {'filter': {'bool': {'must': filters}}}
         if starttime and endtime:
-            query['filter']['bool']['must'].append({'range': {timestamp_field: {'gt': starttime,
+            es_filters['filter']['bool']['must'].insert(0,{'range': {timestamp_field: {'gt': starttime,
                                                                                 'lte': endtime}}})
+        query = {'query': {'filtered': es_filters}}
         if sort:
             query['sort'] = [{timestamp_field: {'order': 'desc' if desc else 'asc'}}]
         return query


### PR DESCRIPTION
This is a proof of concept,  instead of using an implicit matchall query and applying a post filter, use a filtered query so that the filters get applied at query time.

See #327 for more background info. It give a major performance improvement in our case, but we're only using frequency rules at the moment, more tests would be welcome :)

(also, it breaks tests)