### PR TITLE
Support custom subjects for SNS alerts

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -700,7 +700,7 @@ class SnsAlerter(Alerter):
         self.aws_region = self.rule.get('aws_region', 'us-east-1')
         self.boto_profile = self.rule.get('boto_profile', '')
 
-    def create_default_title(self):
+    def create_default_title(self, matches):
         subject = 'ElastAlert: %s' % (self.rule['name'])
         return subject
 
@@ -719,7 +719,7 @@ class SnsAlerter(Alerter):
             sns_client = sns.connect_to_region(self.aws_region,
                                                aws_access_key_id=self.aws_access_key,
                                                aws_secret_access_key=self.aws_secret_key)
-        sns_client.publish(self.sns_topic_arn, body, subject=self.create_default_title())
+        sns_client.publish(self.sns_topic_arn, body, subject=self.create_title(matches))
         elastalert_logger.info("Sent sns notification to %s" % (self.sns_topic_arn))
 
 


### PR DESCRIPTION
When deploying ElastAlert recently, I noticed SNSAlert didn't support custom subjects. This fixes that!

Works for me locally / tests pass:

```
...
============================================= test session starts =============================================
platform darwin -- Python 2.6.9, pytest-3.0.2, py-1.4.31, pluggy-0.3.1
rootdir: /Users/zsteindler/elastalert, inifile: tox.ini
collected 106 items 

tests/alerts_test.py .......................
tests/base_test.py .........................................
tests/config_test.py .........
tests/kibana_test.py ...
tests/rules_test.py .........................
tests/util_test.py .....

========================================= 106 passed in 61.26 seconds =========================================
...
============================================= test session starts =============================================
platform darwin -- Python 2.7.11, pytest-3.0.2, py-1.4.31, pluggy-0.3.1
rootdir: /Users/zsteindler/elastalert, inifile: tox.ini
collected 106 items 

tests/alerts_test.py .......................
tests/base_test.py .........................................
tests/config_test.py .........
tests/kibana_test.py ...
tests/rules_test.py .........................
tests/util_test.py .....

========================================= 106 passed in 8.22 seconds ==========================================
...
___________________________________________________ summary ___________________________________________________
  py26: commands succeeded
  py27: commands succeeded
  congratulations :)
```