### PR TITLE
Updating OpsGenie library, documentation, and examples

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1025,13 +1025,19 @@ an alert, however it could be extended to update or close existing alerts.
 
 It is necessary for the user to create an OpsGenie Rest HTTPS API `integration page <https://app.opsgenie.com/integration>`_ in order to create alerts.
 
-The OpsGenie alert requires three options:
+The OpsGenie alert requires one option:
 
 ``opsgenie_key``: The randomly generated API Integration key created by OpsGenie.
+
+Optional:
 
 ``opsgenie_account``: The OpsGenie account to integrate with.
 
 ``opsgenie_recipients``: A list OpsGenie recipients who will be notified by the alert.
+
+``opsgenie_teams``: A list of OpsGenie teams to notify (useful for schedules with escalation).
+
+``opsgenie_tags``: A list of tags for this alert.
 
 SNS
 ~~~

--- a/elastalert/opsgenie.py
+++ b/elastalert/opsgenie.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
 import logging
-
 import requests
 from alerts import Alerter
 from alerts import BasicMatchString
@@ -11,14 +10,16 @@ from util import elastalert_logger
 
 class OpsGenieAlerter(Alerter):
     '''Sends a http request to the OpsGenie API to signal for an alert'''
-    required_options = frozenset(['opsgenie_key', 'opsgenie_account', 'opsgenie_recipients'])
+    required_options = frozenset(['opsgenie_key'])
 
     def __init__(self, *args):
         super(OpsGenieAlerter, self).__init__(*args)
 
-        self.account = self.rule.get('opsgenie_account', 'genie')
+        self.account = self.rule.get('opsgenie_account')
         self.api_key = self.rule.get('opsgenie_key', 'key')
-        self.recipients = self.rule.get('opsgenie_recipients', ['genies'])
+        self.recipients = self.rule.get('opsgenie_recipients')
+        self.teams = self.rule.get('opsgenie_teams')
+        self.tags = self.rule.get('opsgenie_tags', []) + ['ElastAlert', self.rule['name']]
         self.to_addr = self.rule.get('opsgenie_addr', 'https://api.opsgenie.com/v1/json/alert')
 
     def alert(self, matches):
@@ -32,10 +33,15 @@ class OpsGenieAlerter(Alerter):
         post = {}
         post['apiKey'] = self.api_key
         post['message'] = self.create_default_title(matches)
-        post['recipients'] = self.recipients
+        if self.account:
+            post['user'] = self.account
+        if self.recipients:
+            post['recipients'] = self.recipients
+        if self.teams:
+            post['teams'] = self.teams
         post['description'] = body
         post['source'] = 'ElastAlert'
-        post['tags'] = ['ElastAlert', self.rule['name']]
+        post['tags'] = self.tags
         logging.debug(json.dumps(post))
 
         try:
@@ -62,5 +68,12 @@ class OpsGenieAlerter(Alerter):
         return subject
 
     def get_info(self):
-        return {'type': 'opsgenie',
-                'recipients': self.recipients}
+        ret = {'type': 'opsgenie'}
+        if self.recipients:
+            ret['recipients'] = self.recipients
+        if self.account:
+            ret['account'] = self.account
+        if self.teams:
+            ret['teams'] = self.teams
+
+        return ret

--- a/example_rules/example_opsgenie_frequency.yaml
+++ b/example_rules/example_opsgenie_frequency.yaml
@@ -9,11 +9,27 @@ es_host: localhost
 es_port: 9200
 
 # (Required)
-# OpsGenie credentials and recipient targeting configuration
+# OpsGenie credentials
 opsgenie_key: ogkey
-opsgenie_account: neh
-opsgenie_recipients: 
-  - "neh"
+
+# (Optional)
+# OpsGenie user account that the alert will show as created by
+#opsgenie_account: neh
+
+# (Optional)
+# OpsGenie recipients of the alert
+#opsgenie_recipients:
+#  - "neh"
+
+# (Optional)
+# OpsGenie teams to notify
+#opsgenie_teams:
+#  - "Infrastructure"
+
+# (Optional)
+# OpsGenie alert tags
+opsgenie_tags:
+  - "Production"
 
 # (OptionaL) Connect with SSL to elasticsearch
 #use_ssl: True


### PR DESCRIPTION
Howdy!
This PR adds some functionality to the OpsGenie library - we use Teams for our escalation policies in OpsGenie at my employer, so I've added the ability to set that using ElastAlert rules.

I've also added the ability to set the tags that the alerts send, since in some cases you might have filters set up for alerts in the OpsGenie dashboard (such as 'production' or 'development').

The code contained support for 'opsgenie_account', but it wasn't actually sent to OpsGenie in the POST request. I've added it to the code as well.

I have updated the documentation and sample rule to reflect these changes.

Please let me know if you have any questions.

Thanks!