### PR TITLE
Small bug fixes

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -110,7 +110,7 @@ class JiraFormattedMatchString(BasicMatchString):
     def _add_match_items(self):
         match_items = dict([(x, y) for x, y in self.match.items() if not x.startswith('top_events_')])
         json_blob = self._pretty_print_as_json(match_items)
-        preformatted_text = '{{code:json}}{0}{{code}}'.format(json_blob)
+        preformatted_text = u'{{code:json}}{0}{{code}}'.format(json_blob)
         self.text += preformatted_text
 
 

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -154,11 +154,11 @@ def dt_to_int(dt):
 
 
 def unixms_to_dt(ts):
-    return unix_to_dt(ts / 1000)
+    return unix_to_dt(float(ts) / 1000)
 
 
 def unix_to_dt(ts):
-    dt = datetime.datetime.utcfromtimestamp(ts)
+    dt = datetime.datetime.utcfromtimestamp(float(ts))
     dt = dt.replace(tzinfo=dateutil.tz.tzutc())
     return dt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,12 @@
 PyStaticConfiguration==0.9.0
 PyYAML==3.11
 argparse==1.3.0
+aws-requests-auth==0.2.5
 blist==1.3.6
 boto==2.34.0
 botocore==1.4.5
+configparser==3.3.0r2
+croniter==0.3.8
 elasticsearch==1.3.0
 jira==0.32
 jsonschema==2.2.0
@@ -12,13 +15,10 @@ oauthlib==0.7.2
 python-dateutil==2.4.0
 requests==2.5.1
 requests-oauthlib==0.4.2
-simplejson==3.6.5
+simplejson==3.3.0
 six==1.9.0
 supervisor==3.1.2
 tlslite==0.4.8
 unittest2==0.8.0
 urllib3==1.8.2
 wsgiref==0.1.2
-croniter==0.3.8
-configparser==3.5.0b2
-aws-requests-auth==0.2.5


### PR DESCRIPTION
Fixes 3 bugs.
1. UnicodeDecodeError in JIRA alerter
2. Error when unix timestamps are returned as strings
3. botocore requires simplejson 3.3.0, so pin it there to avoid conflicts, see #487