### PR TITLE
update configparser version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ aws-requests-auth==0.2.5
 blist==1.3.6
 boto==2.34.0
 botocore==1.4.5
-configparser==3.3.0r2
+configparser>=3.3.0r2
 croniter==0.3.8
 elasticsearch==1.3.0
 jira==0.32


### PR DESCRIPTION
Had a problem installing on aws ami with python 2.7
This PR allows to use newer configparser versions.
