### PR TITLE
Dpopes alert metadata and more jira fields

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -36,7 +36,7 @@ Rule Configuration Cheat Sheet
 +--------------------------------------------------------------+           |
 | ``es_password`` (string, no default)                         |           |
 +--------------------------------------------------------------+           |
-| ``es_url_prefix`` (string, no default)                         |           |
+| ``es_url_prefix`` (string, no default)                       |           |
 +--------------------------------------------------------------+           |
 | ``es_send_get_body_as`` (string, default "GET")              |           |
 +--------------------------------------------------------------+           |
@@ -46,29 +46,29 @@ Rule Configuration Cheat Sheet
 +--------------------------------------------------------------+           |
 | ``generate_kibana_link`` (boolean, default False)            |           |
 +--------------------------------------------------------------+           |
-|``use_kibana_dashboard`` (string, no default)                 |           |
+| ``use_kibana_dashboard`` (string, no default)                |           |
 +--------------------------------------------------------------+           |
-|``kibana_url`` (string, default from es_host)                 |           |
+| ``kibana_url`` (string, default from es_host)                |           |
 +--------------------------------------------------------------+           |
-|``use_kibana4_dashboard`` (string, no default)                |           |
+| ``use_kibana4_dashboard`` (string, no default)               |           |
 +--------------------------------------------------------------+           |
-|``kibana4_start_timedelta`` (time, default: 10 min)           |           |
+| ``kibana4_start_timedelta`` (time, default: 10 min)          |           |
 +--------------------------------------------------------------+           |
-|``kibana4_end_timedelta`` (time, default: 10 min)             |           |
+| ``kibana4_end_timedelta`` (time, default: 10 min)            |           |
 +--------------------------------------------------------------+           |
-|``use_local_time`` (boolean, default True)                    |           |
+| ``use_local_time`` (boolean, default True)                   |           |
 +--------------------------------------------------------------+           |
 | ``realert`` (time, default: 1 min)                           |           |
 +--------------------------------------------------------------+           |
-|``exponential_realert`` (time, no default)                    |           |
+| ``exponential_realert`` (time, no default)                   |           |
 +--------------------------------------------------------------+           |
-|``match_enhancements`` (list of strs, no default)             |           |
+| ``match_enhancements`` (list of strs, no default)            |           |
 +--------------------------------------------------------------+           |
 | ``top_count_number`` (int, default 5)                        |           |
 +--------------------------------------------------------------+           |
 | ``top_count_keys`` (list of strs)                            |           |
 +--------------------------------------------------------------+           |
-|``raw_count_keys`` (boolean, default True)                    |           |
+| ``raw_count_keys`` (boolean, default True)                   |           |
 +--------------------------------------------------------------+           |
 | ``include`` (list of strs, default ["*"])                    |           |
 +--------------------------------------------------------------+           |
@@ -78,10 +78,14 @@ Rule Configuration Cheat Sheet
 +--------------------------------------------------------------+           |
 | ``query_delay`` (time, default 0 min)                        |           |
 +--------------------------------------------------------------+           |
-| ``buffer_time`` (time, default from config.yaml)             |           |
+| ``owner`` (string, default empty string)                     |           |
++--------------------------------------------------------------+           |
+| ``priority`` (int, default 2)                                |           |
 |                                                              |           |
 | IGNORED IF ``use_count_query`` or ``use_terms_query`` is true|           |
 +--------------------------------------------------------------+           +
+| ``buffer_time`` (time, default from config.yaml)             |           |
++--------------------------------------------------------------+           |
 | ``timestamp_type`` (string, default iso)                     |           |
 +--------------------------------------------------------------+           |
 | ``timestamp_format`` (string, default "%Y-%m-%dT%H:%M:%SZ")  |           |
@@ -285,6 +289,16 @@ query_delay
 
 ``query_delay``: This option will cause ElastAlert to subtract a time delta from every query, causing the rule to run with a delay.
 This is useful if the data is Elasticsearch doesn't get indexed immediately. (Optional, time)
