### PR TITLE
Set kibana3 dashboard's timestamp fields

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -790,6 +790,10 @@ class ElastAlerter():
         Returns the url to the dashboard. '''
         db = copy.deepcopy(kibana.dashboard_temp)
 
+        # Set timestamp fields to match our rule especially if 
+        # we have configured something other than @timestamp
+        kibana.set_timestamp_field(db, rule['timestamp_field'])
+
         # Set filters
         for filter in rule['filter']:
             if filter:

--- a/elastalert/kibana.py
+++ b/elastalert/kibana.py
@@ -179,6 +179,18 @@ def set_time(dashboard, start, end):
 def set_index_name(dashboard, name):
     dashboard['index']['default'] = name
 
+def set_timestamp_field(dashboard, field):
+    # set the nav timefield if we don't want @timestamp
+    dashboard['nav'][0]['timefield'] = field
+
+    # set the time_field for each of our panels
+    for row in dashboard.get('rows'):
+        for panel in row.get('panels'):
+            panel['time_field'] = field
+
+    # set our filter's  time field
+    dashboard['services']['filter']['list']['0']['field'] = field
+
 
 def add_filter(dashboard, es_filter):
     next_id = max(dashboard['services']['filter']['ids']) + 1


### PR DESCRIPTION
Set kibana3 dashboard's timestamp fields on things like the nav, panels, services, etc so that we can match a rule's configured timestamp field. Helpful when referring to a document's field other than @timestamp