### PR TITLE
Fix output of timestamps in warning which was inconsistent before

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -756,7 +756,8 @@ class ElastAlerter():
                     # We were processing for longer than our refresh interval
                     # This can happen if --start was specified with a large time period
                     # or if we are running too slow to process events in real time.
-                    logging.warning("Querying from %s to %s took longer than %s!" % (old_starttime, endtime, self.run_every))
+                    logging.warning("Querying from %s to %s took longer than %s!" % (old_starttime, pretty_ts(endtime, rule.get('use_local_time')),
+                                                                                     self.run_every))
 
             self.remove_old_events(rule)
 


### PR DESCRIPTION
The warning when an ES query took too long, was inconsistent, leading to wrong logging output:

Old: WARNING:root:Querying from 2016-11-25 14:14 CET to 2016-11-25 13:22:04.872377+00:00 took longer than 0:01:00!
New: WARNING:root:Querying from 2016-11-25 14:14 CET to 2016-11-25 14:22 CET took longer than 0:01:00!