### PR TITLE
hipchat_room_id not restricted to integers

### DIFF
--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -199,7 +199,7 @@ properties:
 
   ### HipChat
   hipchat_auth_token: {type: string}
-  hipchat_room_id: {type: number}
+  hipchat_room_id: {type: string}
   hipchat_domain: {type: string}
   hipchat_ignore_ssl_errors: {type: boolean}
 


### PR DESCRIPTION
It is possible to specify the name of the room though it must be properly encoded (spaces = %20, etc)