### PR TITLE
Don't limit elasticsearch pip package to 2.x version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     package_data={'elastalert': ['schema.yaml']},
     install_requires=[
         'argparse',
-        'elasticsearch<3.0.0',  # Elastalert is not yet compatible with ES5
+        'elasticsearch',
         'jira==0.32',  # jira.exceptions is missing from later versions
         'jsonschema',
         'mock',


### PR DESCRIPTION
Allow elasticsearch to be of the latest version, now that you have added support for ES5