### PR TITLE
Fix version of Elasticsearch dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ boto==2.34.0
 botocore==1.4.5
 configparser>=3.3.0r2
 croniter==0.3.8
-elasticsearch
+elasticsearch>=5.0.0,<6.0.0
 jira==0.32
 jsonschema==2.2.0
 mock==1.0.0


### PR DESCRIPTION
Set version for Elasticsearch 5.x according to this https://pypi.python.org/pypi/elasticsearch/5.0.1
https://github.com/Yelp/elastalert/issues/790