### PR TITLE
Split new_term queries into steps to avoid crazy timeouts

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -142,6 +142,8 @@ Rule Configuration Cheat Sheet
 +----------------------------------------------------+--------+-----------+-----------+--------+-----------+-------+----------+--------+-----------+
 |``terms_window_size`` (time, default 30 days)       |        |           |           |        |           |       |          | Opt    |           |
 +----------------------------------------------------+--------+-----------+-----------+--------+-----------+-------+----------+--------+-----------+
+|``window_step_size`` (time, default 1 day)          |        |           |           |        |           |       |          | Opt    |           |
++----------------------------------------------------+--------+-----------+-----------+--------+-----------+-------+----------+--------+-----------+
 |``alert_on_missing_fields`` (boolean, default False)|        |           |           |        |           |       |          | Opt    |           |
 +----------------------------------------------------+--------+-----------+-----------+--------+-----------+-------+----------+--------+-----------+
 |``cardinality_field`` (string, no default)          |        |           |           |        |           |       |          |        |  Req      |
@@ -815,6 +817,10 @@ Optional:
 
 ``terms_window_size``: The amount of time used for the initial query to find existing terms. No term that has occurred within this time frame
 will trigger an alert. The default is 30 days.
+
+``window_step_size``: When querying for existing terms, split up the time range into steps of this size. For example, using the default
+30 day window size, and the default 1 day step size, 30 invidivdual queries will be made. This helps to avoid timeouts for very
+expensive aggregation queries. The default is 1 day.
 
 ``alert_on_missing_field``: Whether or not to alert when a field is missing from a document. The default is false.
 

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -583,7 +583,7 @@ class NewTermsRule(RuleType):
                 if tmp_start == tmp_end:
                     break
                 tmp_start = tmp_end
-                tmp_end = min(end, tmp_end + step)
+                tmp_end = min(tmp_start + step, end)
                 time_filter[self.rules['timestamp_field']] = {'lt': dt_to_ts(tmp_end), 'gte': dt_to_ts(tmp_start)}
 
             for key, values in self.seen_values.iteritems():
@@ -600,9 +600,7 @@ class NewTermsRule(RuleType):
                         elastalert_logger.info('Found no values for %s' % (field))
                     continue
                 self.seen_values[key] = list(set(values))
-                if type(key) == str:
-                    # Only print this number out for single fields
-                    elastalert_logger.info('Found %s unique values for %s' % (len(values), key))
+                elastalert_logger.info('Found %s unique values for %s' % (len(values), key))
 
     def flatten_aggregation_hierarchy(self, root, hierarchy_tuple=()):
         """ For nested aggregations, the results come back in the following format:

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands = sphinx-build -b html -d build/doctrees source build/html
 [flake8]
 # ignore certain violations
 # E501 - long lines
-exclude = .git,__pycache__,.tox,docs,virtualenv_run
+exclude = .git,__pycache__,.tox,docs,virtualenv_run,modules
 ignore = E501
 max-line-length = 140
 


### PR DESCRIPTION
When calling get_all_terms when a new_term rule starts, split the query (which is default 30 days) into (default 1 day) chunks. This can avoid timeouts because this can be a very expensive query to run. The step size is controllable via ``window_step_size``.