### PR TITLE
Updated schema to allow for download_dashboard

### DIFF
--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -140,8 +140,11 @@ properties:
   max_query_size: {type: integer}
 
   filter :
-    type: array
+    type: [array, object]
     items: *filter
+    additionalProperties: false
+    properties:
+        download_dashboard: {type: string}
 
   include: {type: array, items: {type: string}}
   top_count_keys: {type: array, items: {type: string}}


### PR DESCRIPTION
Fixes #468 by allowing filter to have "download_dashboard" property.

Tested with example rules and one with download_dashboard.