### PR TITLE
Downgraded dateutil to be python2.X compatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,18 @@
 PyStaticConfiguration==0.9.0
 PyYAML==3.11
 argparse==1.3.0
+aws-requests-auth==0.2.5
 blist==1.3.6
 boto==2.34.0
 botocore==1.4.5
+configparser==3.5.0b2
+croniter==0.3.8
 elasticsearch==1.3.0
 jira==0.32
 jsonschema==2.2.0
 mock==1.0.0
 oauthlib==0.7.2
-python-dateutil==2.4.0
+python-dateutil==1.5
 requests==2.5.1
 requests-oauthlib==0.4.2
 simplejson==3.6.5
@@ -19,6 +22,3 @@ tlslite==0.4.8
 unittest2==0.8.0
 urllib3==1.8.2
 wsgiref==0.1.2
-croniter==0.3.8
-configparser==3.5.0b2
-aws-requests-auth==0.2.5

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'jira==0.32',  # jira.exceptions is missing from later versions
         'jsonschema',
         'mock',
-        'python-dateutil',
+        'python-dateutil==1.5',
         'PyStaticConfiguration',
         'pyyaml',
         'simplejson',


### PR DESCRIPTION
Having this version of dateutil causes a crash in cases where the timezone string contains unicode. See https://github.com/Yelp/elastalert/issues/247 and https://github.com/Yelp/elastalert/issues/471. 

We had incorrectly been using the 2.X version, which is for python3. From their website, "If you need dateutil for Python 2.X, please continue using the 1.X series."