### PR TITLE
Added a REST API to List, Create, and Test rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ docs/build/
 build/
 
 my_rules
-certificate

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs/build/
 build/
 
 my_rules
+certificate

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -25,7 +25,7 @@ es_port: 9200
 # Connect with SSL to elasticsearch
 #use_ssl: True
 
-# GET request with body is the default option for Elasticsearch. 
+# GET request with body is the default option for Elasticsearch.
 # If it fails for some reason, you can pass 'GET', 'POST' or 'source'.
 # See http://elasticsearch-py.readthedocs.io/en/master/connection.html?highlight=send_get_body_as#transport
 # for details
@@ -44,3 +44,7 @@ writeback_index: elastalert_status
 # sending the alert until this time period has elapsed
 alert_time_limit:
   days: 2
+
+# API server options
+#api_server_authentication_enabled: true
+#api_server_authentication_key: PrivateKeyGoesHere

--- a/elastalert/api.py
+++ b/elastalert/api.py
@@ -11,6 +11,7 @@ import jsonschema
 from util import EAException
 from base64 import b64encode, b64decode
 from test_rule import MockElastAlerter
+from werkzeug.serving import make_ssl_devcert
 import StringIO
 from flask.ext.cors import CORS
 
@@ -181,8 +182,9 @@ def rules():
         # GET
         return jsonify(load_rules())
 
-def main():
-    app.run(debug=True, ssl_context=('/Users/calebc/Projects/elastalert/certificates/server.crt', '/Users/calebc/Projects/elastalert/certificates/server.key'))
+def debug():
+    context = make_ssl_devcert('certificate/server', host='localhost')
+    app.run(debug=True, threaded=True, ssl_context=context)
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug()

--- a/elastalert/api.py
+++ b/elastalert/api.py
@@ -117,7 +117,8 @@ def test_rule(filepath, days=1):
 def index():
     return jsonify({ "name": "ElastAlert Rest API" })
 
-@app.route("/elastalert/api/rules/<rule_id>", methods=['GET', 'DELETE', 'POST'])
+@app.route("/elastalert/api/rules/<rule_id>", methods=['GET', 'DELETE', 'POST',
+                                                       'PUT'])
 def rule(rule_id):
     if request.method == 'DELETE':
         rules = load_rules()
@@ -126,7 +127,7 @@ def rule(rule_id):
             return jsonify({"response": "Rule Deleted"})
         else:
             return jsonify({"response": "Invalid rule_id"})
-    if request.method == 'POST':
+    if request.method == 'POST' or request.method == 'PUT':
         # Update existing rule
         rules = load_rules()
         if rule_id in rules:

--- a/elastalert/api.py
+++ b/elastalert/api.py
@@ -66,8 +66,7 @@ def create_rule(rule):
 
 def verify_rule(rule):
     # Verify rule has required fields
-    required_fields = ["es_host", "es_port", "index", "name", "type",
-                       "alert"]
+    required_fields = ["index", "name", "type", "alert"]
     if all(field in rule for field in required_fields):
         return True
     else:
@@ -131,9 +130,9 @@ def rule(rule_id):
         # Update existing rule
         rules = load_rules()
         if rule_id in rules:
-            os.remove(rules[rule_id]["rule_file"])
             new_rule = request.get_json()
             if verify_rule(new_rule):
+                os.remove(rules[rule_id]["rule_file"])
                 if create_rule(new_rule):
                     return jsonify({"response": "Rule Updated"})
                 else:

--- a/elastalert/api.py
+++ b/elastalert/api.py
@@ -9,8 +9,11 @@ from datetime import datetime
 from util import EAException
 from functools import wraps
 import jsonschema
+import tempfile
 import StringIO
 import argparse
+import atexit
+import shutil
 import string
 import yaml
 import sys
@@ -204,9 +207,19 @@ def rules():
         # GET
         return jsonify(load_rules())
 
+def cleanup(filepath):
+    shutil.rmtree(os.path.dirname(filepath), ignore_errors=True)
+
 def debug():
-    context = make_ssl_devcert('certificate/server', host='localhost')
+    tempPath = tempfile.mkdtemp() + "/server"
+    atexit.register(cleanup, tempPath)
+
+    print(tempPath)
+
+    context = make_ssl_devcert(tempPath, host='localhost')
     app.run(debug=True, threaded=True, ssl_context=context)
