### PR TITLE
Fix a bug where a buffer_time larger than timeframe would cause frequ…

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -216,7 +216,9 @@ class FrequencyRule(RuleType):
         self.check_for_match(key, end=True)
 
     def check_for_match(self, key, end=False):
-        # Match if, after removing old events, we hit num_events
+        # Match if, after removing old events, we hit num_events.
+        # the 'end' parameter depends on whether this was called from the
+        # middle or end of an add_data call and is used in subclasses
         if self.occurrences[key].count() >= self.rules['num_events']:
             event = self.occurrences[key].data[-1][0]
             if self.attach_related:


### PR DESCRIPTION
Fix a bug where a buffer_time larger than timeframe would cause frequency type to miss matches.

If a single add_data call contained data covering multiple timeframes, we would only check for the match at the end, after some of the data had been thrown away. This splits the behavior for frequency and flatline, where with the former it will alert immediately, but the latter will wait until the end.