### PR TITLE
Handle single unicode strings in email recipients

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -273,15 +273,15 @@ class EmailAlerter(Alerter):
         if self.rule.get('smtp_auth_file'):
             self.get_account(self.rule['smtp_auth_file'])
         # Convert email to a list if it isn't already
-        if isinstance(self.rule['email'], str):
+        if isinstance(self.rule['email'], basestring):
             self.rule['email'] = [self.rule['email']]
         # If there is a cc then also convert it a list if it isn't
         cc = self.rule.get('cc')
-        if cc and isinstance(cc, str):
+        if cc and isinstance(cc, basestring):
             self.rule['cc'] = [self.rule['cc']]
         # If there is a bcc then also convert it to a list if it isn't
         bcc = self.rule.get('bcc')
-        if bcc and isinstance(bcc, str):
+        if bcc and isinstance(bcc, basestring):
             self.rule['bcc'] = [self.rule['bcc']]
 
     def alert(self, matches):

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -108,6 +108,30 @@ def test_email():
         assert 'From: testfrom@test.test' in body
         assert 'Subject: Test alert for test_value, owned by owner_value' in body
 
+def test_email_with_unicode_strings():
+    rule = {'name': 'test alert', 'email': u'testing@test.test', 'from_addr': 'testfrom@test.test',
+            'type': mock_rule(), 'timestamp_field': '@timestamp', 'email_reply_to': 'test@example.com', 'owner': 'owner_value',
+            'alert_subject': 'Test alert for {0}, owned by {1}', 'alert_subject_args': ['test_term', 'owner'], 'snowman': u'☃'}
+    with mock.patch('elastalert.alerts.SMTP') as mock_smtp:
+        mock_smtp.return_value = mock.Mock()
+
+        alert = EmailAlerter(rule)
+        alert.alert([{'test_term': 'test_value'}])
+        expected = [mock.call('localhost'),
+                    mock.call().ehlo(),
+                    mock.call().has_extn('STARTTLS'),
+                    mock.call().starttls(),
+                    mock.call().sendmail(mock.ANY, [u'testing@test.test'], mock.ANY),
+                    mock.call().close()]
+        assert mock_smtp.mock_calls == expected
+
+        body = mock_smtp.mock_calls[4][1][2]
+
+        assert 'Reply-To: test@example.com' in body
+        assert 'To: testing@test.test' in body
+        assert 'From: testfrom@test.test' in body
+        assert 'Subject: Test alert for test_value, owned by owner_value' in body
+
 
 def test_email_with_auth():
     rule = {'name': 'test alert', 'email': ['testing@test.test', 'test@test.test'], 'from_addr': 'testfrom@test.test',


### PR DESCRIPTION
This PR fix a bug related to single unicode strings in email recipients.

Today, if we configure a rule with a single email recipient as an unicode string, the alert emails will be sent with the recipient string split in single chars.

For example:
If the recipient is `u'email@gmail.com'`, the alert emails will be sent to `e,m,a,i,l,@,g,m,a,i,l,.,c,o,m`.