### PR TITLE
Fixed double text

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -120,7 +120,10 @@ class BasicMatchString(object):
             return json.dumps(blob, cls=DateTimeEncoder, sort_keys=True, indent=4, encoding='Latin-1', ensure_ascii=False)
 
     def __str__(self):
-        self.text = self.rule['name'] + '\n\n'
+        self.text = ''
+        if 'alert_text' not in self.rule:
+            self.text += self.rule['name'] + '\n\n'
+
         self._add_custom_alert_text()
         self._ensure_new_line()
         if self.rule.get('alert_text_type') != 'alert_text_only':

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -52,6 +52,7 @@ def test_basic_match_string(ea):
     ea.rules[0]['alert_text'] = 'custom text'
     alert_text = unicode(BasicMatchString(ea.rules[0], match))
     assert 'custom text' in alert_text
+    assert 'anytest' not in alert_text
 
     ea.rules[0]['alert_text_type'] = 'alert_text_only'
     alert_text = unicode(BasicMatchString(ea.rules[0], match))


### PR DESCRIPTION
# Motivation
We should not see a duplicate message, if we set the alert text
```yaml
alert_text: "message"
```
![Slack alert](https://s3.postimg.org/6mai2f183/Screen_Shot_2016_08_23_at_2_49_16_AM.png)

If we need a duplicate message
```yaml
alert_text: "{0} \n\nmessage"
alert_text_args:
  - name
```