### PR TITLE
Use threading module to run queries in parallel

### DIFF
--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -169,6 +169,8 @@ unless overwritten in the rule config. The default is "localhost".
 
 ``boto_profile``: Boto profile to use when signing requests to Amazon Elasticsearch Service, if you don't want to use the instance role keys.
 
+``num_workers``: The number of worker threads which will execute the Elasticsearch queries in parallel. The default is 1.
+
 .. _runningelastalert:
 
 Running ElastAlert


### PR DESCRIPTION
Closes #17.  
Uses `threading` module to run Elasticsearch queries in parallel.

### A little benchmark
The table below shows a little benchmark that I ran in my machine (a [MacBook Pro 2011](https://support.apple.com/kb/SP619)).  
This benchmark is composed by 8 rules used in the production environment of the company that I work.

Each row of the table refers to a different configuration, and the first row corresponds to the original elastalert implementation (without threads).

For each configuration I ran the elastalert 10 times and measure the time spent (in seconds) in each execution.  
Then I finally calculated the [mean](https://en.wikipedia.org/wiki/Arithmetic_mean), the [standard deviation](https://en.wikipedia.org/wiki/Standard_deviation) and the [variance](https://en.wikipedia.org/wiki/Variance) and put the results in the table.

|                 | mean (sec) | standard deviation (sec) | variance (sec) | difference (%) |
|:---------------:|:----------:|:------------------------:|:--------------:|:--------------:|
| without threads | 6.5513104  | 0.3732684                | 0.13932931     | N/A            |
| 2 threads       | 6.5522794  | 0.2512189                | 0.0631109      | +  0.0148%     |
| 4 threads       | 4.4218844  | 0.90058841               | 0.81105948     | - 32.5038%     |
| 8 threads       | 4.0367426  | 0.12913148               | 0.01667494     | - 38.3827%     |

As show above, the code rans 38% faster using 8 threads.