### PR TITLE
[FIX] : Require croniter as an install dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'pyyaml',
         'simplejson',
         'boto',
-        'blist'
+        'blist',
+        'croniter'
     ]
 )


### PR DESCRIPTION
**PYTHON NEWBIE ALERT** :smile: 

I've faced a dependecy error with master after #302 has been merged.

When running elastalert, I got this error:

```
Starting Elastalert...
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/opt/elastalert/elastalert/elastalert.py", line 16, in <module>
    from croniter import croniter
ImportError: No module named croniter
```

I am installing dependencies with the following commads:
```
python setup.py install
pip install -e . 
```

Probably it's my fault because I don´t install dependencies with the right command, but after fighting with it  for a few hours, I found the solution on this PR.