### PR TITLE
Add support for --start NOW

### DIFF
--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -175,7 +175,7 @@ search and alert metadata back to Elasticsearch.
 ``--start <timestamp>`` will force ElastAlert to begin querying from the given time, instead of the default,
 querying from the present. The timestamp should be ISO8601, e.g.  ``YYYY-MM-DDTHH:MM:SS`` (UTC) or with timezone
 ``YYYY-MM-DDTHH:MM:SS-08:00`` (PST). Note that if querying over a large date range, no alerts will be
-sent until that rule has finished querying over the entire time period.
+sent until that rule has finished querying over the entire time period. To force querying from the current time, use "NOW".
 
 ``--end <timestamp>`` will cause ElastAlert to stop querying at the specified timestamp. By default, ElastAlert
 will periodically query until the present indefinitely.

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -55,7 +55,8 @@ class ElastAlerter():
         parser.add_argument('--rule', dest='rule', help='Run only a specific rule (by filename, must still be in rules folder)')
         parser.add_argument('--silence', dest='silence', help='Silence rule for a time period. Must be used with --rule. Usage: '
                                                               '--silence <units>=<number>, eg. --silence hours=2')
-        parser.add_argument('--start', dest='start', help='YYYY-MM-DDTHH:MM:SS Start querying from this timestamp. (Default: present)')
+        parser.add_argument('--start', dest='start', help='YYYY-MM-DDTHH:MM:SS Start querying from this timestamp.'
+                                                          'Use "NOW" to start from current time. (Default: present)')
         parser.add_argument('--end', dest='end', help='YYYY-MM-DDTHH:MM:SS Query to this timestamp. (Default: present)')
         parser.add_argument('--verbose', action='store_true', dest='verbose', help='Increase verbosity without suppressing alerts')
         parser.add_argument('--pin_rules', action='store_true', dest='pin_rules', help='Stop ElastAlert from monitoring config file changes')
@@ -654,11 +655,14 @@ class ElastAlerter():
     def start(self):
         """ Periodically go through each rule and run it """
         if self.starttime:
-            try:
-                self.starttime = ts_to_dt(self.starttime)
-            except (TypeError, ValueError):
-                self.handle_error("%s is not a valid ISO8601 timestamp (YYYY-MM-DDTHH:MM:SS+XX:00)" % (self.starttime))
-                exit(1)
+            if self.starttime == 'NOW':
+                self.starttime = ts_now()
+            else:
+                try:
+                    self.starttime = ts_to_dt(self.starttime)
+                except (TypeError, ValueError):
+                    self.handle_error("%s is not a valid ISO8601 timestamp (YYYY-MM-DDTHH:MM:SS+XX:00)" % (self.starttime))
+                    exit(1)
         self.running = True
         elastalert_logger.info("Starting up")
         while self.running:


### PR DESCRIPTION
A few times I found myself wanting to set `starttime` to "now" to avoid sending old alerts.
I use this parameter mostly for testing, but I figured I'd propose it anyway.

Also, it is a bit confusing that the documentation says that the default is 'present' for that parameter.
From a quick read through the code, it seems that `now - buffer` is used for a rule that has never run,  or it continues from the `previous_endtime` if the rule has run before.