### PR TITLE
Change to cause elastalert to hit after the end time has been reached

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -8,6 +8,7 @@ import signal
 import sys
 import time
 import traceback
+import dateutil.tz
 from email.mime.text import MIMEText
 from smtplib import SMTP
 from smtplib import SMTPException
@@ -664,7 +665,15 @@ class ElastAlerter():
         elastalert_logger.info("Starting up")
         while self.running:
             next_run = datetime.datetime.utcnow() + self.run_every
+
             self.run_all_rules()
+            
+            # Quit after end_time has been reached
+            if hasattr(self.args, 'end'):
+                endtime = ts_to_dt(self.args.end)
+            
+                if next_run.replace(tzinfo=dateutil.tz.tzutc()) > endtime:
+                    exit(0)
 
             if next_run < datetime.datetime.utcnow():
                 continue

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -669,8 +669,8 @@ class ElastAlerter():
             self.run_all_rules()
             
             # Quit after end_time has been reached
-            if hasattr(self.args, 'end'):
-                endtime = ts_to_dt(self.args.end)
+            if self.args.end:
+                endtime = ts_to_dt(self.args.end)   
             
                 if next_run.replace(tzinfo=dateutil.tz.tzutc()) > endtime:
                     exit(0)

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -667,11 +667,11 @@ class ElastAlerter():
             next_run = datetime.datetime.utcnow() + self.run_every
 
             self.run_all_rules()
-            
+
             # Quit after end_time has been reached
             if self.args.end:
-                endtime = ts_to_dt(self.args.end)   
-            
+                endtime = ts_to_dt(self.args.end)
+
                 if next_run.replace(tzinfo=dateutil.tz.tzutc()) > endtime:
                     exit(0)
 


### PR DESCRIPTION
Currently Elastalert waits indefinitely after it has processed all events between the provided start time and end times which makes it difficult to use it in shell scripts.  This check causes Elastalert to exit if an end_time was provided and the next_run would occur after that end_time.