### PR TITLE
Add slack channel config

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1188,6 +1188,8 @@ Optional:
 
 ``slack_username_override``: By default Slack will use your username when posting to the channel. Use this option to change it (free text).
 
+``slack_username_override``: Incoming webhooks have a default channel, but it can be overridden. A public channel can be specified "#other-channel", and a Direct Message with "@username".
+
 ``slack_emoji_override``: By default Elastalert will use the :ghost: emoji when posting to the channel. You can use a different emoji per
 Elastalert rule. Any Apple emoji can be used, see http://emojipedia.org/apple/
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -773,6 +773,7 @@ class SlackAlerter(Alerter):
             self.slack_webhook_url = [self.slack_webhook_url]
         self.slack_proxy = self.rule.get('slack_proxy', None)
         self.slack_username_override = self.rule.get('slack_username_override', 'elastalert')
+        self.slack_channel_override = self.rule.get('slack_channel_override', '')
         self.slack_emoji_override = self.rule.get('slack_emoji_override', ':ghost:')
         self.slack_msg_color = self.rule.get('slack_msg_color', 'danger')
 
@@ -794,6 +795,7 @@ class SlackAlerter(Alerter):
         proxies = {'https': self.slack_proxy} if self.slack_proxy else None
         payload = {
             'username': self.slack_username_override,
+            'channel': self.slack_channel_override,
             'icon_emoji': self.slack_emoji_override,
             'attachments': [
                 {

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -627,6 +627,7 @@ def test_slack_uses_custom_title():
 
     expected_data = {
         'username': 'elastalert',
+        'channel': '',
         'icon_emoji': ':ghost:',
         'attachments': [
             {
@@ -658,6 +659,40 @@ def test_slack_uses_rule_name_when_custom_title_is_not_provided():
 
     expected_data = {
         'username': 'elastalert',
+        'channel': '',
+        'icon_emoji': ':ghost:',
+        'attachments': [
+            {
+                'color': 'danger',
+                'title': rule['name'],
+                'text': BasicMatchString(rule, match).__str__(),
+                'fields': []
+            }
+        ]
+    }
+    mock_post_request.assert_called_once_with(rule['slack_webhook_url'][0], data=json.dumps(expected_data), headers={'content-type': 'application/json'}, proxies=None)
+
+
+def test_slack_uses_custom_slack_channel():
+    rule = {
+        'name': 'Test Rule',
+        'type': 'any',
+        'slack_webhook_url': ['http://please.dontgohere.slack'],
+        'slack_channel_override': '#test-alert',
+        'alert': []
+    }
+    load_modules(rule)
+    alert = SlackAlerter(rule)
+    match = {
+        '@timestamp': '2016-01-01T00:00:00',
+        'somefield': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+
+    expected_data = {
+        'username': 'elastalert',
+        'channel': '#test-alert',
         'icon_emoji': ':ghost:',
         'attachments': [
             {


### PR DESCRIPTION
Added configuration option to customise Slack channel as this is very easy to achieve. Our team at Paypal really want this option to be enabled.

So that we can do something like this:
```yaml
alert:
- slack:
    slack_webhook_url: "https://hooks.slack.com/services/xxxxxx"
    slack_channel_override: "#some-channel"
    alert_text: "Hello World"
```