### PR TITLE
Update example for change type

### DIFF
--- a/example_rules/example_change.yaml
+++ b/example_rules/example_change.yaml
@@ -40,7 +40,7 @@ compare_key: country_name
 # Ignore documents without the compare_key (country_name) field
 ignore_null: true
 
-# (Optional, change specific)
+# (Required, change specific)
 # The change must occur in two documents with the same query_key
 query_key: username
 


### PR DESCRIPTION
The `query_key` in the example file for change type is documented as optional. But it is required field according to the json schema validator. 
```
'required': ['query_key', 'compare_key', 'ignore_null'],
```
This PR aims to update the example file in order to correct the documentation.