### PR TITLE
Fix outdated and/or broken links in documentation

### DIFF
--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -137,9 +137,9 @@ configuration.
 
 ``max_query_size``: The maximum number of documents that will be downloaded from Elasticsearch in a single query. The
 default is 10,000, and if you expect to get near this number, consider using ``use_count_query`` for the rule. If this
-limit is reached, ElastAlert will `scroll <https://www.elastic.co/guide/en/Elasticsearch/reference/current/search-request-scroll.html>`_ through pages the size of ``max_query_size`` until processing all results.
+limit is reached, ElastAlert will `scroll <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html>`_ through pages the size of ``max_query_size`` until processing all results.
 
-``scroll_keepalive``: The maximum time (formatted in `Time Units <https://www.elastic.co/guide/en/Elasticsearch/reference/current/common-options.html#time-units>`_) the scrolling context should be kept alive. Avoid using high values as it abuses resources in Elasticsearch, but be mindful to allow sufficient time to finish processing all the results.
+``scroll_keepalive``: The maximum time (formatted in `Time Units <https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#time-units>`_) the scrolling context should be kept alive. Avoid using high values as it abuses resources in Elasticsearch, but be mindful to allow sufficient time to finish processing all the results.
 
 ``max_aggregation``: The maximum number of alerts to aggregate together. If a rule has ``aggregation`` set, all
 alerts occuring within a timeframe will be sent together. The default is 10,000.

--- a/docs/source/recipes/writing_filters.rst
+++ b/docs/source/recipes/writing_filters.rst
@@ -6,7 +6,7 @@ Writing Filters For Rules
 This document describes how to create a filter section for your rule config file.
 
 The filters used in rules are part of the Elasticsearch query DSL, further documentation for which can be found at
-http://www.Elasticsearch.org/guide/en/Elasticsearch/reference/current/query-dsl.html
+https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
 This document contains a small subset of particularly useful filters.
 
 The filter section is passed to Elasticsearch exactly as follows::
@@ -54,7 +54,7 @@ The term type allows for exact field matches::
 
 Note that a term query may not behave as expected if a field is analyzed. By default, many string fields will be tokenized by whitespace, and a term query for "foo bar" may not match
 a field that appears to have the value "foo bar", unless it is not analyzed. Conversely, a term query for "foo" will match analyzed strings "foo bar" and "foo baz". For full text
-matching on analyzed fields, use query_string. See http://www.Elasticsearch.org/guide/en/Elasticsearch/guide/current/term-vs-full-text.html
+matching on analyzed fields, use query_string. See https://www.elastic.co/guide/en/elasticsearch/guide/current/term-vs-full-text.html
 
 terms
 *****

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -480,7 +480,7 @@ _source_enabled
 
 ``_source_enabled``: If true, ElastAlert will use _source to retrieve fields from documents in Elasticsearch. If false,
 ElastAlert will use ``fields`` to retrieve stored fields. Both of these are represented internally as if they came from ``_source``.
-See https://www.elastic.co/guide/en/Elasticsearch/reference/1.3/mapping-fields.html for more details. The fields used come from ``include``,
+See https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-fields.html for more details. The fields used come from ``include``,
 see above for more details. (Optional, boolean, default True)
 
 Some rules and alerts require additional options, which also go in the top level of the rule configuration file.


### PR DESCRIPTION
A recent bulk capitalization of "Elasticsearch" (#722) resulted in a few broken links. This PR fixes those and updates the links from http://www.elasticsearch.org to https://www.elastic.co and one instance of linking to an outdated reference page.