### PR TITLE
Signed requests to AWS, so requests can be authenticated.

### DIFF
--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -158,6 +158,10 @@ unless overwritten in the rule config. The default is "localhost".
 
 ``email_reply_to``: This sets the Reply-To header in emails. The default is the recipient address.
 
+``aws_region``: This makes ElastAlert to sign HTTP requests when using Amazon ElasticSearch Service. It'll use instance role keys to sign the requests.
+
+``boto_profile``: Boto profile to use when signing requests to Amazon ElasticSearch Service, if you don't want to use the instance role keys.
+
 .. _runningelastalert:
 
 Running ElastAlert

--- a/docs/source/recipes/signing_requests.rst
+++ b/docs/source/recipes/signing_requests.rst
@@ -1,0 +1,22 @@
+.. _signingrequests:
+
+Signing requests to Amazon ElasticSearch service
+============
+
+When using Amazon ElasticSearch service, you need to secure your ElasticSearch from the outside.
+Currently, there is no way to secure your ElasticSearch using network firewall rules, so the only way is to signing the requests using the access key and secret key for a role or user with permissions on the ElasticSearch service.
+
+We offer two different options to sign ElastAlert requests to ElasticSearch: using instance roles and boto profiles.
+
+Using instance role
+-------------------
+Typically, you'll deploy ElastAlert on a running EC2 instance on AWS. You can assign a role to this instance that gives it permissions to read from and write to the ElasticSearch service.
+Then you just need to add the ``aws_region`` option to the configuration file. This will tell ElastAlert to sign the requests to ElasticSearch.
+
+Using boto profiles
+--------------------
+You can also create a user with permissions on the ElasticSearch service and tell ElastAlert to authenticate itself using that user.
+First, create a boto profile in the machine where you'd like to run ElastAlert for the user with permissions. Then, just add two options to the configuration file:
+- ``aws_region``: that tells ElastAlert to sign the requests to ElasticSearch. It's the AWS region where you want to operate.
+- ``boto_profile``: with the name of the boto profile to use to sign the requests.
+

--- a/elastalert/auth.py
+++ b/elastalert/auth.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+import os
+import configparser
+
+from aws_requests_auth.aws_auth import AWSRequestsAuth
+
+from botocore.credentials import InstanceMetadataProvider, InstanceMetadataFetcher
+
+
+class Auth(object):
+
+    def __call__(self, host, username, password, aws_region, boto_profile):
+        """ Return the authorization header. If 'boto_profile' is passed, it'll be used. Otherwise it'll sign requests
+        with instance role.
+
+        :param host: ElasticSearch host.
+        :param username: Username used for authenticating the requests to ElasticSearch.
+        :param password: Password used for authenticating the requests to ElasticSearch.
+        :param aws_region: AWS Region to use. Only required when signing requests.
+        :param boto_profile: Boto profile to use for connecting. Only required when signing requests.
+        """
+        if username and password:
+            return username + ':' + password
+
+        if not aws_region:
+            return None
+
+        if boto_profile:
+            # Executing elastalert from machine with aws credentials
+            config = configparser.ConfigParser()
+            config.read(os.path.expanduser('~') + '/.aws/credentials')
+            aws_access_key_id = str(config[boto_profile]['aws_access_key_id'])
+            aws_secret_access_key = str(config[boto_profile]['aws_secret_access_key'])
+            aws_token = None
+        else:
+            # Executing elastalert from machine deployed with specific role
+            provider = InstanceMetadataProvider(
+                iam_role_fetcher=InstanceMetadataFetcher(timeout=1000, num_attempts=2))
+            aws_credentials = provider.load()
+            aws_access_key_id = str(aws_credentials.access_key)
+            aws_secret_access_key = str(aws_credentials.secret_key)
+            aws_token = str(aws_credentials.token)
+
+        return AWSRequestsAuth(aws_access_key=aws_access_key_id,
+                               aws_secret_access_key=aws_secret_access_key,
+                               aws_token=aws_token,
+                               aws_host=host,
+                               aws_region=aws_region,
+                               aws_service='es')

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -9,7 +9,7 @@ import time
 
 import argparse
 import yaml
-from elasticsearch.client import Elasticsearch
+from elasticsearch.client import Elasticsearch, IndicesClient
 from elasticsearch import RequestsHttpConnection
 from auth import Auth
 
@@ -103,6 +103,11 @@ def main():
         print('Downloading existing data...')
         res = es.search(index=old_index, body={}, size=500000)
         print('Got %s documents' % (len(res['hits']['hits'])))
+
+    es_index = IndicesClient(es)
+    if es_index.exists(index):
+        print('Index ' + index + ' already exists. Skipping index creation.')
+        return None
 
     es.indices.create(index)
     # To avoid a race condition. TODO: replace this with a real check

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ PyYAML==3.11
 argparse==1.3.0
 blist==1.3.6
 boto==2.34.0
+botocore==1.4.5
 elasticsearch==1.3.0
 jira==0.32
 jsonschema==2.2.0
@@ -19,3 +20,5 @@ unittest2==0.8.0
 urllib3==1.8.2
 wsgiref==0.1.2
 croniter==0.3.8
+configparser==3.5.0b2
+aws-requests-auth==0.2.5

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,10 @@ setup(
         'pyyaml',
         'simplejson',
         'boto',
+        'botocore',
         'blist',
-        'croniter'
+        'croniter',
+        'configparser',
+        'aws-requests-auth'
     ]
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ class mock_alert(object):
 @pytest.fixture
 def ea():
     rules = [{'es_host': '',
-              'es_port': '',
+              'es_port': 14900,
               'name': 'anytest',
               'index': 'idx',
               'filter': [],


### PR DESCRIPTION
We are currently using AWS ElasticSearch and it's not possible to secure that service via network rules. The only way of sending secure requests to the service is by signing the requests with the authorization header, using the credentials of an AWS IAM user/role, with permissions on the AWS ElasticSearch service.

Since the authorization logic gets a little bit more complex, I've extracted that logic into its own class called `Auth`, that returns the right header depending on your credentials. This object support four different use cases:
- You don't want authorization header, so you don't pass `username`, `password` nor `aws_region`.
- You pass username and password to achieve basic authentication.
- You've deployed elastalert on an EC2 machine with an specific role, so you need to sign requests using that role's credentials. You just need to pass the `aws_region` argument.
- You need to sign requests and you are executing elastalert from your own machine, so you use a boto_profile passing the `boto_profile` argument.

If you guys think the code could be improved, just let me know!
Thank you.