### PR TITLE
use es_conn_timeout from config file

### DIFF
--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -286,7 +286,7 @@ def build_es_conn_config(conf):
     parsed_conf['es_host'] = conf['es_host']
     parsed_conf['es_port'] = conf['es_port']
     parsed_conf['es_url_prefix'] = ''
-    parsed_conf['es_conn_timeout'] = 10
+    parsed_conf['es_conn_timeout'] = conf['es_conn_timeout']
     parsed_conf['send_get_body_as'] = conf.get('es_send_get_body_as', 'GET')
 
     if 'es_username' in conf:


### PR DESCRIPTION
Hi,

I've noticed that `es_conn_timeout` is hardcoded to 10 and does not use value from configuration file.
This is one line change to fix that.