### PR TITLE
Dpopes sec 5621 keyed time aggregations

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1066,13 +1066,14 @@ class ElastAlerter():
                     if rule['current_aggregate_id'] == _id:
                         rule['current_aggregate_id'] = None
 
-                    # Delete it from the index
-                    try:
-                        self.writeback_es.delete(index=self.writeback_index,
-                                                 doc_type='elastalert',
-                                                 id=_id)
-                    except Exception:  # TODO: Give this a more relevant exception, try:except: is evil.
-                        self.handle_error("Failed to delete alert %s at %s" % (_id, alert_time))
+                # Delete the record with id == _id from the index
+                # In the case of aggregations, this will be the first record encountered during the aggregation window
+                try:
+                    self.writeback_es.delete(index=self.writeback_index,
+                                             doc_type='elastalert',
+                                             id=_id)
+                except Exception:  # TODO: Give this a more relevant exception, try:except: is evil.
+                    self.handle_error("Failed to delete alert %s at %s" % (_id, alert_time))
 
         # Send in memory aggregated alerts
         for rule in self.rules:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -457,6 +457,20 @@ class ElastAlerter():
             return rule.get('buffer_time', self.buffer_time)
         return self.run_every
 
+    def get_query_key_value(self, rule, match):
+        # concatenate query_key (or none) with rule_name to form the key used for silence_cache, grouped aggregates, etc.
+        if 'query_key' in rule:
+            try:
+                key = unicode(lookup_es_key(match, rule['query_key']))
+            except KeyError:
+                # Some matches may not have a query key
+                # Use a special token for these to not clobber all alerts
+                key = '_missing'
+        else:
+            key = ''
+
+        return key
+
     def run_rule(self, rule, endtime, starttime=None):
         """ Run a rule for a given time period, including querying and alerting on results.
 
@@ -509,25 +523,18 @@ class ElastAlerter():
             # If realert is set, silence the rule for that duration
             # Silence is cached by query_key, if it exists
             # Default realert time is 0 seconds
+            silence_cache_key = rule['name']
+            query_key_value = self.get_query_key_value(rule, match)
+            if query_key_value:
+                silence_cache_key += '.' + query_key_value
 
-            # concatenate query_key (or none) with rule_name to form silence_cache key
-            if 'query_key' in rule:
-                try:
-                    key = '.' + unicode(lookup_es_key(match, rule['query_key']))
-                except KeyError:
-                    # Some matches may not have a query key
-                    # Use a special token for these to not clobber all alerts
-                    key = '._missing'
-            else:
-                key = ''
-
-            if self.is_silenced(rule['name'] + key) or self.is_silenced(rule['name']):
-                elastalert_logger.info('Ignoring match for silenced rule %s%s' % (rule['name'], key))
+            if self.is_silenced(silence_cache_key):
+                elastalert_logger.info('Ignoring match for silenced rule %s' % (silence_cache_key,))
                 continue
 
             if rule['realert']:
-                next_alert, exponent = self.next_alert_time(rule, rule['name'] + key, ts_now())
-                self.set_realert(rule['name'] + key, next_alert, exponent)
+                next_alert, exponent = self.next_alert_time(rule, silence_cache_key, ts_now())
+                self.set_realert(silence_cache_key, next_alert, exponent)
 
             if rule.get('run_enhancements_first'):
                 try:
@@ -575,6 +582,7 @@ class ElastAlerter():
 
         blank_rule = {'agg_matches': [],
                       'current_aggregate_id': None,
+                      'current_aggregate_query_key_values': [],
                       'processed_hits': {}}
         rule = blank_rule
 
@@ -589,6 +597,7 @@ class ElastAlerter():
 
         copy_properties = ['agg_matches',
                            'current_aggregate_id',
+                           'current_aggregate_query_key_values',
                            'aggregate_alert_time',
                            'processed_hits',
                            'starttime',
@@ -1039,22 +1048,24 @@ class ElastAlerter():
 
             # Send the alert unless it's a future alert
             if ts_now() > ts_to_dt(alert_time):
-                aggregated_matches = self.get_aggregated_matches(_id)
-                if aggregated_matches:
-                    matches = [match_body] + [agg_match['match_body'] for agg_match in aggregated_matches]
-                    self.alert(matches, rule, alert_time=alert_time)
+                aggregation_keys = self.get_aggregated_match_keys(_id)
+                for key in aggregation_keys:
+                    aggregated_matches = self.get_aggregated_matches(_id, key)
+                    if aggregated_matches:
+                        matches = [match_body] + [agg_match['match_body'] for agg_match in aggregated_matches]
+                        self.alert(matches, rule, alert_time=alert_time)
+                    else:
+                        self.alert([match_body], rule, alert_time=alert_time)
                     if rule['current_aggregate_id'] == _id:
                         rule['current_aggregate_id'] = None
-                else:
-                    self.alert([match_body], rule, alert_time=alert_time)
 
-                # Delete it from the index
-                try:
-                    self.writeback_es.delete(index=self.writeback_index,
-                                             doc_type='elastalert',
-                                             id=_id)
-                except:  # TODO: Give this a more relevant exception, try:except: is evil.
-                    self.handle_error("Failed to delete alert %s at %s" % (_id, alert_time))
+                    # Delete it from the index
+                    try:
+                        self.writeback_es.delete(index=self.writeback_index,
+                                                 doc_type='elastalert',
+                                                 id=_id)
+                    except Exception:  # TODO: Give this a more relevant exception, try:except: is evil.
+                        self.handle_error("Failed to delete alert %s at %s" % (_id, alert_time))
 
         # Send in memory aggregated alerts
         for rule in self.rules:
@@ -1063,11 +1074,55 @@ class ElastAlerter():
                     self.alert(rule['agg_matches'], rule)
                     rule['agg_matches'] = []
 
-    def get_aggregated_matches(self, _id):
-        """ Removes and returns all matches from writeback_es that have aggregate_id == _id """
+    def get_aggregated_match_keys(self, aggregate_id):
+        """ Returns all aggregation keys for a given aggregate_id
+            If the 'query_key' field is set on the rule, this will be the values of the aggregation keys
+            If the 'query_key' field is not set on a rule, such that there are no aggs, this will return an empty list
+        """
+        query = {
+            'query': {
+                'match': {
+                    'aggregate_id': aggregate_id,
+                }
+            },
+            'aggregations': {
+                'values': {
+                    'terms': {
+                        'field': 'aggregation_key',
+                    }
+                }
+            }
+        }
 
+        aggregation_keys = []
+        if self.writeback_es:
+            try:
+                res = self.writeback_es.search(index=self.writeback_index,
+                                               doc_type='elastalert',
+                                               body=query,
+                                               size=0)
+                if 'aggregations' not in res:
+                    return [None]
+                for bucket in res['aggregations']['values']['buckets']:
+                    aggregation_keys.append(bucket['key'])
+            except (KeyError, ElasticsearchException) as e:
+                self.handle_error("Error fetching aggregation keys: %s" % (e), {'id': aggregate_id})
+
+        if not aggregation_keys:
+            aggregation_keys.append(None)
+        return aggregation_keys
+
+    def get_aggregated_matches(self, _id, query_key_value=None):
+        """ Removes and returns all matches from writeback_es that have aggregate_id == _id
+        and optionally aggregate_query_key_value == 'query_key_value', in the case of 'query_key' being set
+        on an alert that uses aggregation
+        """
         # XXX if there are more than self.max_aggregation matches, you have big alerts and we will leave entries in ES.
-        query = {'query': {'query_string': {'query': 'aggregate_id:%s' % (_id)}}}
+        query_string = 'aggregate_id:{0}'.format(_id)
+        if query_key_value:
+            query_string += ' AND aggregation_key:{0}'.format(query_key_value)
+        query = {'query': {'query_string': {'query': query_string}}}
+
         matches = []
         if self.writeback_es:
             try:
@@ -1084,12 +1139,14 @@ class ElastAlerter():
                 self.handle_error("Error fetching aggregated matches: %s" % (e), {'id': _id})
         return matches
 
-    def find_pending_aggregate_alert(self, rule):
+    def find_pending_aggregate_alert(self, rule, query_key_value=None):
         query = {'filter': {'bool': {'must': [{'term': {'rule_name': rule['name']}},
                                               {'range': {'alert_time': {'gt': ts_now()}}},
                                               {'not': {'exists': {'field': 'aggregate_id'}}},
                                               {'term': {'alert_sent': 'false'}}]}},
                  'sort': {'alert_time': {'order': 'desc'}}}
+        if query_key_value:
+            query['filter']['bool']['must'].append({'term': {'aggregation_key': query_key_value}})
         if not self.writeback_es:
             self.writeback_es = elasticsearch_client(self.conf)
         try:
@@ -1107,17 +1164,27 @@ class ElastAlerter():
 
     def add_aggregated_alert(self, match, rule):
         """ Save a match as a pending aggregate alert to elasticsearch. """
+        # Optionally include the 'query_key' as a dimension for aggregations
+        query_key_value = None
+        if 'query_key' in rule:
+            query_key_value = self.get_query_key_value(rule, match)
+
         if (not rule['current_aggregate_id'] or
+                (query_key_value and query_key_value not in rule['current_aggregate_query_key_values']) or
                 ('aggregate_alert_time' in rule and rule['aggregate_alert_time'] < ts_to_dt(match[rule['timestamp_field']]))):
 
             # Elastalert may have restarted while pending alerts exist
-            pending_alert = self.find_pending_aggregate_alert(rule)
+            pending_alert = self.find_pending_aggregate_alert(rule, query_key_value)
             if pending_alert:
                 alert_time = rule['aggregate_alert_time'] = ts_to_dt(pending_alert['_source']['alert_time'])
                 agg_id = rule['current_aggregate_id'] = pending_alert['_id']
-                elastalert_logger.info('Adding alert for %s to aggregation(id: %s), next alert at %s' % (rule['name'], agg_id, alert_time))
+                if 'query_key' in rule:
+                    if query_key_value not in rule['current_aggregate_query_key_values']:
+                        rule['current_aggregate_query_key_values'].append(query_key_value)
+                elastalert_logger.info('Adding alert for %s to aggregation(id: %s, query_key:%s), next alert at %s' % (rule['name'], agg_id, query_key_value, alert_time))
             else:
-                # First match, set alert_time
+                # First match for this query_key value, set alert_time
+                # [DPOPES]: This timestamp logic might need updates
                 match_time = ts_to_dt(match[rule['timestamp_field']])
                 alert_time = ''
                 if isinstance(rule['aggregation'], dict) and rule['aggregation'].get('schedule'):
@@ -1130,23 +1197,33 @@ class ElastAlerter():
                 else:
                     alert_time = match_time + rule['aggregation']
 
-                rule['aggregate_alert_time'] = alert_time
-                agg_id = None
-                elastalert_logger.info('New aggregation for %s. next alert at %s.' % (rule['name'], alert_time))
+                if 'aggregate_alert_time' not in rule:
+                    rule['aggregate_alert_time'] = alert_time
+                # This will either be None since its the first aggregation ever,
+                # OR it will be a value from a different key within the aggregation window
+                agg_id = rule['current_aggregate_id']
+
+                if not agg_id:
+                    elastalert_logger.info('New aggregation for rule:%s, query_key:%s. next alert at %s.' % (rule['name'], query_key_value, alert_time))
         else:
             # Already pending aggregation, use existing alert_time
             alert_time = rule['aggregate_alert_time']
             agg_id = rule['current_aggregate_id']
-            elastalert_logger.info('Adding alert for %s to aggregation(id: %s), next alert at %s' % (rule['name'], agg_id, alert_time))
+            elastalert_logger.info('Adding alert for %s to aggregation(id: %s, query_key:%s), next alert at %s' % (rule['name'], agg_id, query_key_value, alert_time))
 
         alert_body = self.get_alert_body(match, rule, False, alert_time)
         if agg_id:
             alert_body['aggregate_id'] = agg_id
+        if query_key_value:
+            alert_body['aggregation_key'] = query_key_value
         res = self.writeback('elastalert', alert_body)
 
         # If new aggregation, save _id
         if res and not agg_id:
             rule['current_aggregate_id'] = res['_id']
+        if res and 'query_key' in rule:
+            if query_key_value not in rule['current_aggregate_query_key_values']:
+                rule['current_aggregate_query_key_values'].append(query_key_value)
 
         # Couldn't write the match to ES, save it in memory for now
         if not res:
@@ -1154,7 +1231,7 @@ class ElastAlerter():
 
         return res
 
-    def silence(self):
+    def silence(self, rule_name=None):
         """ Silence an alert for a period of time. --silence and --rule must be passed as args. """
         if self.debug:
             logging.error('--silence not compatible with --debug')
@@ -1165,7 +1242,8 @@ class ElastAlerter():
             exit(1)
 
         # With --rule, self.rules will only contain that specific rule
-        rule_name = self.rules[0]['name']
+        if not rule_name:
+            rule_name = self.rules[0]['name']
 
         try:
             unit, num = self.args.silence.split('=')


### PR DESCRIPTION
Sending out in a kind of WIP state:

-  Existing tests pass (with minor changes or additions)
-  Did some preliminary testing and am seeing the correct behavior w.r.t. alerts being sent out in groups based on the key
-  I would like to fix the "first record" hack. @Qmando looking at you for suggestions. I *think* I can just tag even the first encountered record with it's own ID as aggregate_id (and optionally aggregate_key) and change downstream ES queries accordingly.
-  I need to add more unittest coverage for the new functionality.
-  This won't work as-is for a composite query_key field, nor will it work for a non-primitive value of the query_key dimension (for the former, I need to look closer and think about what the solution looks like. for the latter, this can be solved by hashing the contents of the field). It doesn't look a composite query_key field is supported correctly today for realert.