### PR TITLE
Allow nested filter with change in schema

### DIFF
--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -145,7 +145,7 @@ properties:
   filter :
     type: [array, object]
     items: *filter
-    additionalProperties: false
+    additionalProperties: true
     properties:
         download_dashboard: {type: string}
 


### PR DESCRIPTION
Add support for nested filter [ES Nested Filter DSL](https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-nested-query.html) 

### Example:
```
filter:
  - nested:
      path: nested
      query:
        exists:
          field: nested
```

Possible side effect might be dropped support for:
```
filter:
  term: a
```
This will not work as the filter object is now a dict. Might be fixed with more advanced schema.