### PR TITLE
Fix NewTermsRule to use the lookup_es_key api which handles nested field names correctly

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -545,7 +545,7 @@ class NewTermsRule(RuleType):
     def add_data(self, data):
         for document in data:
             for field in self.fields:
-                value = document.get(field)
+                value = lookup_es_key(document, field)
                 if not value and self.rules.get('alert_on_missing_field'):
                     document['missing_field'] = field
                     self.add_match(document)

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -509,7 +509,7 @@ def test_new_term():
 
 
 def test_new_term_nested_field():
-    
+
     rules = {'fields': ['a', 'b.c'],
              'timestamp_field': '@timestamp',
              'es_host': 'example.com', 'es_port': 10, 'index': 'logstash'}
@@ -522,24 +522,12 @@ def test_new_term_nested_field():
 
         assert rule.es.search.call_count == 2
 
-    # Key1 and key2 shouldn't cause a match
-    rule.add_data([{'@timestamp': ts_now(), 'a': 'key1', 'b': {'c': 'key2'}}])
-    assert rule.matches == []
-
-    # Neither will missing values
-    rule.add_data([{'@timestamp': ts_now(), 'a': 'key2'}])
-    assert rule.matches == []
-
     # Key3 causes an alert for nested field b.c
-    rule.add_data([{'@timestamp': ts_now(), 'a': 'key2', 'b': {'c': 'key3'}}])
+    rule.add_data([{'@timestamp': ts_now(), 'b': {'c': 'key3'}}])
     assert len(rule.matches) == 1
     assert rule.matches[0]['new_field'] == 'b.c'
     assert rule.matches[0]['b']['c'] == 'key3'
     rule.matches = []
-
-    # Key3 doesn't cause another alert for nested field b.c
-    rule.add_data([{'@timestamp': ts_now(), 'a': 'key2', 'b.c': 'key3'}])
-    assert rule.matches == []
 
 
 def test_new_term_with_terms():


### PR DESCRIPTION
Nested field names did not work properly for NewTermsRule.  I fixed NewTermsRule::add_data to use lookup_es_key instead of a raw dictionary lookup, and added a new test to prove that it works correctly.