### PR TITLE
fix elasticsearch mapping for elastalert type

### DIFF
--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -69,6 +69,7 @@ def main():
                                                         '@timestamp': {'format': 'dateOptionalTime', 'type': 'date'}}}}
     es_mapping = {'elastalert': {'properties': {'rule_name': {'index': 'not_analyzed', 'type': 'string'},
                                                 '@timestamp': {'format': 'dateOptionalTime', 'type': 'date'},
+                                                'alert_time': {'format': 'dateOptionalTime', 'type': 'date'},
                                                 'match_body': {'enabled': False, 'type': 'object'},
                                                 'aggregate_id': {'index': 'not_analyzed', 'type': 'string'}}}}
     past_mapping = {'past_elastalert': {'properties': {'rule_name': {'index': 'not_analyzed', 'type': 'string'},


### PR DESCRIPTION
 add mapping for "alert_time", otherwise sorting on this field fails on ES2.x

The request 
GET /elastalert_status/elastalert/_search?size=1000
{
  "filter": {
    "range": {
      "alert_time": {
        "to": "2016-01-03T09:37:13.629493Z",
        "from": "2016-01-01T09:37:13.629470Z"
      }
    }
  },
  "query": {
    "query_string": {
      "query": "!_exists_:aggregate_id AND alert_sent:false"
    }
  },
  "sort": {
    "alert_time": {
      "order": "asc"
    }
  }
}

fails with:

{
   "error": {
      "root_cause": [
         {
            "type": "search_parse_exception",
            "reason": "No mapping found for [alert_time] in order to sort on"
         }
      ],
      "type": "search_phase_execution_exception",
      "reason": "all shards failed",
      "phase": "query",
      "grouped": true,
      "failed_shards": [
         {
            "shard": 0,
            "index": "elastalert_status",
            "node": "XXXXXXXXXXXX",
            "reason": {
               "type": "search_parse_exception",
               "reason": "No mapping found for [alert_time] in order to sort on"
            }
         }
      ]
   },
   "status": 400
}

and following warning is logged by elastalert:

WARNING:elasticsearch:GET /elastalert_status/elastalert/_search?size=1000 [status:400 request:0.107s]
