### PR TITLE
copy es username, password global configs into rule

### DIFF
--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -134,6 +134,8 @@ def load_options(rule, conf, args=None):
     rule.setdefault('use_local_time', True)
     rule.setdefault('es_port', conf.get('es_port'))
     rule.setdefault('es_host', conf.get('es_host'))
+    rule.setdefault('es_username', conf.get('es_username'))
+    rule.setdefault('es_password', conf.get('es_password'))
     rule.setdefault('max_query_size', conf.get('max_query_size'))
     rule.setdefault('description', "")
 


### PR DESCRIPTION
Hi,
Made this PR so that user wont need to specific `es_username` and `es_password` in every rules' configs.
Thanks !