+
+owner
+^^^^^^^^^^^
+
+``owner``: This value will be used to identify the stakeholder of the alert. Optionally, this field can be included in any alert type. (Optional, string)
+
+priority
+^^^^^^^^^^^
+
+``priority``: This value will be used to identify the relative priority of the alert. Optionally, this field can be included in any alert type (e.g. for use in email subject/body text). (Optional, int, default 2)
 
 max_query_size
 ^^^^^^^^^^^^^^
@@ -1013,14 +1027,20 @@ For an example JIRA account file, see ``example_rules/jira_acct.yaml``. The acco
 
 Optional:
 
-``jira_component``: The name of the component to set the ticket to.
+``jira_component``: The name of the component or components to set the ticket to. This can be a single string or a list of strings. This is provided for backwards compatibility and will eventually be deprecated. It is preferable to use the plurarl ``jira_components`` instead.
+
+``jira_components``: The name of the component or components to set the ticket to. This can be a single string or a list of strings.
 
 ``jira_description``: Similar to ``alert_text``, this text is prepended to the JIRA description.
 
-``jira_label``: The label to add to the JIRA ticket.
+``jira_label``: The label or labels to add to the JIRA ticket.  This can be a single string or a list of strings. This is provided for backwards compatibility and will eventually be deprecated. It is preferable to use the plural ``jira_labels`` instead.
+
+``jira_labels``: The label or labels to add to the JIRA ticket.  This can be a single string or a list of strings.
 
 ``jira_priority``: The index of the priority to set the issue to. In the JIRA dropdown for priorities, 0 would represent the first priority,
 1 the 2nd, etc.
+
+``jira_watchers``: A list of user names to add as watchers on a JIRA ticket. This can be a single string or a list of strings.
 
 ``jira_bump_tickets``: If true, ElastAlert search for existing tickets newer than ``jira_max_age`` and comment on the ticket with
 information about the alert instead of opening another ticket. ElastAlert finds the existing ticket by searching by summary. If the
@@ -1053,6 +1073,21 @@ Example usage::
 
     jira_bump_in_statuses:
       - Open
+
+Arbitrary Jira fields:
+
+Elastalert supports setting any arbitrary JIRA field that your jira issue supports. For example, if you had a custom field, called "Affected User", you can set it by providing that field name in ``snake_case`` prefixed with ``jira_``.  These fields can contain primitive strings or arrays of strings. Note that when you create a custom field in your JIRA server, internally, the field is represented as ``customfield_1111``. In elastalert, you may refer to either the public facing name OR the internal representation.
+
+Example usage::
+
+    jira_arbitrary_singular_field: My Name
+    jira_arbitrary_multivalue_field:
+      - Name 1
+      - Name 2
+    jira_customfield_12345: My Custom Value
+    jira_customfield_9999:
+      - My Custom Value 1
+      - My Custom Value 2
 
 OpsGenie
 ~~~~~~~~

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -46,7 +46,11 @@ class BasicMatchString(object):
             # Support referencing other top-level rule properties
             # This technically may not work if there is a top-level rule property with the same name
             # as an es result key, since it would have been matched in the lookup_es_key call above
-            alert_text_values = [self.rule.get(arg) if val is None else val for val in alert_text_values]
+            for i in xrange(len(alert_text_values)):
+                if alert_text_values[i] is None:
+                    alert_value = self.rule.get(alert_text_args[i])
+                    if alert_value:
+                        alert_text_values[i] = alert_value
 
             alert_text_values = [missing if val is None else val for val in alert_text_values]
             alert_text = alert_text.format(*alert_text_values)
@@ -54,6 +58,13 @@ class BasicMatchString(object):
             kw = {}
             for name, kw_name in self.rule.get('alert_text_kw').items():
                 val = lookup_es_key(self.match, name)
+
+                # Support referencing other top-level rule properties
+                # This technically may not work if there is a top-level rule property with the same name
+                # as an es result key, since it would have been matched in the lookup_es_key call above
+                if val is None:
+                    val = self.rule.get(name)
+
                 kw[kw_name] = missing if val is None else val
             alert_text = alert_text.format(**kw)
 
