### PR TITLE
Fixed duplicate alerts when using new_term

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -565,6 +565,7 @@ class NewTermsRule(RuleType):
                                  self.rules['timestamp_field']: timestamp,
                                  'new_field': field}
                         self.add_match(match)
+                        self.seen_values[field].append(bucket['key'])
 
 
 class CardinalityRule(RuleType):


### PR DESCRIPTION
Fixes a bug when using new_term and use_terms_data where the same term would cause alerts to fire over and over again.

See equivalent code just 14 lines up in add_data.