### PR TITLE
Factor in query delay for remove_old_events

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -349,6 +349,8 @@ class ElastAlerter():
         now = ts_now()
         remove = []
         buffer_time = rule.get('buffer_time', self.buffer_time)
+        if rule.get('query_delay'):
+            buffer_time += rule['query_delay']
         for _id, timestamp in rule['processed_hits'].iteritems():
             if now - timestamp > buffer_time:
                 remove.append(_id)


### PR DESCRIPTION
Fixes #739 

Don't forget _ids until they are buffer_time PLUS query delay old.