### PR TITLE
fixed issue of converting elasticsearch type date into float

### DIFF
--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -154,7 +154,7 @@ def dt_to_int(dt):
 
 
 def unixms_to_dt(ts):
-    return unix_to_dt(ts / 1000)
+    return unix_to_dt(float(ts)/1000)
 
 
 def unix_to_dt(ts):


### PR DESCRIPTION
While fetching records with timestamp, declared as type "date" in elasticsearch, it is required to convert the field to float or integer. This is needed since return type comes as unicode string.