### PR TITLE
Allow for setting hipchat from attribute

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1229,6 +1229,8 @@ the room you want to post to. The room ID will be the numeric part of the URL.
 
 ``hipchat_notify``: When set to true, triggers a hipchat bell as if it were a user. Default is true.
 
+``hipchat_from``: When humans report to hipchat, a timestamp appears next to their name. For bots, the name is the name of the token. The from, instead of a timestamp, defaults to empty unless set, which you can do here. This is optional.
+
 ``hipchat_message_format``: Determines how the message is treated by HipChat and rendered inside HipChat applications
 html - Message is rendered as HTML and receives no special treatment. Must be valid HTML and entities must be escaped (e.g.: '&amp;' instead of '&'). May contain basic tags: a, b, i, strong, em, br, img, pre, code, lists, tables.
 text - Message is treated just like a message sent by a user. Can include @mentions, emoticons, pastes, and auto-detected URLs (Twitter, YouTube, images, etc).

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -759,6 +759,7 @@ class HipChatAlerter(Alerter):
         self.hipchat_domain = self.rule.get('hipchat_domain', 'api.hipchat.com')
         self.hipchat_ignore_ssl_errors = self.rule.get('hipchat_ignore_ssl_errors', False)
         self.hipchat_notify = self.rule.get('hipchat_notify', True)
+        self.hipchat_from = self.rule.get('hipchat_from', '')
         self.url = 'https://%s/v2/room/%s/notification?auth_token=%s' % (
             self.hipchat_domain, self.hipchat_room_id, self.hipchat_auth_token)
         self.hipchat_proxy = self.rule.get('hipchat_proxy', None)
@@ -782,7 +783,8 @@ class HipChatAlerter(Alerter):
             'color': self.hipchat_msg_color,
             'message': body,
             'message_format': self.hipchat_message_format,
-            'notify': self.hipchat_notify
+            'notify': self.hipchat_notify,
+            'from': self.hipchat_from
         }
 
         try:

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -197,6 +197,7 @@ def load_options(rule, conf, args=None):
     rule.setdefault('hipchat_msg_color', conf.get('hipchat_msg_color', 'red'))
     rule.setdefault('hipchat_domain', conf.get('hipchat_domain', 'api.hipchat.com'))
     rule.setdefault('hipchat_notify', conf.get('hipchat_notify', True))
+    rule.setdefault('hipchat_from', conf.get('hipchat_from', ''))
     rule.setdefault('hipchat_ignore_ssl_errors', conf.get('hipchat_ignore_ssl_errors', False))
     if 'hipchat_auth_token' in conf:
         rule.setdefault('hipchat_auth_token', conf.get('hipchat_auth_token'))

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -203,6 +203,7 @@ properties:
   hipchat_domain: {type: string}
   hipchat_ignore_ssl_errors: {type: boolean}
   hipchat_notify: {type: boolean}
+  hipchat_from: {type: string}
 
   ### Slack
   slack_webhook_url: *arrayOfString


### PR DESCRIPTION
I am new to python and to ElastAlert, so I didn't so any bounds checking. This code assumes that users won't set a string that is longer than 64 characters. See https://www.hipchat.com/docs/apiv2/method/send_room_notification. Empty string is allowed according to that page.

@Qmando: Is there an easy way to run tests on this project, perhaps in a docker container. I prefer not to install python or any other language on my system (docker is good at doing that on a per-project level). 

I saw the tox target in the Makefile, but my computer certainly doesn't have that installed either. Any chance you could outline how to get a test environment set up? I could probably whip up a docker target for running tests.