### PR TITLE
Added ability for required options to be split between inline and global

### DIFF
--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -300,10 +300,9 @@ def load_alerts(rule, alert_field):
         for (alert_config, alert) in inline_alerts:
             copied_conf = copy.copy(rule)
             rule_reqs = alert.required_options
-            if rule_reqs - frozenset(alert_config.keys()):
-                raise EAException('Missing required option(s): %s' % (', '.join(rule_reqs - frozenset(rule.keys()))))
-
             copied_conf.update(alert_config)
+            if rule_reqs - frozenset(copied_conf.keys()):
+                raise EAException('Missing required option(s): %s' % (', '.join(rule_reqs - frozenset(copied_conf.keys()))))
             alert_field.append(alert(copied_conf))
 
         for alert in global_alerts:


### PR DESCRIPTION
The requirements were previously checked against only the inline alert configuration, even though the they can be used at the top level.

For example, if you have something like
```
jira_server: jira.com
alert:
- jira:
    jira_project: "foo"
- jira:
    jira_project: "bar"
```
it would have complained about jira_server being missing, even though it can be shared between alerts.