### PR TITLE
Fix process events for testing locally

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -248,6 +248,7 @@ class ElastAlerter():
                 # Except sometimes they aren't lists. This is dependent on ES version
                 hit['_source'].setdefault(key, value[0] if type(value) is list and len(value) == 1 else value)
             hit['_source'][rule['timestamp_field']] = rule['ts_to_dt'](hit['_source'][rule['timestamp_field']])
+            hit[rule['timestamp_field']] = hit['_source'][rule['timestamp_field']]
 
             # Tack metadata fields into _source
             for field in ['_id', '_index', '_type']:


### PR DESCRIPTION
When running `elastalert-test-rule` to test a rule that overrides the timestamp field as '@timestamp', hits are received, but they can't be processed:

```
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/dmilanp/project/Repos/elastalert/elastalert/test_rule.py", line 292, in <module>
    main()
  File "/Users/dmilanp/project/Repos/elastalert/elastalert/test_rule.py", line 289, in main
    test_instance.run_rule_test()
  File "/Users/dmilanp/project/Repos/elastalert/elastalert/test_rule.py", line 284, in run_rule_test
    self.run_elastalert(rule_yaml, args)
  File "/Users/dmilanp/project/Repos/elastalert/elastalert/test_rule.py", line 251, in run_elastalert
    client.run_rule(rule, endtime, starttime)
  File "elastalert/elastalert.py", line 530, in run_rule
    if not self.run_query(rule, rule['starttime'], tmp_endtime):
  File "elastalert/elastalert.py", line 414, in run_query
    data = self.remove_duplicate_events(data, rule)
  File "elastalert/elastalert.py", line 374, in remove_duplicate_events
    rule['processed_hits'][event['_id']] = event[rule['timestamp_field']]
KeyError: '@timestamp'
```

The problem is that the timestamp field is correctly substituted by @timestamp, and inserted into the _source attribute of each event (process_hits static method, in elastalert.py), but it is unavailable for the event overall:

```
event: {'_id': 'IfpWtmOQguAuYpfH', '_source': {'bulk.rejected': '0', '@timestamp': datetime.datetime(2016, 3, 7, 11, 6, 27, 583087, tzinfo=tzutc()), 'App_id': 'es.health', 'search.active': '0', 'cluster': 'production', 'host': 'my.host.project.net', '_id': 'IfpWtmOQguAuYpfH', 'search.completed': '0', 'search.rejected': '0'}}
```

Note that if we change
`rule['processed_hits'][event['_id']] = event[rule['timestamp_field']]`
for
`rule['processed_hits'][event['_id']] = event['_source'][rule['timestamp_field']]` the problem is fixed there, but arises again:

```
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/dmilanp/project/Repos/elastalert/elastalert/test_rule.py", line 292, in <module>
    main()
  File "/Users/dmilanp/project/Repos/elastalert/elastalert/test_rule.py", line 289, in main
    test_instance.run_rule_test()
  File "/Users/dmilanp/project/Repos/elastalert/elastalert/test_rule.py", line 284, in run_rule_test
    self.run_elastalert(rule_yaml, args)
  File "/Users/dmilanp/project/Repos/elastalert/elastalert/test_rule.py", line 251, in run_elastalert
    client.run_rule(rule, endtime, starttime)
  File "elastalert/elastalert.py", line 522, in run_rule
    if not self.run_query(rule, rule['starttime'], tmp_endtime):
  File "elastalert/elastalert.py", line 417, in run_query
    rule_inst.add_data(data)
  File "elastalert/ruletypes.py", line 205, in add_data
    self.occurrences.setdefault(key, EventWindow(self.rules['timeframe'], getTimestamp=self.get_ts)).append((event, 1))
  File "elastalert/ruletypes.py", line 261, in append
    self.data.add(event)
  File "/Users/dmilanp/project/Repos/elastalert/venv/lib/python2.7/site-packages/blist/_sortedlist.py", line 137, in add
    i, _ = self._bisect_right(value)
  File "/Users/dmilanp/project/Repos/elastalert/venv/lib/python2.7/site-packages/blist/_sortedlist.py", line 99, in _bisect_right
    key = self._u2key(v)
  File "/Users/dmilanp/project/Repos/elastalert/venv/lib/python2.7/site-packages/blist/_sortedlist.py", line 50, in _u2key
    return self._key(value)
  File "elastalert/ruletypes.py", line 170, in <lambda>
    self.get_ts = lambda event: event[0][self.ts_field]
KeyError: '@timestamp'
```

A way of fixing the problem is mofifying the `process_hits` staticmethod:

```
  hit['_source'][rule['timestamp_field']] = rule['ts_to_dt'](hit['_source'][rule['timestamp_field']])
+ hit[rule['timestamp_field']] = hit['_source'][rule['timestamp_field']]
```

This makes tests run successfully.