### PR TITLE
Add support for incident_key to the pagerduty alerter

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1157,6 +1157,9 @@ The alerter requires the following option:
 
 ``pagerduty_client_name``: The name of the monitoring client that is triggering this event.
 
+``pagerduty_incident_key``: If not set pagerduty will trigger a new incident for each alert sent. If set to a unique string per rule pagerduty will identify the incident that this event should be applied.
+If there's no open (i.e. unresolved) incident with this key, a new one will be created. If there's already an open incident with a matching key, this event will be appended to that incident's log.
+
 VictorOps
 ~~~~~~~~~
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -625,6 +625,7 @@ class PagerDutyAlerter(Alerter):
         super(PagerDutyAlerter, self).__init__(rule)
         self.pagerduty_service_key = self.rule['pagerduty_service_key']
         self.pagerduty_client_name = self.rule['pagerduty_client_name']
+        self.pagerduty_incident_key = self.rule.get('pagerduty_incident_key', '')
         self.url = 'https://events.pagerduty.com/generic/2010-04-15/create_event.json'
 
     def alert(self, matches):
@@ -636,6 +637,7 @@ class PagerDutyAlerter(Alerter):
             'service_key': self.pagerduty_service_key,
             'description': self.rule['name'],
             'event_type': 'trigger',
+            'incident_key': self.pagerduty_incident_key,
             'client': self.pagerduty_client_name,
             'details': {
                 "information": body.encode('UTF-8'),


### PR DESCRIPTION
By default pagerduty alerter will create a new incident for each alert sent. This might not be what we intend especially if we sent alerts from logs events (that don't resolve themselves ever). In order to improve the pagerduty alerter we can take advantage of the `incident_key` feature (see [api doc](https://developer.pagerduty.com/documentation/integration/events/trigger)) to apply new alerts to an existing trigger.

This PR adds support for pagerduty_incident_key and if undefined keeps the original functionality; if defined will take advantage of the incident_key and allow to de-dup problems easily. 