### PR TITLE
Flatline alert with no documents and not use_count_query

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -495,7 +495,8 @@ class FlatlineRule(FrequencyRule):
     def garbage_collect(self, ts):
         # We add an event with a count of zero to the EventWindow for each key. This will cause the EventWindow
         # to remove events that occurred more than one `timeframe` ago, and call onRemoved on them.
-        for key in self.occurrences.keys() or ['all']:
+        default = ['all'] if 'query_key' not in self.rules else []
+        for key in self.occurrences.keys() or default:
             self.occurrences.setdefault(key, EventWindow(self.rules['timeframe'], getTimestamp=self.get_ts)).append(({self.ts_field: ts}, 0))
             self.first_event.setdefault(key, ts)
             self.check_for_match(key)

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -495,8 +495,9 @@ class FlatlineRule(FrequencyRule):
     def garbage_collect(self, ts):
         # We add an event with a count of zero to the EventWindow for each key. This will cause the EventWindow
         # to remove events that occurred more than one `timeframe` ago, and call onRemoved on them.
-        for key in self.occurrences.keys():
+        for key in self.occurrences.keys() or ['all']:
             self.occurrences.setdefault(key, EventWindow(self.rules['timeframe'], getTimestamp=self.get_ts)).append(({self.ts_field: ts}, 0))
+            self.first_event.setdefault(key, ts)
             self.check_for_match(key)
 
 

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -718,6 +718,24 @@ def test_flatline():
     assert len(rule.matches) == 3
 
 
+def test_flatline_no_data():
+    rules = {
+        'timeframe': datetime.timedelta(seconds=30),
+        'threshold': 2,
+        'timestamp_field': '@timestamp',
+    }
+
+    rule = FlatlineRule(rules)
+
+    # Initial lack of data
+    rule.garbage_collect(ts_to_dt('2014-09-26T12:00:00Z'))
+    assert len(rule.matches) == 0
+
+    # Passed the timeframe, still no events
+    rule.garbage_collect(ts_to_dt('2014-09-26T12:35:00Z'))
+    assert len(rule.matches) == 1
+
+
 def test_flatline_count():
     rules = {'timeframe': datetime.timedelta(seconds=30),
              'threshold': 1,


### PR DESCRIPTION
If occurrences is empty and we're not using query_key, set the default value for "all" so that we can alert on lack of events.