### PR TITLE
Add a Configuration Variable for HipChat Message Colors

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1115,6 +1115,8 @@ The alerter requires the following two options:
 ``hipchat_room_id``: The id associated with the HipChat room you want to send the alert to. Go to https://XXXXX.hipchat.com/rooms and choose
 the room you want to post to. The room ID will be the numeric part of the URL.
 
+``hipchat_msg_color``: The color of the message background that is sent to HipChat. May be set to green, yellow or red. Default is red.
+
 ``hipchat_domain``: The custom domain in case you have Hipchat own server deployment. Default is api.hipchat.com.
 
 ``hipchat_ignore_ssl_errors``: Ignore SSL errors (self-signed certificates, etc.). Default is false.

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -525,6 +525,7 @@ class HipChatAlerter(Alerter):
 
     def __init__(self, rule):
         super(HipChatAlerter, self).__init__(rule)
+        self.hipchat_msg_color = self.rule.get('hipchat_msg_color', 'red')
         self.hipchat_auth_token = self.rule['hipchat_auth_token']
         self.hipchat_room_id = self.rule['hipchat_room_id']
         self.hipchat_domain = self.rule.get('hipchat_domain', 'api.hipchat.com')
@@ -542,7 +543,7 @@ class HipChatAlerter(Alerter):
         # post to hipchat
         headers = {'content-type': 'application/json'}
         payload = {
-            'color': 'red',
+            'color': self.hipchat_msg_color,
             'message': body.replace('\n', '<br />'),
             'notify': True
         }


### PR DESCRIPTION
This PR adds the following functionality:
* Allows a user of the HipChat plugin to set the message background color via the variable `hipchat_msg_color`
* Updates in documentation for `hipchat_msg_color`