### PR TITLE
Fixed bug where send_notify_email would crash on new rule errors

### DIFF
--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -728,7 +728,7 @@ def test_rule_changes(ea):
                 mock_load.return_value = {'filter': [], 'name': 'rule3', 'new': 'stuff', 'rule_file': 'rules/rule4.yaml'}
                 mock_hashes.return_value = new_hashes
                 ea.load_rule_changes()
-                mock_send.assert_called_once()
+                mock_send.assert_called_once_with(exception=mock.ANY, rule_file='rules/rule4.yaml')
     assert len(ea.rules) == 3
     assert not any(['new' in rule for rule in ea.rules])
 


### PR DESCRIPTION
If an error occurs, new_rule will not exist. Instead, we can use the file name to help clarify the error message. All it previously used was the rule name, so the file name should also be sufficient.