### PR TITLE
handle special custom multi value fields

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -481,40 +481,27 @@ class JiraAlerter(Alerter):
 
                 # Handle arrays of simple types like strings or numbers
                 if arg_type == 'array':
+                    # As a convenience, support the scenario wherein the user only provides
+                    # a single value for a multi-value field e.g. jira_labels: Only_One_Label
+                    if type(value) != list:
+                        value = [value]
                     array_items = field['schema']['items']
                     # Simple string types
                     if array_items in ['string', 'date', 'datetime']:
                         # Special case for multi-select custom types (the JIRA metadata says that these are strings, but
                         # in reality, they are required to be provided as an object.
                         if 'custom' in field['schema'] and field['schema']['custom'] in self.custom_string_types_with_special_handling:
-                            if type(value) != list:
-                                self.jira_args[arg_name] = [{'value': value}]
-                            else:
-                                self.jira_args[arg_name] = [{'value': v} for v in value]
-                        # As a convenience, support the scenario wherein the user only provides
-                        # a single value for a multi-value field e.g. jira_labels: Only_One_Label
-                        if type(value) != list:
-                            self.jira_args[arg_name] = [value]
+                            self.jira_args[arg_name] = [{'value': v} for v in value]
                         else:
                             self.jira_args[arg_name] = value
-                    # Also attempt to handle arrays of complex types that have to be passed as objects with an identifier 'key'
                     elif array_items == 'number':
-                        # As a convenience, support the scenario wherein the user only provides
-                        # a single value for a multi-value field e.g. jira_labels: Only_One_Label
-                        if type(value) != list:
-                            self.jira_args[arg_name] = [int(value)]
-                        else:
-                            self.jira_args[arg_name] = [int(v) for v in value]
+                        self.jira_args[arg_name] = [int(v) for v in value]
+                    # Also attempt to handle arrays of complex types that have to be passed as objects with an identifier 'key'
                     else:
                         # Try setting it as an object, using 'name' as the key
                         # This may not work, as the key might actually be 'key', 'id', 'value', or something else
                         # If it works, great!  If not, it will manifest itself as an API error that will bubble up
-                        # Again, as a convenience, support the scenario wherein the user only provides
-                        # a single value for a multi-value field e.g. jira_custom_labels: Only_One_Custom_Label
-                        if type(value) != list:
-                            self.jira_args[arg_name] = [{'name': value}]
-                        else:
-                            self.jira_args[arg_name] = [{'name': v} for v in value]
+                        self.jira_args[arg_name] = [{'name': v} for v in value]
                 # Handle non-array types
                 else:
                     # Simple string types

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -380,7 +380,7 @@ class JiraAlerter(Alerter):
     # There are likely others that will need to be updated on a case-by-case basis
     custom_string_types_with_special_handling = [
         'com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes',
-        'com.atlassian.jira.plugin.system.customfieldtypes:multiselect'
+        'com.atlassian.jira.plugin.system.customfieldtypes:multiselect',
     ]
 
     def __init__(self, rule):


### PR DESCRIPTION
Some custom types (such as multicheckboxes, multiselect to name a few) have false advertisements in their JIRA metadata as returned by jira.fields().  This PR adds some special handling for these two types.  And I also did a quick opportunistic refactor to reduce some of the repeated coalescing of non-lists to lists while I was in there.