### PR TITLE
Add support for nested cardinality_field

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -774,9 +774,10 @@ class CardinalityRule(RuleType):
                 key = 'all'
             self.cardinality_cache.setdefault(key, {})
             self.first_event.setdefault(key, event[self.ts_field])
-            if self.cardinality_field in event:
+            value = hashable(lookup_es_key(event, self.cardinality_field))
+            if value is not None:
                 # Store this timestamp as most recent occurence of the term
-                self.cardinality_cache[key][event[self.cardinality_field]] = event[self.ts_field]
+                self.cardinality_cache[key][value] = event[self.ts_field]
                 self.check_for_match(key, event)
 
     def check_for_match(self, key, event, gc=True):

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -903,6 +903,12 @@ def test_cardinality_nested_cardinality_field():
     rule.garbage_collect(datetime.datetime.now())
     assert len(rule.matches) == 0
 
+    # Add an event with no IP, stay at 4 cardinality
+    event = {'@timestamp': datetime.datetime.now()}
+    rule.add_data([event])
+    rule.garbage_collect(datetime.datetime.now())
+    assert len(rule.matches) == 0
+
     # Next unique will trigger
     event = {'@timestamp': datetime.datetime.now(), 'd': {'ip': '10.0.0.5'}}
     rule.add_data([event])


### PR DESCRIPTION
This PR partially addresses https://github.com/Yelp/elastalert/issues/663 by adding support for specifying a nested cardinality_field (e.g., `d.ip` for an event that looks like `{ '@timestamp': ..., 'd': { 'ip': '127.0.0.1', ... } }`