### PR TITLE
Added option for silencing rules before enhancements run

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -417,7 +417,8 @@ run_enhancements_first
 ^^^^^^^^^^^^^^^^^^^^^^
 
 ``run_enhancements_first``: If set to true, enhancements will be run as soon as a match is found. This means that they can be changed
-or dropped before affecting realert or being added to an aggregation. (Optional, boolean, default false)
+or dropped before affecting realert or being added to an aggregation. Silence stashes will still be created before the
+enhancement runs, meaning even if a ``DropMatchException`` is raised, the rule will still be silenced. (Optional, boolean, default false)
 
 query_key
 ^^^^^^^^^

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -419,12 +419,6 @@ run_enhancements_first
 ``run_enhancements_first``: If set to true, enhancements will be run as soon as a match is found. This means that they can be changed
 or dropped before affecting realert or being added to an aggregation. (Optional, boolean, default false)
 
-silence_matches_first
-^^^^^^^^^^^^^^^^^^^^^
-
-``silence_matches_first``: If set to true, a silence stash will be created for matches before enhancements are run. This means that even
-if a ``DropMatchException`` is raised, the rule will be silenced. (Optional, boolean, default false)
-
 query_key
 ^^^^^^^^^
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -419,6 +419,12 @@ run_enhancements_first
 ``run_enhancements_first``: If set to true, enhancements will be run as soon as a match is found. This means that they can be changed
 or dropped before affecting realert or being added to an aggregation. (Optional, boolean, default false)
 
+silence_matches_first
+^^^^^^^^^^^^^^^^^^^^^
+
+``silence_matches_first``: If set to true, a silence stash will be created for matches before enhancements are run. This means that even
+if a ``DropMatchException`` is raised, the rule will be silenced.
+
 query_key
 ^^^^^^^^^
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -423,7 +423,7 @@ silence_matches_first
 ^^^^^^^^^^^^^^^^^^^^^
 
 ``silence_matches_first``: If set to true, a silence stash will be created for matches before enhancements are run. This means that even
-if a ``DropMatchException`` is raised, the rule will be silenced.
+if a ``DropMatchException`` is raised, the rule will be silenced. (Optional, boolean, default false)
 
 query_key
 ^^^^^^^^^

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -571,7 +571,7 @@ class ElastAlerter():
                 elastalert_logger.info('Ignoring match for silenced rule %s%s' % (rule['name'], key))
                 continue
 
-            if rule['realert'] and rule.get('silence_matches_first'):
+            if rule['realert']:
                 next_alert, exponent = self.next_alert_time(rule, rule['name'] + key, ts_now())
                 self.set_realert(rule['name'] + key, next_alert, exponent)
 
@@ -584,10 +584,6 @@ class ElastAlerter():
                             self.handle_error("Error running match enhancement: %s" % (e), {'rule': rule['name']})
                 except DropMatchException:
                     continue
-
-            if rule['realert'] and not rule.get('silence_matches_first'):
-                next_alert, exponent = self.next_alert_time(rule, rule['name'] + key, ts_now())
-                self.set_realert(rule['name'] + key, next_alert, exponent)
 
             # If no aggregation, alert immediately
             if not rule['aggregation']:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -571,6 +571,10 @@ class ElastAlerter():
                 elastalert_logger.info('Ignoring match for silenced rule %s%s' % (rule['name'], key))
                 continue
 
+            if rule['realert'] and rule.get('silence_matches_first'):
+                next_alert, exponent = self.next_alert_time(rule, rule['name'] + key, ts_now())
+                self.set_realert(rule['name'] + key, next_alert, exponent)
+
             if rule.get('run_enhancements_first'):
                 try:
                     for enhancement in rule['match_enhancements']:
@@ -581,7 +585,7 @@ class ElastAlerter():
                 except DropMatchException:
                     continue
 
-            if rule['realert']:
+            if rule['realert'] and not rule.get('silence_matches_first'):
                 next_alert, exponent = self.next_alert_time(rule, rule['name'] + key, ts_now())
                 self.set_realert(rule['name'] + key, next_alert, exponent)
 


### PR DESCRIPTION
~~Adds an option so that you can silence rules after a match even if the enhancements drop the match.~~

run_enhancements_first runs AFTER silence stash is created