### PR TITLE
Updating requirements

### DIFF
--- a/docs/source/running_elastalert.rst
+++ b/docs/source/running_elastalert.rst
@@ -7,7 +7,7 @@ Requirements
 ------------
 
 - pip
-- Elasticsearch 1.*
+- Elasticsearch > 1.*
 - ISO8601 timestamped data
 - Python 2.6
 


### PR DESCRIPTION
Elasticsearch greater than 1.* should be stated - I'm running on 2.1 with no issues.

Also working on Python 2.7 which runs fine, might want to add that in as well. Haven't read enough of the source but would this work for 3.x?