### PR TITLE
Allow these options to be specified globally in config.yaml

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1181,6 +1181,12 @@ the room you want to post to. The room ID will be the numeric part of the URL.
 
 ``hipchat_proxy``: By default Elastalert will not use a network proxy to send notifications to HipChat. Set this option using ``hostname:port`` if you need to use a proxy.
 
+``hipchat_message_format``: Determines how the message is treated by our server and rendered inside HipChat applications
+html - Message is rendered as HTML and receives no special treatment. Must be valid HTML and entities must be escaped (e.g.: '&amp;' instead of '&'). May contain basic tags: a, b, i, strong, em, br, img, pre, code, lists, tables.
+text - Message is treated just like a message sent by a user. Can include @mentions, emoticons, pastes, and auto-detected URLs (Twitter, YouTube, images, etc).
+Valid values: html, text.
+Defaults to 'html'.
+
 Slack
 ~~~~~
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -730,6 +730,7 @@ class HipChatAlerter(Alerter):
     def __init__(self, rule):
         super(HipChatAlerter, self).__init__(rule)
         self.hipchat_msg_color = self.rule.get('hipchat_msg_color', 'red')
+        self.hipchat_message_format = self.rule.get('hipchat_message_format', 'html')
         self.hipchat_auth_token = self.rule['hipchat_auth_token']
         self.hipchat_room_id = self.rule['hipchat_room_id']
         self.hipchat_domain = self.rule.get('hipchat_domain', 'api.hipchat.com')
@@ -745,13 +746,18 @@ class HipChatAlerter(Alerter):
         if (len(body) > 9999):
             body = body[:9980] + '..(truncated)'
 
+        # Use appropriate line ending for text/html
+        if self.hipchat_message_format == 'html':
+            body = body.replace('\n', '<br />')
+
         # Post to HipChat
         headers = {'content-type': 'application/json'}
         # set https proxy, if it was provided
         proxies = {'https': self.hipchat_proxy} if self.hipchat_proxy else None
         payload = {
             'color': self.hipchat_msg_color,
-            'message': body.replace('\n', '<br />'),
+            'message': body,
+            'message_format': self.hipchat_message_format,
             'notify': True
         }
 

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -205,6 +205,12 @@ def load_options(rule, conf, args=None):
     # Set slack options from global config
     rule.setdefault('slack_webhook_url', conf.get('slack_webhook_url'))
 
+    # Set pagerduty options from global config
+    if 'pagerduty_service_key' in conf:
+        rule.setdefault('pagerduty_service_key', conf.get('pagerduty_service_key'))
+    if 'pagerduty_client_name' in conf:
+        rule.setdefault('pagerduty_client_name', conf.get('pagerduty_client_name'))
+
     # Make sure we have required options
     if required_locals - frozenset(rule.keys()):
         raise EAException('Missing required option(s): %s' % (', '.join(required_locals - frozenset(rule.keys()))))
@@ -233,6 +239,12 @@ def load_options(rule, conf, args=None):
     if 'top_count_keys' in rule and rule.get('raw_count_keys', True):
         keys = rule.get('top_count_keys')
         rule['top_count_keys'] = [key + '.raw' if not key.endswith('.raw') else key for key in keys]
+
+    # Get kibana link options from global config
+    if 'generate_kibana_link' in conf:
+        rule.setdefault('generate_kibana_link', conf.get('generate_kibana_link'))
+    if 'kibana_url' in conf:
+        rule.setdefault('kibana_url', conf.get('kibana_url'))
 
     # Check that generate_kibana_url is compatible with the filters
     if rule.get('generate_kibana_link'):


### PR DESCRIPTION
These are options that can be specified on the global config and not necessarily each individual rule.  

In our environment we want devs to be able to create rules and if necessary send alerts to pagerduty.  However the keys for doing such are not available to the devs.  We use chef for deploying new rules and template the config.yaml in a way that they won't have access to the keys.  However doing a template for every rule is just unnecessary.  

Same for the kibana link options.  We don't see a reason why we would ever want this off and the options should just be present on a global configuration level, not for each individual rule.  Yet they can be still overridden on a per rule basis for those that want.