### PR TITLE
Added debug warning

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -73,11 +73,11 @@ class ElastAlerter():
         self.debug = self.args.debug
         self.verbose = self.args.verbose
 
-        if self.debug:
-            self.verbose = True
-
-        if self.verbose:
+        if self.verbose or self.debug:
             elastalert_logger.setLevel(logging.INFO)
+
+        if self.debug:
+            elastalert_logger.info("Note: In debug mode, alerts will be logged to console but NOT actually sent. To send them, use --verbose.")
 
         if not self.args.es_debug:
             logging.getLogger('elasticsearch').setLevel(logging.WARNING)


### PR DESCRIPTION
Adds a warning. Lots of people are confused when they use ``--debug`` and no alerts come.
Note: self.verbose is not used anywhere else in this code.