### PR TITLE
Added sort to get_aggregated_matches

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1105,7 +1105,7 @@ class ElastAlerter():
         """ Removes and returns all matches from writeback_es that have aggregate_id == _id """
 
         # XXX if there are more than self.max_aggregation matches, you have big alerts and we will leave entries in ES.
-        query = {'query': {'query_string': {'query': 'aggregate_id:%s' % (_id)}}, "sort": {"@timestamp": "asc"}}
+        query = {'query': {'query_string': {'query': 'aggregate_id:%s' % (_id)}}, 'sort': {'@timestamp': 'asc'}}
         matches = []
         if self.writeback_es:
             try:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1105,7 +1105,7 @@ class ElastAlerter():
         """ Removes and returns all matches from writeback_es that have aggregate_id == _id """
 
         # XXX if there are more than self.max_aggregation matches, you have big alerts and we will leave entries in ES.
-        query = {'query': {'query_string': {'query': 'aggregate_id:%s' % (_id)}}}
+        query = {'query': {'query_string': {'query': 'aggregate_id:%s' % (_id)}}, "sort": {"@timestamp": "asc"}}
         matches = []
         if self.writeback_es:
             try:


### PR DESCRIPTION
Grab the aggregate matches in ascending time order so that they will already be in order when the alerter receives them.