@@ -166,7 +177,11 @@ class Alerter(object):
             # Support referencing other top-level rule properties
             # This technically may not work if there is a top-level rule property with the same name
             # as an es result key, since it would have been matched in the lookup_es_key call above
-            alert_subject_values = [self.rule.get(arg) if val is None else val for val in alert_subject_values]
+            for i in xrange(len(alert_subject_values)):
+                if alert_subject_values[i] is None:
+                    alert_value = self.rule.get(alert_subject_args[i])
+                    if alert_value:
+                        alert_subject_values[i] = alert_value
 
             alert_subject_values = ['<MISSING VALUE>' if val is None else val for val in alert_subject_values]
             return alert_subject.format(*alert_subject_values)

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -423,7 +423,8 @@ class JiraAlerter(Alerter):
                 # Handle arrays of simple types like strings or numbers
                 if arg_type == 'array':
                     array_items = field['schema']['items']
-                    if array_items == 'string':
+                    # Simple string types
+                    if array_items in ['string', 'date', 'datetime']:
                         # As a convenience, support the scenario wherein the user only provides
                         # a single value for a multi-value field e.g. jira_labels: Only_One_Label
                         if type(value) != list:
@@ -450,8 +451,8 @@ class JiraAlerter(Alerter):
                             self.jira_args[arg_name] = [{'name': v} for v in value]
                 # Handle non-array types
                 else:
-                    # String type
-                    if arg_type == 'string':
+                    # Simple string types
+                    if arg_type in ['string', 'date', 'datetime']:
                         self.jira_args[arg_name] = value
                     # Number type
                     elif arg_type == 'number':

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import logging
 import subprocess
+import sys
 import warnings
 from email.mime.text import MIMEText
 from smtplib import SMTP
@@ -41,6 +42,12 @@ class BasicMatchString(object):
         if 'alert_text_args' in self.rule:
             alert_text_args = self.rule.get('alert_text_args')
             alert_text_values = [lookup_es_key(self.match, arg) for arg in alert_text_args]
+
+            # Support referencing other top-level rule properties
+            # This technically may not work if there is a top-level rule property with the same name
+            # as an es result key, since it would have been matched in the lookup_es_key call above
+            alert_text_values = [self.rule.get(arg) if val is None else val for val in alert_text_values]
+
             alert_text_values = [missing if val is None else val for val in alert_text_values]
             alert_text = alert_text.format(*alert_text_values)
         elif 'alert_text_kw' in self.rule:
@@ -155,6 +162,12 @@ class Alerter(object):
         if 'alert_subject_args' in self.rule:
             alert_subject_args = self.rule['alert_subject_args']
             alert_subject_values = [lookup_es_key(matches[0], arg) for arg in alert_subject_args]
+
+            # Support referencing other top-level rule properties
+            # This technically may not work if there is a top-level rule property with the same name
+            # as an es result key, since it would have been matched in the lookup_es_key call above
+            alert_subject_values = [self.rule.get(arg) if val is None else val for val in alert_subject_values]
+
             alert_subject_values = ['<MISSING VALUE>' if val is None else val for val in alert_subject_values]
             return alert_subject.format(*alert_subject_values)
 

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -29,6 +29,8 @@ class RuleType(object):
         self.matches = []
         self.rules = rules
         self.occurrences = {}
