### PR TITLE
Check for NoneType hits_terms

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -60,9 +60,14 @@ class BasicMatchString(object):
             if key.startswith('top_events_'):
                 self.text += '%s:\n' % (key[11:])
                 top_events = counts.items()
-                top_events.sort(key=lambda x: x[1], reverse=True)
-                for term, count in top_events:
-                    self.text += '%s: %s\n' % (term, count)
+
+                if not top_events:
+                    self.text += 'No events found.\n'
+                else:
+                    top_events.sort(key=lambda x: x[1], reverse=True)
+                    for term, count in top_events:
+                        self.text += '%s: %s\n' % (term, count)
+
                 self.text += '\n'
 
     def _add_match_items(self):

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -893,3 +893,16 @@ def test_uncaught_exceptions(ea):
     with mock.patch.object(ea, 'send_notification_email') as mock_email:
         ea.handle_uncaught_exception(e, ea.rules[0])
     assert mock_email.call_args_list[0][1] == {'exception': e, 'rule': ea.disabled_rules[0]}
+
+
+def test_get_top_counts_handles_no_hits_returned(ea):
+    with mock.patch.object(ea, 'get_hits_terms') as mock_hits:
+        mock_hits.return_value = None
+
+        rule = ea.rules[0]
+        starttime = datetime.datetime.now() - datetime.timedelta(minutes=10)
+        endtime = datetime.datetime.now()
+        keys = ['foo']
+
+        all_counts = ea.get_top_counts(rule, starttime, endtime, keys)
+        assert all_counts == {'top_events_foo': {}}


### PR DESCRIPTION
PR to address #450. This should prevent the `NoneType` error that occurs when `get_hits_terms` returns `None`. I also chose to edit the top counts text that gets displayed so that it doesn't appear empty.

Let me know if there's anything that should be changed, and thanks for this tool!