### PR TITLE
Slack Push Notifications

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -777,6 +777,7 @@ class SlackAlerter(Alerter):
         self.slack_emoji_override = self.rule.get('slack_emoji_override', ':ghost:')
         self.slack_msg_color = self.rule.get('slack_msg_color', 'danger')
         self.slack_parse_override = self.rule.get('slack_parse_override', 'none')
+        self.slack_text_string = self.rule.get('slack_text_string', '')
 
     def format_body(self, body):
         # https://api.slack.com/docs/formatting
@@ -799,6 +800,7 @@ class SlackAlerter(Alerter):
             'channel': self.slack_channel_override,
             'icon_emoji': self.slack_emoji_override,
             'parse': self.slack_parse_override,
+            'text': self.slack_text_string,
             'attachments': [
                 {
                     'color': self.slack_msg_color,

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -776,6 +776,7 @@ class SlackAlerter(Alerter):
         self.slack_channel_override = self.rule.get('slack_channel_override', '')
         self.slack_emoji_override = self.rule.get('slack_emoji_override', ':ghost:')
         self.slack_msg_color = self.rule.get('slack_msg_color', 'danger')
+        self.slack_parse_override = self.rule.get('slack_parse_override', 'none')
 
     def format_body(self, body):
         # https://api.slack.com/docs/formatting
@@ -797,6 +798,7 @@ class SlackAlerter(Alerter):
             'username': self.slack_username_override,
             'channel': self.slack_channel_override,
             'icon_emoji': self.slack_emoji_override,
+            'parse': self.slack_parse_override,
             'attachments': [
                 {
                     'color': self.slack_msg_color,

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -208,6 +208,7 @@ properties:
   slack_emoji_override: {type: string}
   slack_msg_color: {enum: [good, warning, danger]}
   slack_parse_override: {enum: [none, full]}
+  slack_text_string: {type: string}
 
   ### PagerDuty
   pagerduty_service_key: {type: string}

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -207,6 +207,7 @@ properties:
   slack_username_override: {type: string}
   slack_emoji_override: {type: string}
   slack_msg_color: {enum: [good, warning, danger]}
+  slack_parse_override: {enum: [none, full]}
 
   ### PagerDuty
   pagerduty_service_key: {type: string}


### PR DESCRIPTION
Slack allows push notifications with particular keywords, such as @channel and @username. This is useful to send alerts directly to a smartphone etc.

To accomplish this, you first need to send 'parse: full' to the Slack webhook, this is set to none by default.

The current Slack implementation only appears to trigger on mentions within a text string and not within an attachment, which is the reason for slack_text_string.

The rule can then be configured with:

slack_parse_override: full
slack_text_string: "@channel Elastalert: Alert"
slack_webhook_url: