### PR TITLE
Moved new_elasticsearch into util

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -3,7 +3,6 @@ import copy
 import datetime
 
 from blist import sortedlist
-from elasticsearch.client import Elasticsearch
 from util import add_raw_postfix
 from util import dt_to_ts
 from util import EAException
@@ -11,6 +10,7 @@ from util import elastalert_logger
 from util import format_index
 from util import hashable
 from util import lookup_es_key
+from util import new_elasticsearch
 from util import new_get_event_ts
 from util import pretty_ts
 from util import ts_now
@@ -521,12 +521,7 @@ class NewTermsRule(RuleType):
 
     def get_all_terms(self, args):
         """ Performs a terms aggregation for each field to get every existing term. """
-        self.es = Elasticsearch(
-            host=self.rules['es_host'],
-            port=self.rules['es_port'],
-            timeout=self.rules.get('es_conn_timeout', 50),
-            send_get_body_as=self.rules.get('send_get_body_as', 'GET')
-        )
+        self.es = new_elasticsearch(self.rules)
         window_size = datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))
         field_name = {"field": "", "size": 2147483647}  # Integer.MAX_VALUE
         query_template = {"aggs": {"values": {"terms": field_name}}}

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -7,10 +7,10 @@ from util import add_raw_postfix
 from util import dt_to_ts
 from util import EAException
 from util import elastalert_logger
+from util import elasticsearch_client
 from util import format_index
 from util import hashable
 from util import lookup_es_key
-from util import new_elasticsearch
 from util import new_get_event_ts
 from util import pretty_ts
 from util import ts_now
@@ -521,7 +521,7 @@ class NewTermsRule(RuleType):
 
     def get_all_terms(self, args):
         """ Performs a terms aggregation for each field to get every existing term. """
-        self.es = new_elasticsearch(self.rules)
+        self.es = elasticsearch_client(self.rules)
         window_size = datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))
         field_name = {"field": "", "size": 2147483647}  # Integer.MAX_VALUE
         query_template = {"aggs": {"values": {"terms": field_name}}}

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -19,6 +19,7 @@ import yaml
 from elastalert.config import load_modules
 from elastalert.config import load_options
 from elastalert.elastalert import ElastAlerter
+from elastalert.util import elasticsearch_client
 from elastalert.util import lookup_es_key
 from elastalert.util import ts_now
 from elastalert.util import ts_to_dt
@@ -47,8 +48,7 @@ class MockElastAlerter(object):
             return []
 
         # Set up elasticsearch client and query
-        es_config = ElastAlerter.build_es_conn_config(conf)
-        es_client = ElastAlerter.elasticsearch_client(es_config)
+        es_client = elasticsearch_client(conf)
         start_time = ts_now() - datetime.timedelta(days=args.days)
         end_time = ts_now()
         ts = conf.get('timestamp_field', '@timestamp')

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -48,7 +48,7 @@ class MockElastAlerter(object):
 
         # Set up elasticsearch client and query
         es_config = ElastAlerter.build_es_conn_config(conf)
-        es_client = ElastAlerter.new_elasticsearch(es_config)
+        es_client = ElastAlerter.elasticsearch_client(es_config)
         start_time = ts_now() - datetime.timedelta(days=args.days)
         end_time = ts_now()
         ts = conf.get('timestamp_field', '@timestamp')
@@ -171,7 +171,7 @@ class MockElastAlerter(object):
         elastalert.get_hits_count = self.mock_count
         elastalert.get_hits_terms = self.mock_terms
         elastalert.get_hits = self.mock_hits
-        elastalert.new_elasticsearch = mock.Mock()
+        elastalert.elasticsearch_client = mock.Mock()
 
     def run_elastalert(self, rule, conf, args):
         """ Creates an ElastAlert instance and run's over for a specific rule using either real or mock data. """

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -4,6 +4,9 @@ import logging
 
 import dateutil.parser
 import dateutil.tz
+from auth import Auth
+from elasticsearch import RequestsHttpConnection
+from elasticsearch.client import Elasticsearch
 
 logging.basicConfig()
 elastalert_logger = logging.getLogger('elastalert')
@@ -244,3 +247,57 @@ def add_raw_postfix(field):
     if not field.endswith('.raw'):
         field += '.raw'
     return field
+
+
+def new_elasticsearch(conf):
+    """ returns an Elasticsearch instance configured using an es_conn_config """
+    es_conn_conf = build_es_conn_config(conf)
+    auth = Auth()
+    es_conn_conf['http_auth'] = auth(host=es_conn_conf['es_host'],
+                                     username=es_conn_conf['es_username'],
+                                     password=es_conn_conf['es_password'],
+                                     aws_region=es_conn_conf['aws_region'],
+                                     boto_profile=es_conn_conf['boto_profile'])
+
+    return Elasticsearch(host=es_conn_conf['es_host'],
+                         port=es_conn_conf['es_port'],
+                         url_prefix=es_conn_conf['es_url_prefix'],
+                         use_ssl=es_conn_conf['use_ssl'],
+                         connection_class=RequestsHttpConnection,
+                         http_auth=es_conn_conf['http_auth'],
+                         timeout=es_conn_conf['es_conn_timeout'],
+                         send_get_body_as=es_conn_conf['send_get_body_as'])
+
+
+def build_es_conn_config(conf):
+    """ Given a conf dictionary w/ raw config properties 'use_ssl', 'es_host', 'es_port'
+    'es_username' and 'es_password', this will return a new dictionary
+    with properly initialized values for 'es_host', 'es_port', 'use_ssl' and 'http_auth' which
+    will be a basicauth username:password formatted string """
+    parsed_conf = {}
+    parsed_conf['use_ssl'] = False
+    parsed_conf['http_auth'] = None
+    parsed_conf['es_username'] = None
+    parsed_conf['es_password'] = None
+    parsed_conf['aws_region'] = None
+    parsed_conf['boto_profile'] = None
+    parsed_conf['es_host'] = conf['es_host']
+    parsed_conf['es_port'] = conf['es_port']
+    parsed_conf['es_url_prefix'] = ''
+    parsed_conf['es_conn_timeout'] = 10
+    parsed_conf['send_get_body_as'] = conf.get('es_send_get_body_as', 'GET')
+
+    if 'es_username' in conf:
+        parsed_conf['es_username'] = conf['es_username']
+        parsed_conf['es_password'] = conf['es_password']
+
+    if 'aws_region' in conf:
+        parsed_conf['aws_region'] = conf['aws_region']
+
+    if 'boto_profile' in conf:
+        parsed_conf['boto_profile'] = conf['boto_profile']
+
+    if 'use_ssl' in conf:
+        parsed_conf['use_ssl'] = conf['use_ssl']
+
+    return parsed_conf

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -249,7 +249,7 @@ def add_raw_postfix(field):
     return field
 
 
-def new_elasticsearch(conf):
+def elasticsearch_client(conf):
     """ returns an Elasticsearch instance configured using an es_conn_config """
     es_conn_conf = build_es_conn_config(conf)
     auth = Auth()

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -569,7 +569,7 @@ def test_kibana(ea):
             'include': ['@timestamp'],
             'timestamp_field': '@timestamp'}
     match = {'@timestamp': '2014-10-10T00:00:00'}
-    with mock.patch("elastalert.elastalert.Elasticsearch") as mock_es:
+    with mock.patch("elastalert.elastalert.new_elasticsearch") as mock_es:
         mock_create = mock.Mock(return_value={'_id': 'ABCDEFGH'})
         mock_es_inst = mock.Mock()
         mock_es_inst.create = mock_create

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -569,7 +569,7 @@ def test_kibana(ea):
             'include': ['@timestamp'],
             'timestamp_field': '@timestamp'}
     match = {'@timestamp': '2014-10-10T00:00:00'}
