### PR TITLE
Add support for composite keys in the NewTermsRule

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -128,7 +128,7 @@ Rule Configuration Cheat Sheet
 +----------------------------------------------------+--------+-----------+-----------+--------+-----------+-------+----------+--------+-----------+
 |``threshold`` (int, no default)                     |        |           |           |        |           |       |    Req   |        |           |
 +----------------------------------------------------+--------+-----------+-----------+--------+-----------+-------+----------+--------+-----------+
-|``fields`` (string, no default)                     |        |           |           |        |           |       |          | Req    |           |
+|``fields`` (string or list, no default)             |        |           |           |        |           |       |          | Req    |           |
 +----------------------------------------------------+--------+-----------+-----------+--------+-----------+-------+----------+--------+-----------+
 |``terms_window_size`` (time, default 30 days)       |        |           |           |        |           |       |          | Opt    |           |
 +----------------------------------------------------+--------+-----------+-----------+--------+-----------+-------+----------+--------+-----------+
@@ -771,7 +771,9 @@ use an aggregation query to gather all known terms for a list of fields.
 
 This rule requires one additional option:
 
-``fields``: A list of fields to monitor for new terms. ``query_key`` will be used if ``fields`` is not set.
+``fields``: A list of fields to monitor for new terms. ``query_key`` will be used if ``fields`` is not set. Each entry in the
+list of fields can itself be a list.  If a field entry is provided as a list, it will be interpreted as a set of fields
+that compose a composite key used for the elasticsearch query.  These fields may only refer to primitive types.
 
 Optional:
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -773,7 +773,10 @@ This rule requires one additional option:
 
 ``fields``: A list of fields to monitor for new terms. ``query_key`` will be used if ``fields`` is not set. Each entry in the
 list of fields can itself be a list.  If a field entry is provided as a list, it will be interpreted as a set of fields
-that compose a composite key used for the elasticsearch query.  These fields may only refer to primitive types.
+that compose a composite key used for the elasticsearch query.  ``Note: the composite fields may only refer to primitive
+types, otherwise the initial elasticsearch query will not properly return the aggregation results, thus causing alerts
+to fire every time the elastalert service initially launches with the rule. A warning will be logged to the console if
+this scenario is encountered. However, future alerts will actually work as expected after the initial flurry.``
 
 Optional:
 

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -6,6 +6,11 @@ definitions:
     type: [string, array]
     items: {type: string}
 
+  # Either a single string OR an array of strings OR an array of ararys
+  arrayOfStringsOrOtherArrays: &arrayOfStringsOrOtherArray
+    type: [string, array]
+    items: {type: string, type: array}
+
   timeFrame: &timeframe
     type: object
     additionalProperties: false
@@ -92,7 +97,7 @@ oneOf:
     required: [fields]
     properties:
       type: {enum: [new_term]}
-      fields: *arrayOfString
+      fields: *arrayOfStringsOrOtherArray
       terms_window_size: *timeframe
       alert_on_missing_field: {type: boolean}
       use_terms_query: {type: boolean}

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -564,6 +564,93 @@ def test_new_term_with_terms():
     assert rule.matches == []
 
 
+def test_new_term_with_composite_fields():
+    rules = {'fields': [['a', 'b', 'c'], ['d', 'e.f']],
+             'timestamp_field': '@timestamp',
+             'es_host': 'example.com', 'es_port': 10, 'index': 'logstash'}
+
+    mock_res = {
+        'aggregations': {
+            'filtered': {
+                'values': {
+                    'buckets': [
+                        {
+                            'key': 'key1',
+                            'doc_count': 5,
+                            'values': {
+                                'buckets': [
+                                    {
+                                        'key': 'key2',
+                                        'doc_count': 5,
+                                        'values': {
+                                            'buckets': [
+                                                {
+                                                    'key': 'key3',
+                                                    'doc_count': 3,
+                                                },
+                                                {
+                                                    'key': 'key4',
+                                                    'doc_count': 2,
+                                                },
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    with mock.patch('elastalert.ruletypes.Elasticsearch') as mock_es:
+        mock_es.return_value = mock.Mock()
+        mock_es.return_value.search.return_value = mock_res
+        rule = NewTermsRule(rules)
+
+        assert rule.es.search.call_count == 2
+
+    # key3 already exists, and thus shouldn't cause a match
+    rule.add_data([{'@timestamp': ts_now(), 'a': 'key1', 'b': 'key2', 'c': 'key3'}])
+    assert rule.matches == []
+
+    # key5 causes an alert for composite field [a, b, c]
+    rule.add_data([{'@timestamp': ts_now(), 'a': 'key1', 'b': 'key2', 'c': 'key5'}])
+    assert len(rule.matches) == 1
+    assert rule.matches[0]['new_field'] == ('a', 'b', 'c')
+    assert rule.matches[0]['a'] == 'key1'
+    assert rule.matches[0]['b'] == 'key2'
+    assert rule.matches[0]['c'] == 'key5'
+    rule.matches = []
+
+    # New values in other fields that are not part of the composite key should not cause an alert
+    rule.add_data([{'@timestamp': ts_now(), 'a': 'key1', 'b': 'key2', 'c': 'key4', 'd': 'unrelated_value'}])
+    assert len(rule.matches) == 0
+    rule.matches = []
+
+    # Verify nested fields work properly
+    # Key6 causes an alert for nested field e.f
+    rule.add_data([{'@timestamp': ts_now(), 'd': 'key4', 'e': {'f': 'key6'}}])
+    assert len(rule.matches) == 1
+    assert rule.matches[0]['new_field'] == ('d', 'e.f')
+    assert rule.matches[0]['d'] == 'key4'
+    assert rule.matches[0]['e']['f'] == 'key6'
+    rule.matches = []
+
+    # Missing_fields
+    rules['alert_on_missing_field'] = True
+    with mock.patch('elastalert.ruletypes.Elasticsearch') as mock_es:
+        mock_es.return_value = mock.Mock()
+        mock_es.return_value.search.return_value = mock_res
+        rule = NewTermsRule(rules)
+    rule.add_data([{'@timestamp': ts_now(), 'a': 'key2'}])
+    assert len(rule.matches) == 2
+    # This means that any one of the three n composite fields were not present
+    assert rule.matches[0]['missing_field'] == ('a', 'b', 'c')
+    assert rule.matches[1]['missing_field'] == ('d', 'e.f')
+
+
 def test_flatline():
     events = hits(10)
     rules = {'timeframe': datetime.timedelta(seconds=30),


### PR DESCRIPTION
Enable a new_term rule to specify a composite key.  Composite keys can be specified via the following syntax:

```
fields:
  - ["message.addresses.ipv4", "message.port.number"]
```

In the above example rule, elastalert will keep track of unique records based on the combination of ip and port number.

NOTE: this will not work for complex types e.g. it will NOT work for the following case:

```
fields:
  - ["message.addresses.ipv4", "message.port"]
```

This is because the elastic search query used for calculating the baseline does not include the sub-aggregation details when a complex type is used.  This results in all already present data to incorrectly fire an alert.  After that initial false reporting, future alerting does work as expected.  @Qmando let me know if you have any idea of how to fix this or if it's worth trying to figure out.