### PR TITLE
Improved default configuration file

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -17,7 +17,7 @@ buffer_time:
 es_host: elasticsearch.example.com
 
 # The elasticsearch port
-es_port: 14900
+es_port: 9200
 
 # Optional URL prefix for elasticsearch
 #es_url_prefix: elasticsearch

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -13,7 +13,7 @@ buffer_time:
   minutes: 15
 
 # The elasticsearch hostname for metadata writeback
-# Note that every rule can have it's own elasticsearch host
+# Note that every rule can have its own elasticsearch host
 es_host: elasticsearch.example.com
 
 # The elasticsearch port


### PR DESCRIPTION
A typo is fixed and the port for Elasticsearch is changed to 9200 which has been the default for at least 1.5 years.