### PR TITLE
HipchatAlerter: solving issue with long messages giving 400 bad request.

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -515,7 +515,7 @@ class HipChatAlerter(Alerter):
                 body += '\n----------------------------------------\n'
 
         # Hipchat sends 400 bad request on messages longer than 10000 characters
-        if (len(body) > 9999)
+        if (len(body) > 9999):
             body = body[:9980] + '..(truncated)'
 
         # post to hipchat

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -514,6 +514,10 @@ class HipChatAlerter(Alerter):
             if len(matches) > 1:
                 body += '\n----------------------------------------\n'
 
+        # Hipchat sends 400 bad request on messages longer than 10000 characters
+        if (len(body) > 9980)
+            body = body[:9980] + '..(truncated)'
+
         # post to hipchat
         headers = {'content-type': 'application/json'}
         payload = {

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -515,7 +515,7 @@ class HipChatAlerter(Alerter):
                 body += '\n----------------------------------------\n'
 
         # Hipchat sends 400 bad request on messages longer than 10000 characters
-        if (len(body) > 9980)
+        if (len(body) > 9999)
             body = body[:9980] + '..(truncated)'
 
         # post to hipchat


### PR DESCRIPTION
Hipchat sends 400 bad request on posts with messages>10000 characters.
(https://www.hipchat.com/docs/api/method/rooms/message).

This lead to:
ERROR:root:Error while running alert hipchat: Error posting to hipchat: 400 Client Error: Bad Request
on one of my projects rules posting errors from an application-log due to a very long java stacktrace.

Solved by truncating messages that are too long to be accepted by hipchat.