### PR TITLE
Exit alert code early if matches is empty

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -905,6 +905,9 @@ class ElastAlerter():
         :param matches: A list of matches.
         :param rule: A rule configuration.
         """
+        if not matches:
+            return
+
         if alert_time is None:
             alert_time = ts_now()
 


### PR DESCRIPTION
If matches is empty, exceptions occur when code tries to access matches[0]