### PR TITLE
SlackAlerter - allow to use icon_url

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1255,7 +1255,10 @@ Optional:
 ``slack_channel_override``: Incoming webhooks have a default channel, but it can be overridden. A public channel can be specified "#other-channel", and a Direct Message with "@username".
 
 ``slack_emoji_override``: By default ElastAlert will use the :ghost: emoji when posting to the channel. You can use a different emoji per
-ElastAlert rule. Any Apple emoji can be used, see http://emojipedia.org/apple/
+ElastAlert rule. Any Apple emoji can be used, see http://emojipedia.org/apple/ . If slack_icon_url_override parameter is provided, emoji is ignored.
+
+``slack_icon_url_override``: By default ElastAlert will use the :ghost: emoji when posting to the channel. You can provide icon_url to use custom image.
+Provide absolute address of the pciture, for example: http://some.address.com/image.jpg .
 
 ``slack_msg_color``: By default the alert will be posted with the 'danger' color. You can also use 'good' or 'warning' colors.
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -864,9 +864,9 @@ class SlackAlerter(Alerter):
             ]
         }
         if self.slack_icon_url_override != '':
-            payload.icon_url = self.slack_icon_url_override
+            payload['icon_url'] = self.slack_icon_url_override
         else:
-            payload.icon_emoji = self.slack_emoji_override
+            payload['icon_emoji'] = self.slack_emoji_override
 
         for url in self.slack_webhook_url:
             try:

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -828,6 +828,7 @@ class SlackAlerter(Alerter):
         self.slack_username_override = self.rule.get('slack_username_override', 'elastalert')
         self.slack_channel_override = self.rule.get('slack_channel_override', '')
         self.slack_emoji_override = self.rule.get('slack_emoji_override', ':ghost:')
+        self.slack_icon_url_override = self.rule.get('slack_icon_url_override', '')
         self.slack_msg_color = self.rule.get('slack_msg_color', 'danger')
         self.slack_parse_override = self.rule.get('slack_parse_override', 'none')
         self.slack_text_string = self.rule.get('slack_text_string', '')
@@ -851,7 +852,6 @@ class SlackAlerter(Alerter):
         payload = {
             'username': self.slack_username_override,
             'channel': self.slack_channel_override,
-            'icon_emoji': self.slack_emoji_override,
             'parse': self.slack_parse_override,
             'text': self.slack_text_string,
             'attachments': [
@@ -863,6 +863,10 @@ class SlackAlerter(Alerter):
                 }
             ]
         }
+        if self.slack_icon_url_override != '':
+            payload.icon_url = self.slack_icon_url_override
+        else:
+            payload.icon_emoji = self.slack_emoji_override
 
         for url in self.slack_webhook_url:
             try:

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -209,6 +209,7 @@ properties:
   slack_webhook_url: *arrayOfString
   slack_username_override: {type: string}
   slack_emoji_override: {type: string}
+  slack_icon_url_override: {type: string}
   slack_msg_color: {enum: [good, warning, danger]}
   slack_parse_override: {enum: [none, full]}
   slack_text_string: {type: string}


### PR DESCRIPTION
When alerting using slack, I use custom url for icon, not only standard emojis.

This makes it possible to use either icon_url or icon_emoji. If url is configured, alert uses url, if not, emoji is used.

PS: Haven't made many PRs yet, if anything is missing or should've been done differently, please let me know. Thx :)