-    with mock.patch("elastalert.elastalert.new_elasticsearch") as mock_es:
+    with mock.patch("elastalert.elastalert.elasticsearch_client") as mock_es:
         mock_create = mock.Mock(return_value={'_id': 'ABCDEFGH'})
         mock_es_inst = mock.Mock()
         mock_es_inst.create = mock_create

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -178,7 +178,7 @@ def test_match(ea):
     hits = generate_hits([START_TIMESTAMP, END_TIMESTAMP])
     ea.current_es.search.return_value = hits
     ea.rules[0]['type'].matches = [{'@timestamp': END}]
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         ea.run_rule(ea.rules[0], END, START)
 
     ea.rules[0]['alert'][0].alert.called_with({'@timestamp': END_TIMESTAMP})
@@ -204,7 +204,7 @@ def test_run_rule_calls_garbage_collect(ea):
 
 
 def run_rule_query_exception(ea, mock_es):
-    with mock.patch('elastalert.elastalert.Elasticsearch') as mock_es_init:
+    with mock.patch('elastalert.elastalert.new_elasticsearch') as mock_es_init:
         mock_es_init.return_value = mock_es
         ea.run_rule(ea.rules[0], END, START)
 
@@ -246,7 +246,7 @@ def test_match_with_module_with_agg(ea):
     hits = generate_hits([START_TIMESTAMP, END_TIMESTAMP])
     ea.current_es.search.return_value = hits
     ea.rules[0]['type'].matches = [{'@timestamp': END}]
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         ea.run_rule(ea.rules[0], END, START)
     assert mod.process.call_count == 0
 
@@ -260,7 +260,7 @@ def test_match_with_enhancements_first(ea):
     hits = generate_hits([START_TIMESTAMP, END_TIMESTAMP])
     ea.current_es.search.return_value = hits
     ea.rules[0]['type'].matches = [{'@timestamp': END}]
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         with mock.patch.object(ea, 'add_aggregated_alert') as add_alert:
             ea.run_rule(ea.rules[0], END, START)
     mod.process.assert_called_with({'@timestamp': END})
@@ -269,7 +269,7 @@ def test_match_with_enhancements_first(ea):
     # Assert that dropmatchexception behaves properly
     mod.process = mock.MagicMock(side_effect=DropMatchException)
     ea.rules[0]['type'].matches = [{'@timestamp': END}]
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         with mock.patch.object(ea, 'add_aggregated_alert') as add_alert:
             ea.run_rule(ea.rules[0], END, START)
     mod.process.assert_called_with({'@timestamp': END})
@@ -282,7 +282,7 @@ def test_agg(ea):
     alerttime1 = dt_to_ts(ts_to_dt(hits_timestamps[0]) + datetime.timedelta(minutes=10))
     hits = generate_hits(hits_timestamps)
     ea.current_es.search.return_value = hits
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         # Aggregate first two, query over full range
         ea.rules[0]['aggregation'] = datetime.timedelta(minutes=10)
         ea.rules[0]['type'].matches = [{'@timestamp': h} for h in hits_timestamps]
@@ -313,7 +313,7 @@ def test_agg(ea):
                                           {'hits': {'hits': [{'_id': 'BCDE', '_source': call2}]}},
                                           {'hits': {'total': 0, 'hits': []}}]
 
-    with mock.patch('elastalert.elastalert.Elasticsearch') as mock_es:
+    with mock.patch('elastalert.elastalert.new_elasticsearch') as mock_es:
         ea.send_pending_alerts()
         # Assert that current_es was refreshed from the aggregate rules
         assert mock_es.called_with(host='', port='')
@@ -339,7 +339,7 @@ def test_agg_cron(ea):
     alerttime1 = dt_to_ts(ts_to_dt('2014-09-26T12:46:00'))
     alerttime2 = dt_to_ts(ts_to_dt('2014-09-26T13:04:00'))
 
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         with mock.patch('elastalert.elastalert.croniter.get_next') as mock_ts:
             # Aggregate first two, query over full range
             mock_ts.side_effect = [dt_to_unix(ts_to_dt('2014-09-26T12:46:00')), dt_to_unix(ts_to_dt('2014-09-26T13:04:00'))]
@@ -378,7 +378,7 @@ def test_agg_no_writeback_connectivity(ea):
                                    {'@timestamp': hit2},
                                    {'@timestamp': hit3}]
     ea.writeback_es.create.side_effect = elasticsearch.exceptions.ElasticsearchException('Nope')
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         with mock.patch.object(ea, 'find_pending_aggregate_alert', return_value=None):
             ea.run_rule(ea.rules[0], END, START)
 
@@ -389,7 +389,7 @@ def test_agg_no_writeback_connectivity(ea):
     ea.current_es.search.return_value = {'hits': {'total': 0, 'hits': []}}
     ea.add_aggregated_alert = mock.Mock()
 
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         ea.run_rule(ea.rules[0], END, START)
 
     ea.add_aggregated_alert.assert_any_call({'@timestamp': hit1}, ea.rules[0])
@@ -406,7 +406,7 @@ def test_silence(ea):
     # Don't alert even with a match
     match = [{'@timestamp': '2014-11-17T00:00:00'}]
     ea.rules[0]['type'].matches = match
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         ea.run_rule(ea.rules[0], END, START)
     assert ea.rules[0]['alert'][0].alert.call_count == 0
 
@@ -414,7 +414,7 @@ def test_silence(ea):
     match = [{'@timestamp': '2014-11-17T00:00:00'}]
     ea.rules[0]['type'].matches = match
     with mock.patch('elastalert.elastalert.ts_now') as mock_ts:
-        with mock.patch('elastalert.elastalert.Elasticsearch'):
+        with mock.patch('elastalert.elastalert.new_elasticsearch'):
             # Converted twice to add tzinfo
             mock_ts.return_value = ts_to_dt(dt_to_ts(datetime.datetime.utcnow() + datetime.timedelta(hours=5)))
             ea.run_rule(ea.rules[0], END, START)
@@ -442,7 +442,7 @@ def test_silence_query_key(ea):
     match = [{'@timestamp': '2014-11-17T00:00:00', 'username': 'qlo'}]
     ea.rules[0]['type'].matches = match
     ea.rules[0]['query_key'] = 'username'
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         ea.run_rule(ea.rules[0], END, START)
     assert ea.rules[0]['alert'][0].alert.call_count == 0
 
@@ -450,7 +450,7 @@ def test_silence_query_key(ea):
     match = [{'@timestamp': '2014-11-17T00:00:00', 'username': 'qlo'}]
     ea.rules[0]['type'].matches = match
     with mock.patch('elastalert.elastalert.ts_now') as mock_ts:
-        with mock.patch('elastalert.elastalert.Elasticsearch'):
+        with mock.patch('elastalert.elastalert.new_elasticsearch'):
             # Converted twice to add tzinfo
             mock_ts.return_value = ts_to_dt(dt_to_ts(datetime.datetime.utcnow() + datetime.timedelta(hours=5)))
             ea.run_rule(ea.rules[0], END, START)
@@ -461,7 +461,7 @@ def test_realert(ea):
     hits = ['2014-09-26T12:35:%sZ' % (x) for x in range(60)]
     matches = [{'@timestamp': x} for x in hits]
     ea.current_es.search.return_value = hits
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         ea.rules[0]['realert'] = datetime.timedelta(seconds=50)
         ea.rules[0]['type'].matches = matches
         ea.run_rule(ea.rules[0], END, START)
@@ -469,7 +469,7 @@ def test_realert(ea):
 
     # Doesn't alert again
     matches = [{'@timestamp': x} for x in hits]
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         ea.run_rule(ea.rules[0], END, START)
         ea.rules[0]['type'].matches = matches
         assert ea.rules[0]['alert'][0].alert.call_count == 1
@@ -477,7 +477,7 @@ def test_realert(ea):
     # mock ts_now() to past the realert time
     matches = [{'@timestamp': hits[0]}]
     with mock.patch('elastalert.elastalert.ts_now') as mock_ts:
-        with mock.patch('elastalert.elastalert.Elasticsearch'):
+        with mock.patch('elastalert.elastalert.new_elasticsearch'):
             # mock_ts is converted twice to add tzinfo
             mock_ts.return_value = ts_to_dt(dt_to_ts(datetime.datetime.utcnow() + datetime.timedelta(minutes=10)))
             ea.rules[0]['type'].matches = matches
@@ -492,35 +492,35 @@ def test_realert_with_query_key(ea):
     # Alert and silence username: qlo
     match = [{'@timestamp': '2014-11-17T00:00:00', 'username': 'qlo'}]
     ea.rules[0]['type'].matches = match
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         ea.run_rule(ea.rules[0], END, START)
     assert ea.rules[0]['alert'][0].alert.call_count == 1
 
     # Dont alert again for same username
     match = [{'@timestamp': '2014-11-17T00:05:00', 'username': 'qlo'}]
     ea.rules[0]['type'].matches = match
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         ea.run_rule(ea.rules[0], END, START)
     assert ea.rules[0]['alert'][0].alert.call_count == 1
 
     # Do alert with a different value
     match = [{'@timestamp': '2014-11-17T00:05:00', 'username': ''}]
     ea.rules[0]['type'].matches = match
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         ea.run_rule(ea.rules[0], END, START)
     assert ea.rules[0]['alert'][0].alert.call_count == 2
 
     # Alert with query_key missing
     match = [{'@timestamp': '2014-11-17T00:05:00'}]
     ea.rules[0]['type'].matches = match
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         ea.run_rule(ea.rules[0], END, START)
     assert ea.rules[0]['alert'][0].alert.call_count == 3
 
     # Still alert with a different value
     match = [{'@timestamp': '2014-11-17T00:05:00', 'username': 'ghengis_khan'}]
     ea.rules[0]['type'].matches = match
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         ea.run_rule(ea.rules[0], END, START)
     assert ea.rules[0]['alert'][0].alert.call_count == 4
 
@@ -532,14 +532,14 @@ def test_realert_with_nested_query_key(ea):
     # Alert and silence username: qlo
     match = [{'@timestamp': '2014-11-17T00:00:00', 'user': {'name': 'qlo'}}]
     ea.rules[0]['type'].matches = match
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         ea.run_rule(ea.rules[0], END, START)
     assert ea.rules[0]['alert'][0].alert.call_count == 1
 
     # Dont alert again for same username
     match = [{'@timestamp': '2014-11-17T00:05:00', 'user': {'name': 'qlo'}}]
     ea.rules[0]['type'].matches = match
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         ea.run_rule(ea.rules[0], END, START)
     assert ea.rules[0]['alert'][0].alert.call_count == 1
 
@@ -547,7 +547,7 @@ def test_realert_with_nested_query_key(ea):
 def test_count(ea):
     ea.rules[0]['use_count_query'] = True
     ea.rules[0]['doc_type'] = 'doctype'
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         ea.run_rule(ea.rules[0], END, START)
 
     # Assert that es.count is run against every run_every timeframe between START and END
@@ -580,7 +580,7 @@ def test_query_segmenting(ea):
     ea.rules[0]['buffer_time'] = datetime.timedelta(minutes=53)
     mock_es = mock.Mock()
     mock_es.search.side_effect = _duplicate_hits_generator([START_TIMESTAMP])
-    with mock.patch('elastalert.elastalert.Elasticsearch') as mock_es_init:
+    with mock.patch('elastalert.elastalert.new_elasticsearch') as mock_es_init:
         mock_es_init.return_value = mock_es
         run_and_assert_segmented_queries(ea, START, END, ea.rules[0]['buffer_time'])
     # Assert that num_hits correctly includes the 1 hit per query
@@ -588,13 +588,13 @@ def test_query_segmenting(ea):
 
     # run_every segments with count queries
     ea.rules[0]['use_count_query'] = True
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         run_and_assert_segmented_queries(ea, START, END, ea.run_every)
 
     # run_every segments with terms queries
     ea.rules[0].pop('use_count_query')
     ea.rules[0]['use_terms_query'] = True
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         run_and_assert_segmented_queries(ea, START, END, ea.run_every)
 
 
@@ -672,7 +672,7 @@ def test_set_starttime(ea):
     assert ea.rules[0]['starttime'] == end - ea.run_every
 
     # Count query, with previous endtime
-    with mock.patch('elastalert.elastalert.Elasticsearch'):
+    with mock.patch('elastalert.elastalert.new_elasticsearch'):
         ea.run_rule(ea.rules[0], END, START)
     ea.set_starttime(ea.rules[0], end)
     assert ea.rules[0]['starttime'] == END
@@ -688,7 +688,7 @@ def test_kibana_dashboard(ea):
     match = {'@timestamp': '2014-10-11T00:00:00'}
     mock_es = mock.Mock()
     ea.rules[0]['use_kibana_dashboard'] = 'my dashboard'
-    with mock.patch('elastalert.elastalert.Elasticsearch') as mock_es_init:
+    with mock.patch('elastalert.elastalert.new_elasticsearch') as mock_es_init:
         mock_es_init.return_value = mock_es
 
         # No dashboard found

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 import datetime
 
-import elasticsearch
 import mock
 import pytest
 
-from elastalert.elastalert import ElastAlerter
+import elastalert.elastalert
+import elastalert.util
 from elastalert.util import dt_to_ts
 from elastalert.util import ts_to_dt
 
@@ -69,11 +69,11 @@ def ea():
             'old_query_limit': datetime.timedelta(weeks=1),
             'disable_rules_on_error': False,
             'scroll_keepalive': '30s'}
-    elasticsearch.client.Elasticsearch = mock_es_client
+    elastalert.elastalert.new_elasticsearch = mock_es_client
     with mock.patch('elastalert.elastalert.get_rule_hashes'):
         with mock.patch('elastalert.elastalert.load_rules') as load_conf:
             load_conf.return_value = conf
-            ea = ElastAlerter(['--pin_rules'])
+            ea = elastalert.elastalert.ElastAlerter(['--pin_rules'])
     ea.rules[0]['type'] = mock_ruletype()
     ea.rules[0]['alert'] = [mock_alert()]
     ea.writeback_es = mock_es_client()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,7 @@ def ea():
             'old_query_limit': datetime.timedelta(weeks=1),
             'disable_rules_on_error': False,
             'scroll_keepalive': '30s'}
-    elastalert.elastalert.new_elasticsearch = mock_es_client
+    elastalert.elastalert.elasticsearch_client = mock_es_client
     with mock.patch('elastalert.elastalert.get_rule_hashes'):
         with mock.patch('elastalert.elastalert.load_rules') as load_conf:
             load_conf.return_value = conf

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -472,7 +472,7 @@ def test_new_term():
     mock_res = {'aggregations': {'filtered': {'values': {'buckets': [{'key': 'key1', 'doc_count': 1},
                                                                      {'key': 'key2', 'doc_count': 5}]}}}}
 
-    with mock.patch('elastalert.ruletypes.new_elasticsearch') as mock_es:
+    with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
         call_args = []
@@ -523,7 +523,7 @@ def test_new_term():
 
     # Missing_field
     rules['alert_on_missing_field'] = True
-    with mock.patch('elastalert.ruletypes.new_elasticsearch') as mock_es:
+    with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
         rule = NewTermsRule(rules)
@@ -539,7 +539,7 @@ def test_new_term_nested_field():
              'es_host': 'example.com', 'es_port': 10, 'index': 'logstash'}
     mock_res = {'aggregations': {'filtered': {'values': {'buckets': [{'key': 'key1', 'doc_count': 1},
                                                                      {'key': 'key2', 'doc_count': 5}]}}}}
-    with mock.patch('elastalert.ruletypes.new_elasticsearch') as mock_es:
+    with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
         rule = NewTermsRule(rules)
@@ -562,7 +562,7 @@ def test_new_term_with_terms():
     mock_res = {'aggregations': {'filtered': {'values': {'buckets': [{'key': 'key1', 'doc_count': 1},
                                                                      {'key': 'key2', 'doc_count': 5}]}}}}
 
-    with mock.patch('elastalert.ruletypes.new_elasticsearch') as mock_es:
+    with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
         rule = NewTermsRule(rules)
@@ -630,7 +630,7 @@ def test_new_term_with_composite_fields():
         }
     }
 
-    with mock.patch('elastalert.ruletypes.new_elasticsearch') as mock_es:
+    with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
         rule = NewTermsRule(rules)
@@ -666,7 +666,7 @@ def test_new_term_with_composite_fields():
 
     # Missing_fields
     rules['alert_on_missing_field'] = True
-    with mock.patch('elastalert.ruletypes.new_elasticsearch') as mock_es:
+    with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
         rule = NewTermsRule(rules)

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -472,7 +472,7 @@ def test_new_term():
     mock_res = {'aggregations': {'filtered': {'values': {'buckets': [{'key': 'key1', 'doc_count': 1},
                                                                      {'key': 'key2', 'doc_count': 5}]}}}}
 
-    with mock.patch('elastalert.ruletypes.Elasticsearch') as mock_es:
+    with mock.patch('elastalert.ruletypes.new_elasticsearch') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
         call_args = []
@@ -523,7 +523,7 @@ def test_new_term():
 
     # Missing_field
     rules['alert_on_missing_field'] = True
-    with mock.patch('elastalert.ruletypes.Elasticsearch') as mock_es:
+    with mock.patch('elastalert.ruletypes.new_elasticsearch') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
         rule = NewTermsRule(rules)
@@ -539,7 +539,7 @@ def test_new_term_nested_field():
              'es_host': 'example.com', 'es_port': 10, 'index': 'logstash'}
     mock_res = {'aggregations': {'filtered': {'values': {'buckets': [{'key': 'key1', 'doc_count': 1},
                                                                      {'key': 'key2', 'doc_count': 5}]}}}}
-    with mock.patch('elastalert.ruletypes.Elasticsearch') as mock_es:
+    with mock.patch('elastalert.ruletypes.new_elasticsearch') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
         rule = NewTermsRule(rules)
@@ -562,7 +562,7 @@ def test_new_term_with_terms():
     mock_res = {'aggregations': {'filtered': {'values': {'buckets': [{'key': 'key1', 'doc_count': 1},
                                                                      {'key': 'key2', 'doc_count': 5}]}}}}
 
-    with mock.patch('elastalert.ruletypes.Elasticsearch') as mock_es:
+    with mock.patch('elastalert.ruletypes.new_elasticsearch') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
         rule = NewTermsRule(rules)
@@ -630,7 +630,7 @@ def test_new_term_with_composite_fields():
         }
     }
 
-    with mock.patch('elastalert.ruletypes.Elasticsearch') as mock_es:
+    with mock.patch('elastalert.ruletypes.new_elasticsearch') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
         rule = NewTermsRule(rules)
@@ -666,7 +666,7 @@ def test_new_term_with_composite_fields():
 
     # Missing_fields
     rules['alert_on_missing_field'] = True
-    with mock.patch('elastalert.ruletypes.Elasticsearch') as mock_es:
+    with mock.patch('elastalert.ruletypes.new_elasticsearch') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
         rule = NewTermsRule(rules)


### PR DESCRIPTION
Fixes #670 

NewTerm now uses the standardized Elasticsearch instance, which was moved into util to avoid circular imports.

