### PR TITLE
The config parser doesn't honor es_url_prefix

### DIFF
--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -304,7 +304,7 @@ def build_es_conn_config(conf):
 
     if 'verify_certs' in conf:
         parsed_conf['verify_certs'] = conf['verify_certs']
- 
+
     if 'es_url_prefix' in conf:
         parsed_conf['es_url_prefix'] = conf['es_url_prefix']
 

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -304,5 +304,8 @@ def build_es_conn_config(conf):
 
     if 'verify_certs' in conf:
         parsed_conf['verify_certs'] = conf['verify_certs']
+    
+    if 'es_url_prefix' in conf:
+        parsed_conf['es_url_prefix'] = conf['es_url_prefix']
 
     return parsed_conf

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -304,7 +304,7 @@ def build_es_conn_config(conf):
 
     if 'verify_certs' in conf:
         parsed_conf['verify_certs'] = conf['verify_certs']
-    
+ 
     if 'es_url_prefix' in conf:
         parsed_conf['es_url_prefix'] = conf['es_url_prefix']
 


### PR DESCRIPTION
This patch is to the util.py#build_es_conn_config function\
It correctly adds the es_url_prefix key into the parsed_conf\
dictionary