+
+
 
 if __name__ == '__main__':
     debug()

--- a/elastalert/api.py
+++ b/elastalert/api.py
@@ -1,0 +1,149 @@
+import argparse
+from flask import Flask, jsonify, request
+import sys
+from config import get_file_paths, load_configuration
+from staticconf.loader import yaml_loader
+import yaml
+import re
+import string
+import os
+from util import EAException
+from base64 import b64encode, b64decode
+from test_rule import MockElastAlerter
+import StringIO
+from flask.ext.cors import CORS
+
+""" A REST API webserver that allows for interaction with ElastAlert from
+an API. """
+
+app = Flask(__name__)
+CORS(app)
+
+# Parse the arguments
+parser = argparse.ArgumentParser()
+parser.add_argument('--config', action='store', dest='config', default="config.yaml", help='Global config file (default: config.yaml)')
+parser.add_argument('--rule', dest='rule', help='Run only a specific rule (by filename, must still be in rules folder)')
+args = parser.parse_args(sys.argv[1:])
+conf = {}
+
+def load_rules():
+    global conf
+    conf = yaml_loader(args.config)
+    conf.setdefault('max_query_size', 100000)
+    conf.setdefault('disable_rules_on_error', True)
+    # Load each rule configuration file
+    rules = {} # empty rules dict
+    rule_files = get_file_paths(conf)
+    for rule_file in rule_files:
+        try:
+            rule = yaml_loader(rule_file)
+            rule['rule_file'] = rule_file
+        except yaml.scanner.ScannerError as e:
+            raise EAException('Could not parse file %s: %s' % (filename, e))
+        except EAException as e:
+            raise EAException('Error loading file %s: %s' % (rule_file, e))
+
+        rule['rule_id'] = b64encode(rule['name'])
+        rules[rule['rule_id']] = rule
+    return rules
+
+def slugify(s):
+    """ Convert String to a filename slug """
+    valid_chars = "-_.()%s%s" % (string.ascii_letters, string.digits)
+    return ''.join(c for c in s if c in valid_chars)
+
+def save_rule(filepath, rule):
+    if not os.path.exists(os.path.dirname(filepath)):
+        os.makedirs(os.path.dirname(filepath))
+    with open(filepath, 'w') as outfile:
+        outfile.write(yaml.safe_dump(rule, default_flow_style=False))
+
+def test_rule(filepath, days=1):
+    test_instance = MockElastAlerter()
+
+    # I have to do some hackery to mimic an argparser object
+    def args():
+        file = None
+        schema_only = None
+        days = None
+        save = None
+        count = None
+
+    args.file = filepath
+    args.schema_only = False
+    args.days = days
+    args.save = False
+    args.count = False
+
+    # Redirect STDOUT to get output from rule test
+    testOutputHandler = StringIO.StringIO()
+    sys.stdout = testOutputHandler
+    sys.stderr = testOutputHandler
+
+    # Run rule test
+    test_instance.test_file(args)
+
+    # Assign output of method to string
+    ruleTestOutput = testOutputHandler.getvalue()
+
+    # Restore sys.stdout and sys.stderr
+    sys.stdout = sys.__stdout__
+    sys.stderr = sys.__stderr__
+
+    return ruleTestOutput
+
+@app.route("/elastalert/api", methods=['GET'])
+def index():
+    return jsonify({ "name": "ElastAlert Rest API" })
+
+@app.route("/elastalert/api/rules/<rule_id>", methods=['GET', 'DELETE'])
+def rule(rule_id):
+    if request.method == 'DELETE':
+        rules = load_rules()
+        if rule_id in rules:
+            os.remove(rules[rule_id]["rule_file"])
+            return jsonify({"response": "Rule Deleted"})
+    else:
+        # GET
+        rules = load_rules()
+        return jsonify(rules[rule_id])
+
+@app.route("/elastalert/api/rules/test", methods=['POST'])
+def test():
+    rule = request.get_json()
+
+    filepath = "%s/%s.yaml" % ("temp_test_rules",
+                               slugify(rule["name"]))
+
+    save_rule(filepath, rule)
+
+    result = test_rule(filepath)
+
+    return jsonify({"test_results": result})
+
+@app.route("/elastalert/api/rules", methods=['GET', 'POST'])
+def rules():
+    if request.method == 'POST':
+        # create a rule
+        new_rule = request.get_json()
+        load_rules()
+
+        # Verify rule has required fields
+        required_fields = ["es_host", "es_port", "index", "name", "type",
+                           "alert"]
+        if all(field in new_rule for field in required_fields):
+            filepath = "%s/%s.yaml" % (conf['rules_folder'],
+                                       slugify(new_rule["name"]))
+            save_rule(filepath, new_rule)
+            return jsonify({"response": "Rule Created"})
+        else:
+            return jsonify({"response": "Rule Invalid"})
+    else:
+        # GET
+        return jsonify(load_rules())
+
+def main():
+    app.run(debug=True, ssl_context=('/Users/calebc/Projects/elastalert/certificates/server.crt', '/Users/calebc/Projects/elastalert/certificates/server.key'))
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/elastalert/api.py
+++ b/elastalert/api.py
@@ -88,13 +88,11 @@ def test_rule(filepath, days=1):
 
     # I have to do some hackery to mimic an argparser object
     def args():
