### PR TITLE
Add Dockerfile for an Alpine Linux based image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:latest
+
+RUN apk update && apk upgrade && \
+   apk add tzdata python py-yaml curl wget bash python-dev git && \
+   apk add build-base && \ 
+   # Install setuptools
+   curl https://bootstrap.pypa.io/ez_setup.py -o - | python && \
+   # install supervisord
+   easy_install supervisor && \
+   # Checkout Yelp/elastalert
+   mkdir -p /usr/src && \
+   cd /usr/src/ && \
+   git clone https://github.com/Yelp/elastalert.git && \
+   # Build elastalert
+   cd /usr/src/elastalert/ && \
+   python setup.py install && \
+   # Setup config directory
+   sed -i 's/example_rules/rules/g' config.yaml.example && \
+   mkdir -p /opt/elastalert/rules && \
+   mv config.yaml.example /opt/elastalert/config.yaml && \
+   mv supervisord.conf.example /opt/elastalert/supervisord.conf && \
+   sed -i -e 's/nodaemon=false/nodaemon=true/' /opt/elastalert/supervisord.conf && \
+   ln -s $(find /usr/lib/python* -name elastalert.py) /opt/elastalert/elastalert.py && \
+   # Include example_rules folder
+   mkdir -p /opt/elastalert/example_rules && \
+   cp example_rules/* /opt/elastalert/example_rules/ && \
+   # Remove files to save space
+   cd / && \
+   rm -rf /usr/src/elastalert && \
+   apk del python-dev git && \
+   rm -rf /var/cache/apk/* && \
+   cp /usr/share/zoneinfo/America/New_York /etc/localtime && \
+   echo "America/New_York" >  /etc/timezone && \
+   echo "EST5EDT" >  /etc/TZ && \ 
+   apk del build-base
+
+WORKDIR /opt/elastalert
+
+ONBUILD COPY config.yaml /opt/elastalert/config.yaml
+ONBUILD COPY rules/* /opt/elastalert/rules/
+VOLUME ["/opt/elastalert"]
+VOLUME ["/var/log"]
+
+CMD ["supervisord","-c","/opt/elastalert/supervisord.conf"]
+
+COPY Dockerfile /Dockerfile


### PR DESCRIPTION
I've been using a small (65Mb) elastalert Docker image for basic monitoring on our test EFK stack (Elasticsearch-Fluentd-Kibana). The image clones the Yelp/elastalert repo and builds everything from source. To build it:

`docker build --no-cache=true -t elastalert:onbuild .`

The resulting image can be the base for an environment specific image: a new Dockerfile (below) must reference it, and the config.yaml and rules (inside a /rules folder) would be added as a new layer.

`FROM elastalert:onbuild`

The image can also be executed with a mounted config.yaml and rules folder. First step is creating the ES index for elastalert:

`docker run --rm -v /opt/elastalert/config.yaml:/opt/elastalert/config.yaml -v /opt/elastalert/rules:/opt/elastalert/rules elastalert:onbuild bash -c "elastalert-create-index"`

and then run a container:

`docker run -d --name elastalert -v /opt/elastalert/config.yaml:/opt/elastalert/config.yaml -v /opt/elastalert/rules:/opt/elastalert/rules elastalert:onbuild`

Although my current approach is mounting rules and config from a local volume, some additional ENV variables could be added to customize it (i.e. retrieve config.yaml from a remote URL, ES url, etc)

Might be a starting point for a small, official image in the future. Thoughts?

Gerardo