### PR TITLE
Use 'aggregation_key' instead of 'query_key' for keyed aggregations

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -110,6 +110,8 @@ Rule Configuration Cheat Sheet
 +----------------------------------------------------+--------+-----------+-----------+--------+-----------+-------+----------+--------+-----------+
 | ``query_key`` (string, no default)                 |   Opt  |           |           |   Req  |    Opt    |  Opt  |   Opt    |  Req   |  Opt      |
 +----------------------------------------------------+--------+-----------+-----------+--------+-----------+-------+----------+--------+-----------+
+| ``aggregation_key`` (string, no default)           |   Opt  |           |           |        |           |       |          |        |           |
++----------------------------------------------------+--------+-----------+-----------+--------+-----------+-------+----------+--------+-----------+
 | ``timeframe`` (time, no default)                   |        |           |           |   Opt  |    Req    |  Req  |   Req    |        |  Req      |
 +----------------------------------------------------+--------+-----------+-----------+--------+-----------+-------+----------+--------+-----------+
 | ``num_events`` (int, no default)                   |        |           |           |        |    Req    |       |          |        |           |
@@ -267,11 +269,11 @@ For example, if you wish to receive alerts every Monday and Friday::
 
 This uses Cron syntax, which you can read more about `here <http://www.nncron.ru/help/EN/working/cron-format.htm>`_. Make sure to `only` include either a schedule field or standard datetime fields (such as ``hours``, ``minutes``, ``days``), not both.
 
-By default, all events that occur during an aggregation window are grouped together. However, if your rule has the ``query_key`` field set, then each event sharing a common key value will be grouped together. A separate aggregation window will be made for each newly encountered key value.
+By default, all events that occur during an aggregation window are grouped together. However, if your rule has the ``aggregation_key`` field set, then each event sharing a common key value will be grouped together. A separate aggregation window will be made for each newly encountered key value.
 
 For example, if you wish to receive alerts that are grouped by the user who triggered the event, you can set::
 
-    query_key: 'my_data.username'
+    aggregation_key: 'my_data.username'
 
 Then, assuming an aggregation window of 10 minutes, if you receive the following data points::
 
@@ -451,6 +453,11 @@ additional alerts for ``{'username': 'bob'}`` will be ignored while other userna
 ``query_key`` will be grouped together. A list of fields may also be used, which will create a compound query key. This compound key is
 treated as if it were a single field whose value is the component values, or "None", joined by commas. A new field with the key
 "field1,field2,etc" will be created in each document and may conflict with existing fields of the same name.
+
+aggregation_key
+^^^^^^^^^^^^^^^
+
+``aggregation_key``: Having an aggregation key in conjunction with an aggregation will make it so that each new value encountered for the aggregation_key field will result in a new, separate aggregation window.
 
 timestamp_type
 ^^^^^^^^^^^^^^

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -223,12 +223,18 @@ def load_options(rule, conf, args=None):
         rule['compound_query_key'] = rule['query_key']
         rule['query_key'] = ','.join(rule['query_key'])
 
+    if isinstance(rule.get('aggregate_key'), list):
+        rule['compound_aggregate_key'] = rule['aggregate_key']
+        rule['aggregate_key'] = ','.join(rule['aggregate_key'])
+
     # Add QK, CK and timestamp to include
     include = rule.get('include', ['*'])
     if 'query_key' in rule:
         include.append(rule['query_key'])
     if 'compound_query_key' in rule:
         include += rule['compound_query_key']
+    if 'compound_aggregate_key' in rule:
+        include += rule['compound_aggregate_key']
     if 'compare_key' in rule:
         include.append(rule['compare_key'])
     if 'top_count_keys' in rule:

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -397,7 +397,7 @@ def test_agg_no_writeback_connectivity(ea):
     ea.add_aggregated_alert.assert_any_call({'@timestamp': hit3}, ea.rules[0])
 
 
-def test_agg_with_query_key(ea):
+def test_agg_with_aggregation_key(ea):
     ea.max_aggregation = 1337
     hits_timestamps = ['2014-09-26T12:34:45', '2014-09-26T12:40:45', '2014-09-26T12:43:45']
     alerttime1 = dt_to_ts(ts_to_dt(hits_timestamps[0]) + datetime.timedelta(minutes=10))
@@ -411,7 +411,7 @@ def test_agg_with_query_key(ea):
         ea.rules[0]['type'].matches[0]['key'] = 'Key Value 1'
         ea.rules[0]['type'].matches[1]['key'] = 'Key Value 2'
         ea.rules[0]['type'].matches[2]['key'] = 'Key Value 1'
-        ea.rules[0]['query_key'] = 'key'
+        ea.rules[0]['aggregation_key'] = 'key'
         ea.run_rule(ea.rules[0], END, START)
 
     # Assert that the three matches were added to elasticsearch


### PR DESCRIPTION
…so as not to change existing functionality w.r.t. query_key used in aggregations / realert scenarios

Will also update the documentation.