### PR TITLE
Opsgenie custom message

### DIFF
--- a/elastalert/opsgenie.py
+++ b/elastalert/opsgenie.py
@@ -21,7 +21,7 @@ class OpsGenieAlerter(Alerter):
         self.recipients = self.rule.get('opsgenie_recipients', ['genies'])
         self.to_addr = self.rule.get('opsgenie_addr', 'https://api.opsgenie.com/v1/json/alert')
         self.custom_message = self.rule.get('opsgenie_message')
-        self.set_alias = self.rule.get('opsgenie_set_alias', False)
+        self.alias = self.rule.get('opsgenie_alias')
 
     def alert(self, matches):
         body = ''
@@ -35,7 +35,7 @@ class OpsGenieAlerter(Alerter):
             self.message = self.create_default_title(matches)
         else:
             self.message = self.custom_message.format(**matches[0])
-
+        
         post = {}
         post['apiKey'] = self.api_key
         post['message'] = self.message
@@ -44,8 +44,8 @@ class OpsGenieAlerter(Alerter):
         post['source'] = 'ElastAlert'
         post['tags'] = ['ElastAlert', self.rule['name']]
 
-        if self.set_alias:
-            post['alias'] = self.message
+        if self.alias is not None:
+            post['alias'] = self.alias.format(**matches[0])
 
         logging.debug(json.dumps(post))
 

--- a/elastalert/opsgenie.py
+++ b/elastalert/opsgenie.py
@@ -31,12 +31,12 @@ class OpsGenieAlerter(Alerter):
             # Separate text of aggregated alerts with dashes
             if len(matches) > 1:
                 body += '\n----------------------------------------\n'
-        
+
         if self.custom_message is None:
             self.message = self.create_default_title(matches)
         else:
             self.message = self.custom_message.format(**matches[0])
-        
+
         post = {}
         post['apiKey'] = self.api_key
         post['message'] = self.message

--- a/elastalert/opsgenie.py
+++ b/elastalert/opsgenie.py
@@ -21,6 +21,7 @@ class OpsGenieAlerter(Alerter):
         self.recipients = self.rule.get('opsgenie_recipients', ['genies'])
         self.to_addr = self.rule.get('opsgenie_addr', 'https://api.opsgenie.com/v1/json/alert')
         self.custom_message = self.rule.get('opsgenie_message')
+        self.set_alias = self.rule.get('opsgenie_set_alias', False)
 
     def alert(self, matches):
         body = ''
@@ -42,6 +43,10 @@ class OpsGenieAlerter(Alerter):
         post['description'] = body
         post['source'] = 'ElastAlert'
         post['tags'] = ['ElastAlert', self.rule['name']]
+
+        if self.set_alias:
+            post['alias'] = self.message
+
         logging.debug(json.dumps(post))
 
         try:

--- a/elastalert/opsgenie.py
+++ b/elastalert/opsgenie.py
@@ -20,6 +20,7 @@ class OpsGenieAlerter(Alerter):
         self.api_key = self.rule.get('opsgenie_key', 'key')
         self.recipients = self.rule.get('opsgenie_recipients', ['genies'])
         self.to_addr = self.rule.get('opsgenie_addr', 'https://api.opsgenie.com/v1/json/alert')
+        self.custom_message = self.rule.get('opsgenie_message')
 
     def alert(self, matches):
         body = ''
@@ -28,10 +29,15 @@ class OpsGenieAlerter(Alerter):
             # Separate text of aggregated alerts with dashes
             if len(matches) > 1:
                 body += '\n----------------------------------------\n'
+        
+        if self.custom_message is None:
+            self.message = self.create_default_title(matches)
+        else:
+            self.message = self.custom_message.format(**matches[0])
 
         post = {}
         post['apiKey'] = self.api_key
-        post['message'] = self.create_default_title(matches)
+        post['message'] = self.message
         post['recipients'] = self.recipients
         post['description'] = body
         post['source'] = 'ElastAlert'


### PR DESCRIPTION
I added in two fields for the OpsGenie alert.

1. opsgenie_message
This allows the OpsGenie message to be set to something other than the rule name. The message can be formatted using the first match.

2. opsgenie_alias
This allows the OpsGenie alias to be set. It can also be formatted using the first match.