### PR TITLE
Don't exit if rule directory is empty on startup

### DIFF
--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -423,10 +423,6 @@ def load_rules(args):
         rules.append(rule)
         names.append(rule['name'])
 
-    if not rules:
-        logging.exception('No rules loaded. Exiting')
-        exit(1)
-
     conf['rules'] = rules
     return conf
 


### PR DESCRIPTION
Currently, if starting Elastalert,  load_rules exits when the rule directory is currently empty. This behavior is unwanted, as Elastalert watches for new files in the rules directory, and will pick them up when available. Now, running Elastalert as daemon is unpredictable in case the rule directory is empty. 

The current fix removes the exit behavior on startup when the rule directory is empty.