### PR TITLE
Set `es_conn_timeout` in rule conf

### DIFF
--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -137,6 +137,7 @@ def load_options(rule, conf, args=None):
     rule.setdefault('es_username', conf.get('es_username'))
     rule.setdefault('es_password', conf.get('es_password'))
     rule.setdefault('max_query_size', conf.get('max_query_size'))
+    rule.setdefault('es_conn_timeout', conf.get('es_conn_timeout'))
     rule.setdefault('description', "")
 
     # Set timestamp_type conversion function, used when generating queries and processing hits


### PR DESCRIPTION
The rule configuration currently does not inherit the base config's setting for `es_conn_timeout` so the `Elasticsearch` instance created in each `run_rule` call via `new_elasticsearch` doesn't use the timeout specified in the config.

This was causing an issue where I had set `es_conn_timeout` in `config.yaml`, used that config using the `--config` flag but ended up with a 10 second timeout.