### PR TITLE
Pin elasticsearch at <3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 ElastAlert is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in Elasticsearch.
 
+ElastAlert currently works with Elasticsearch 1.X and 2.X.
+
 At Yelp, we use Elasticsearch, Logstash and Kibana for managing our ever increasing amount of data and logs.
 Kibana is great for visualizing and querying data, but we quickly realized that it needed a companion tool for alerting
 on inconsistencies in our data. Out of this need, ElastAlert was created.

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     package_data={'elastalert': ['schema.yaml']},
     install_requires=[
         'argparse',
-        'elasticsearch<=3.0.0',  # Elastalert is not yet compatible with ES5
+        'elasticsearch<3.0.0',  # Elastalert is not yet compatible with ES5
         'jira==0.32',  # jira.exceptions is missing from later versions
         'jsonschema',
         'mock',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     package_data={'elastalert': ['schema.yaml']},
     install_requires=[
         'argparse',
-        'elasticsearch',
+        'elasticsearch<=3.0.0',  # Elastalert is not yet compatible with ES5
         'jira==0.32',  # jira.exceptions is missing from later versions
         'jsonschema',
         'mock',


### PR DESCRIPTION
ES5 doesn't work with elastalert yet and without this, would install by default.
Fixes #774 