+        self.rules['owner'] = self.rules.get('owner', '')
+        self.rules['priority'] = self.rules.get('priority', '2')
 
     def add_data(self, data):
         """ The function that the elastalert client calls with results from ES.

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -139,6 +139,9 @@ properties:
   query_delay: *timeframe
   max_query_size: {type: integer}
 
+  owner: {type: string}
+  priority: {type: integer}
+
   filter :
     type: [array, object]
     items: *filter
@@ -182,10 +185,16 @@ properties:
   jira_issuetype: {type: string}
   jira_account_file: {type: string} # a Yaml file that includes the keys {user:, password:}
 
-  jira_component: {type: string}
-  jira_label: {type: string}
+  jira_assignee: {type: string}
+  jira_component: *arrayOfString
+  jira_components: *arrayOfString
+  jira_label: *arrayOfString
+  jira_labels: *arrayOfString
   jira_bump_tickets: {type: boolean}
+  jira_bump_in_statuses: *arrayOfString
+  jira_bump_not_in_statuses: *arrayOfString
   jira_max_age: {type: number}
+  jira_watchers: *arrayOfString
 
   ### HipChat
   hipchat_auth_token: {type: string}

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -5,6 +5,7 @@ import subprocess
 from contextlib import nested
 
 import mock
+import pytest
 from jira.exceptions import JIRAError
 
 from elastalert.alerts import BasicMatchString
@@ -312,18 +313,19 @@ def test_jira():
         'jira_account_file': 'jirafile',
         'type': mock_rule(),
         'jira_project': 'testproject',
+        'jira_priority': 0,
         'jira_issuetype': 'testtype',
         'jira_server': 'jiraserver',
         'jira_label': 'testlabel',
         'jira_component': 'testcomponent',
         'jira_description': description_txt,
+        'jira_watchers': ['testwatcher1', 'testwatcher2'],
         'timestamp_field': '@timestamp',
         'alert_subject': 'Issue {0} occurred at {1}',
         'alert_subject_args': ['test_term', '@timestamp']
     }
 
     mock_priority = mock.Mock(id='5')
-    mock_fields = mock.Mock(id='6')
 
     with nested(
         mock.patch('elastalert.alerts.JIRA'),
@@ -331,6 +333,7 @@ def test_jira():
     ) as (mock_jira, mock_open):
         mock_open.return_value = {'user': 'jirauser', 'password': 'jirapassword'}
         mock_jira.return_value.priorities.return_value = [mock_priority]
+        mock_jira.return_value.fields.return_value = []
         alert = JiraAlerter(rule)
         alert.alert([{'test_term': 'test_value', '@timestamp': '2014-10-31T00:00:00'}])
 
@@ -340,15 +343,19 @@ def test_jira():
         mock.call().fields(),
         mock.call().create_issue(
             issuetype={'name': 'testtype'},
+            priority={'id': '5'},
             project={'key': 'testproject'},
             labels=['testlabel'],
             components=[{'name': 'testcomponent'}],
             description=mock.ANY,
-            summary='Issue test_value occurred at 2014-10-31T00:00:00')
+            summary='Issue test_value occurred at 2014-10-31T00:00:00',
+        ),
+        mock.call().add_watcher(mock.ANY, 'testwatcher1'),
+        mock.call().add_watcher(mock.ANY, 'testwatcher2'),
     ]
 
     # We don't care about additional calls to mock_jira, such as __str__
-    assert mock_jira.mock_calls[:4] == expected
+    assert mock_jira.mock_calls[:6] == expected
     assert mock_jira.mock_calls[3][2]['description'].startswith(description_txt)
 
     # Search called if jira_bump_tickets
@@ -361,7 +368,7 @@ def test_jira():
         mock_jira.return_value = mock.Mock()
         mock_jira.return_value.search_issues.return_value = []
         mock_jira.return_value.priorities.return_value = [mock_priority]
-        mock_jira.return_value.fields.return_value = [mock_fields]
+        mock_jira.return_value.fields.return_value = []
 
         alert = JiraAlerter(rule)
         alert.alert([{'test_term': 'test_value', '@timestamp': '2014-10-31T00:00:00'}])
@@ -379,6 +386,7 @@ def test_jira():
         mock_jira.return_value = mock.Mock()
         mock_jira.return_value.search_issues.return_value = []
         mock_jira.return_value.priorities.return_value = [mock_priority]
+        mock_jira.return_value.fields.return_value = []
 
         alert = JiraAlerter(rule)
         alert.alert([{'test_term': 'test_value', '@timestamp': '2014-10-31T00:00:00'}])
@@ -394,11 +402,130 @@ def test_jira():
         mock_jira.return_value = mock.Mock()
         mock_jira.return_value.search_issues.side_effect = JIRAError
         mock_jira.return_value.priorities.return_value = [mock_priority]
+        mock_jira.return_value.fields.return_value = []
 
         alert = JiraAlerter(rule)
         alert.alert([{'test_term': 'test_value', '@timestamp': '2014-10-31T00:00:00'}])
 
     assert mock_jira.mock_calls == expected
+
+
+def test_jira_arbitrary_field_support():
+    description_txt = "Description stuff goes here like a runbook link."
+    rule = {
+        'name': 'test alert',
+        'jira_account_file': 'jirafile',
+        'type': mock_rule(),
+        'jira_project': 'testproject',
+        'jira_issuetype': 'testtype',
+        'jira_server': 'jiraserver',
+        'jira_label': 'testlabel',
+        'jira_component': 'testcomponent',
+        'jira_description': description_txt,
+        'jira_watchers': ['testwatcher1', 'testwatcher2'],
+        'jira_arbitrary_string_field': 'arbitrary_string_value',
+        'jira_arbitrary_string_array_field': ['arbitrary_string_value1', 'arbitrary_string_value2'],
+        'jira_arbitrary_string_array_field_provided_as_single_value': 'arbitrary_string_value_in_array_field',
+        'jira_arbitrary_number_field': 1,
+        'jira_arbitrary_number_array_field': [2, 3],
+        'jira_arbitrary_number_array_field_provided_as_single_value': 1,
+        'jira_arbitrary_complex_field': 'arbitrary_complex_value',
+        'jira_arbitrary_complex_array_field': ['arbitrary_complex_value1', 'arbitrary_complex_value2'],
+        'jira_arbitrary_complex_array_field_provided_as_single_value': 'arbitrary_complex_value_in_array_field',
+        'timestamp_field': '@timestamp',
+        'alert_subject': 'Issue {0} occurred at {1}',
+        'alert_subject_args': ['test_term', '@timestamp']
+    }
+
+    mock_priority = mock.MagicMock(id='5')
+
+    mock_fields = [
+        {'name': 'arbitrary string field', 'id': 'arbitrary_string_field', 'schema': {'type': 'string'}},
+        {'name': 'arbitrary string array field', 'id': 'arbitrary_string_array_field', 'schema': {'type': 'array', 'items': 'string'}},
+        {'name': 'arbitrary string array field provided as single value', 'id': 'arbitrary_string_array_field_provided_as_single_value', 'schema': {'type': 'array', 'items': 'string'}},
+        {'name': 'arbitrary number field', 'id': 'arbitrary_number_field', 'schema': {'type': 'number'}},
+        {'name': 'arbitrary number array field', 'id': 'arbitrary_number_array_field', 'schema': {'type': 'array', 'items': 'number'}},
+        {'name': 'arbitrary number array field provided as single value', 'id': 'arbitrary_number_array_field_provided_as_single_value', 'schema': {'type': 'array', 'items': 'number'}},
+        {'name': 'arbitrary complex field', 'id': 'arbitrary_complex_field', 'schema': {'type': 'ArbitraryType'}},
+        {'name': 'arbitrary complex array field', 'id': 'arbitrary_complex_array_field', 'schema': {'type': 'array', 'items': 'ArbitraryType'}},
+        {'name': 'arbitrary complex array field provided as single value', 'id': 'arbitrary_complex_array_field_provided_as_single_value', 'schema': {'type': 'array', 'items': 'ArbitraryType'}},
+    ]
+
+    with nested(
+            mock.patch('elastalert.alerts.JIRA'),
+            mock.patch('elastalert.alerts.yaml_loader')
+    ) as (mock_jira, mock_open):
+        mock_open.return_value = {'user': 'jirauser', 'password': 'jirapassword'}
+        mock_jira.return_value.priorities.return_value = [mock_priority]
+        mock_jira.return_value.fields.return_value = mock_fields
+        alert = JiraAlerter(rule)
+        alert.alert([{'test_term': 'test_value', '@timestamp': '2014-10-31T00:00:00'}])
+
+    expected = [
+        mock.call('jiraserver', basic_auth=('jirauser', 'jirapassword')),
+        mock.call().priorities(),
+        mock.call().fields(),
+        mock.call().create_issue(
+            issuetype={'name': 'testtype'},
+            project={'key': 'testproject'},
+            labels=['testlabel'],
+            components=[{'name': 'testcomponent'}],
+            description=mock.ANY,
+            summary='Issue test_value occurred at 2014-10-31T00:00:00',
+            arbitrary_string_field='arbitrary_string_value',
+            arbitrary_string_array_field=['arbitrary_string_value1', 'arbitrary_string_value2'],
+            arbitrary_string_array_field_provided_as_single_value=['arbitrary_string_value_in_array_field'],
+            arbitrary_number_field=1,
+            arbitrary_number_array_field=[2, 3],
+            arbitrary_number_array_field_provided_as_single_value=[1],
+            arbitrary_complex_field={'name': 'arbitrary_complex_value'},
+            arbitrary_complex_array_field=[{'name': 'arbitrary_complex_value1'}, {'name': 'arbitrary_complex_value2'}],
+            arbitrary_complex_array_field_provided_as_single_value=[{'name': 'arbitrary_complex_value_in_array_field'}],
+        ),
+        mock.call().add_watcher(mock.ANY, 'testwatcher1'),
+        mock.call().add_watcher(mock.ANY, 'testwatcher2'),
+    ]
+
+    # We don't care about additional calls to mock_jira, such as __str__
+    assert mock_jira.mock_calls[:6] == expected
+    assert mock_jira.mock_calls[3][2]['description'].startswith(description_txt)
+
+    # Reference an arbitrary string field that is not defined on the JIRA server
+    rule['jira_nonexistent_field'] = 'nonexistent field value'
+
+    with nested(
+            mock.patch('elastalert.alerts.JIRA'),
+            mock.patch('elastalert.alerts.yaml_loader')
+    ) as (mock_jira, mock_open):
+        mock_open.return_value = {'user': 'jirauser', 'password': 'jirapassword'}
+        mock_jira.return_value.priorities.return_value = [mock_priority]
+        mock_jira.return_value.fields.return_value = mock_fields
+
+        with pytest.raises(Exception) as exception:
+            alert = JiraAlerter(rule)
+            alert.alert([{'test_term': 'test_value', '@timestamp': '2014-10-31T00:00:00'}])
+        assert "Could not find a definition for the jira field 'nonexistent field'" in str(exception)
+
+    del rule['jira_nonexistent_field']
+
+    # Reference a watcher that does not exist
+    rule['jira_watchers'] = 'invalid_watcher'
+
+    with nested(
+            mock.patch('elastalert.alerts.JIRA'),
+            mock.patch('elastalert.alerts.yaml_loader')
+    ) as (mock_jira, mock_open):
+        mock_open.return_value = {'user': 'jirauser', 'password': 'jirapassword'}
+        mock_jira.return_value.priorities.return_value = [mock_priority]
+        mock_jira.return_value.fields.return_value = mock_fields
+
+        # Cause add_watcher to raise, which most likely means that the user did not exist
+        mock_jira.return_value.add_watcher.side_effect = Exception()
+
+        with pytest.raises(Exception) as exception:
+            alert = JiraAlerter(rule)
+            alert.alert([{'test_term': 'test_value', '@timestamp': '2014-10-31T00:00:00'}])
+        assert "Exception encountered when trying to add 'invalid_watcher' as a watcher. Does the user exist?" in str(exception)
 
 
 def test_kibana(ea):


### PR DESCRIPTION
@Qmando Here is a pull request for adding additional alert metadata (owner, priority) && support for alerts to refer and set arbitrary JIRA fields (and also addressing #54 while I was at it).  I have done some manual testing and it appears to work as advertised, but I will be adding more automated tests right now.  Just wanted to get the initial stab out there so that you can take a look if you're so inclined.