### PR TITLE
Avoid confusion in systems that have write-back configuration

### DIFF
--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -234,7 +234,7 @@ class MockElastAlerter(object):
             client.run_rule(rule, endtime, starttime)
 
             if mock_writeback.call_count:
-                print("\nWould have written the following documents to elastalert_status:\n")
+                print("\nWould have written the following documents to writeback index (default is elastalert_status):\n")
                 for call in mock_writeback.call_args_list:
                     print("%s - %s\n" % (call[0][0], call[0][1]))
 


### PR DESCRIPTION
I was confused when I first saw this message because I have a custom writeback index--and I thought that something might be misconfigured. Turns out the verbiage just needed clarification.