### PR TITLE
Add fail_on_non_zero_exit field to CommandAlerter

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -677,6 +677,8 @@ class CommandAlerter(Alerter):
             if self.rule.get('pipe_match_json'):
                 match_json = json.dumps(matches, cls=DateTimeEncoder) + '\n'
                 stdout, stderr = subp.communicate(input=match_json)
+            if self.rule.get("fail_on_non_zero_exit", False) and subp.wait():
+                raise EAException("Non-zero exit code while running command %s" % (' '.join(command)))
         except OSError as e:
             raise EAException("Error while running command %s: %s" % (' '.join(command), e))
 

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -171,6 +171,7 @@ properties:
   ### Commands
   command: *arrayOfString
   pipe_match_json: {type: boolean}
+  fail_on_non_zero_exit: {type: boolean}
 
   ### Email
   email: *arrayOfString


### PR DESCRIPTION
Allows monitoring of when commands fail to run.
When a command returns a non-zero exit status, the alert raises an exception.
