### PR TITLE
Add alert_text_kw for keyword templating

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -865,7 +865,7 @@ There are several ways to format the body text of the various types of events. I
     field_values        = Field, ": ", Value
 
 Similarly to ``alert_subject``, ``alert_text`` can be further formatted using standard Python formatting syntax.
-The field names whose values will be used as the arguments can be passed with ``alert_text_args``.
+The field names whose values will be used as the arguments can be passed with ``alert_text_args`` or ``alert_text_kw``.
 
 By default::
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -36,12 +36,20 @@ class BasicMatchString(object):
             self.text += '\n'
 
     def _add_custom_alert_text(self):
+        missing = '<MISSING VALUE>'
         alert_text = unicode(self.rule.get('alert_text', ''))
         if 'alert_text_args' in self.rule:
             alert_text_args = self.rule.get('alert_text_args')
             alert_text_values = [lookup_es_key(self.match, arg) for arg in alert_text_args]
-            alert_text_values = ['<MISSING VALUE>' if val is None else val for val in alert_text_values]
+            alert_text_values = [missing if val is None else val for val in alert_text_values]
             alert_text = alert_text.format(*alert_text_values)
+        elif 'alert_text_kw' in self.rule:
+            kw = {}
+            for name, kw_name in self.rule.get('alert_text_kw').items():
+                val = lookup_es_key(self.match, name)
+                kw[kw_name] = missing if val is None else val
+            alert_text = alert_text.format(**kw)
+
         self.text += alert_text
 
     def _add_rule_text(self):

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -152,6 +152,7 @@ properties:
   # Alert Content
   alert_text: {type: string} # Python format string
   alert_text_args: {type: array, items: {type: string}}
+  alert_text_kw: {type: object}
   alert_text_type: {enum: [alert_text_only, exclude_fields]}
   timestamp_field: {type: string}
   field: {}

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -511,3 +511,16 @@ def test_slack_uses_rule_name_when_custom_title_is_not_provided():
         ]
     }
     mock_post_request.assert_called_once_with(rule['slack_webhook_url'], data=json.dumps(expected_data), headers={'content-type': 'application/json'}, proxies=None)
+
+
+def test_alert_text_kw(ea):
+    rule = ea.rules[0].copy()
+    rule['alert_text'] = '{field} at {time}'
+    rule['alert_text_kw'] = {
+        '@timestamp': 'time',
+        'field': 'field',
+    }
+    match = {'@timestamp': '1918-01-17', 'field': 'value'}
+    alert_text = unicode(BasicMatchString(rule, match))
+    body = '{field} at {@timestamp}'.format(**match)
+    assert body in alert_text


### PR DESCRIPTION
This allows writing template with names and not positions which makes the template more readable.

New field `alert_text_kw` is a mapping of `match key` -> `template key`.