### PR TITLE
Fix arrayOfStringsOrOtherArray types

### DIFF
--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -9,7 +9,7 @@ definitions:
   # Either a single string OR an array of strings OR an array of ararys
   arrayOfStringsOrOtherArrays: &arrayOfStringsOrOtherArray
     type: [string, array]
-    items: {type: string, type: array}
+    items: {type: [string, array]}
 
   timeFrame: &timeframe
     type: object


### PR DESCRIPTION
It seems that 3e82bbf4ad7c6 wants the `arrayOfStringsOrOtherArray` to accept either a single string or an array of strings or an array of arrays. This fix will do that.