### PR TITLE
Fixed strings in command

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -648,7 +648,7 @@ class CommandAlerter(Alerter):
     def __init__(self, *args):
         super(CommandAlerter, self).__init__(*args)
         self.last_command = []
-        if isinstance(self.rule['command'], basestring) and '%' in self.rule['command']:
+        if isinstance(self.rule['command'], basestring):
             logging.warning('Warning! You could be vulnerable to shell injection!')
             self.rule['command'] = [self.rule['command']]
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -649,7 +649,8 @@ class CommandAlerter(Alerter):
         super(CommandAlerter, self).__init__(*args)
         self.last_command = []
         if isinstance(self.rule['command'], basestring):
-            logging.warning('Warning! You could be vulnerable to shell injection!')
+            if '%' in self.rule['command']:
+                logging.warning('Warning! You could be vulnerable to shell injection!')
             self.rule['command'] = [self.rule['command']]
 
     def alert(self, matches):

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -648,7 +648,9 @@ class CommandAlerter(Alerter):
     def __init__(self, *args):
         super(CommandAlerter, self).__init__(*args)
         self.last_command = []
+        self.shell = False
         if isinstance(self.rule['command'], basestring):
+            self.shell = True
             if '%' in self.rule['command']:
                 logging.warning('Warning! You could be vulnerable to shell injection!')
             self.rule['command'] = [self.rule['command']]
@@ -663,7 +665,7 @@ class CommandAlerter(Alerter):
 
         # Run command and pipe data
         try:
-            subp = subprocess.Popen(command, stdin=subprocess.PIPE)
+            subp = subprocess.Popen(command, stdin=subprocess.PIPE, shell=self.shell)
 
             if self.rule.get('pipe_match_json'):
                 match_json = json.dumps(matches) + '\n'

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -577,14 +577,21 @@ def test_command():
              'somefield': 'foobarbaz'}
     with mock.patch("elastalert.alerts.subprocess.Popen") as mock_popen:
         alert.alert([match])
-    assert mock_popen.called_with(['/bin/test', '--arg', 'foobarbaz'], stdin=subprocess.PIPE)
+    assert mock_popen.called_with(['/bin/test', '--arg', 'foobarbaz'], stdin=subprocess.PIPE, shell=False)
 
     # Test command as string with formatted arg
     rule = {'command': '/bin/test/ --arg %(somefield)s'}
     alert = CommandAlerter(rule)
     with mock.patch("elastalert.alerts.subprocess.Popen") as mock_popen:
         alert.alert([match])
-    assert mock_popen.called_with('/bin/test --arg foobarbaz', stdin=subprocess.PIPE)
+    assert mock_popen.called_with('/bin/test --arg foobarbaz', stdin=subprocess.PIPE, shell=False)
+
+    # Test command as string without formatted arg
+    rule = {'command': '/bin/test/foo.sh'}
+    alert = CommandAlerter(rule)
+    with mock.patch("elastalert.alerts.subprocess.Popen") as mock_popen:
+        alert.alert([match])
+    assert mock_popen.called_with('/bin/test/foo.sh', stdin=subprocess.PIPE, shell=True)
 
     # Test command with pipe_match_json
     rule = {'command': ['/bin/test/', '--arg', '%(somefield)s'],
@@ -597,7 +604,7 @@ def test_command():
         mock_popen.return_value = mock_subprocess
         mock_subprocess.communicate.return_value = (None, None)
         alert.alert([match])
-    assert mock_popen.called_with(['/bin/test', '--arg', 'foobarbaz'], stdin=subprocess.PIPE)
+    assert mock_popen.called_with(['/bin/test', '--arg', 'foobarbaz'], stdin=subprocess.PIPE, shell=False)
     assert mock_subprocess.communicate.called_with(input=json.dumps(match))
 
 


### PR DESCRIPTION
Fixes an issue where if you don't have a "%" in the command, it will interpret a string as a list.
In alert(), we treat the command as a list, but it was only being converted from a string to a list IF there was a % formatter.

See #592