-        file = None
         schema_only = None
         days = None
         save = None
         count = None
 
-    args.file = filepath
     args.schema_only = False
     args.days = days
     args.save = False
@@ -106,7 +104,7 @@ def test_rule(filepath, days=1):
     sys.stderr = testOutputHandler
 
     # Run rule test
-    test_instance.test_file(args)
+    test_instance.test_file(filepath, args)
 
     # Assign output of method to string
     ruleTestOutput = testOutputHandler.getvalue()
@@ -155,12 +153,7 @@ def rule(rule_id):
 def test():
     rule = request.get_json()
 
-    filepath = "%s/%s.yaml" % ("temp_test_rules",
-                               slugify(rule["name"]))
-
-    save_rule(filepath, rule)
-
-    result = test_rule(filepath)
+    result = test_rule(rule)
 
     return jsonify({"test_results": result})
 

--- a/elastalert/api.py
+++ b/elastalert/api.py
@@ -217,7 +217,7 @@ def debug():
     print(tempPath)
 
     context = make_ssl_devcert(tempPath, host='localhost')
-    app.run(debug=True, threaded=True, ssl_context=context)
+    app.run(host="0.0.0.0", port=5000, debug=True, threaded=True, ssl_context=context)
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ unittest2==0.8.0
 urllib3==1.8.2
 wsgiref==0.1.2
 Flask==0.10.1
+Flask-Cors==2.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ urllib3==1.8.2
 wsgiref==0.1.2
 Flask==0.10.1
 Flask-Cors==2.1.2
+cryptography==1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ tlslite==0.4.8
 unittest2==0.8.0
 urllib3==1.8.2
 wsgiref==0.1.2
+Flask==0.10.1

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         'console_scripts': ['elastalert-create-index=elastalert.create_index:main',
                             'elastalert-test-rule=elastalert.test_rule:main',
                             'elastalert-rule-from-kibana=elastalert.rule_from_kibana:main',
-                            'elastalert-api-server=elastalert.api:main',
+                            'elastalert-api-server-debug=elastalert.api:debug',
                             'elastalert=elastalert.elastalert:main']},
     packages=find_packages(),
     package_data={'elastalert': ['schema.yaml']},

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
     entry_points={
         'console_scripts': ['elastalert-create-index=elastalert.create_index:main',
                             'elastalert-test-rule=elastalert.test_rule:main',
-                            'elastalert-rule-from-kibana=elastalert.rule_from_kibana:main']},
+                            'elastalert-rule-from-kibana=elastalert.rule_from_kibana:main',
+                            'elastalert-api-server=elastalert.api:main']},
     packages=find_packages(),
     package_data={'elastalert': ['schema.yaml']},
     install_requires=[
@@ -30,5 +31,6 @@ setup(
         'PyStaticConfiguration',
         'pyyaml',
         'simplejson',
+        'flask',
     ]
 )


### PR DESCRIPTION
Below are some changes I made to ElastAlert that add a REST API. I added this because I've been working on a kibana plugin that I'll hopefully be releasing soon that will allow for quick and easy management of ElastAlert Rules from directly within kibana. Figured I'd push these now though because it might help other out there that want to do something similar.