### PR TITLE
Add support to replace dots in field names before writing to Elasticsearch

### DIFF
--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -170,6 +170,9 @@ unless overwritten in the rule config. The default is "localhost".
 
 ``boto_profile``: Boto profile to use when signing requests to Amazon Elasticsearch Service, if you don't want to use the instance role keys.
 
+``replace_dots_in_field_names``: If ``True``, ElastAlert replaces any dots in field names with an underscore before writing documents to Elasticsearch.
+The default value is ``False``. Elasticsearch 2.0 - 2.3 does not support dots in field names.
+
 .. _runningelastalert:
 
 Running ElastAlert

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -160,6 +160,7 @@ properties:
   use_local_time: {type: boolean}
   match_enhancements: {type: array, items: {type: string}}
   query_key: *arrayOfString
+  replace_dots_in_field_names: {type: boolean}
 
   # Alert Content
   alert_text: {type: string} # Python format string
@@ -218,7 +219,7 @@ properties:
   ### PagerDuty
   pagerduty_service_key: {type: string}
   pagerduty_client_name: {type: string}
-  
+
   ### Twilio
   twilio_accout_sid: {type: string}
   twilio_auth_token: {type: string}

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -7,6 +7,7 @@ import dateutil.tz
 from auth import Auth
 from elasticsearch import RequestsHttpConnection
 from elasticsearch.client import Elasticsearch
+from six import string_types
 
 logging.basicConfig()
 elastalert_logger = logging.getLogger('elastalert')
@@ -247,6 +248,18 @@ def add_raw_postfix(field):
     if not field.endswith('.raw'):
         field += '.raw'
     return field
+
+
+def replace_dots_in_field_names(document):
+    """ This method destructively modifies document by replacing any dots in
+    field names with an underscore. """
+    for key, value in list(document.items()):
+        if isinstance(value, dict):
+            value = replace_dots_in_field_names(value)
+        if isinstance(key, string_types) and key.find('.') != -1:
+            del document[key]
+            document[key.replace('.', '_')] = value
+    return document
 
 
 def elasticsearch_client(conf):

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from elastalert.util import lookup_es_key, set_es_key, add_raw_postfix
+from elastalert.util import lookup_es_key, set_es_key, add_raw_postfix, replace_dots_in_field_names
 
 
 def test_setting_keys(ea):
@@ -64,3 +64,36 @@ def test_add_raw_postfix(ea):
     expected = 'foo.raw'
     assert add_raw_postfix('foo') == expected
     assert add_raw_postfix('foo.raw') == expected
+
+
+def test_replace_dots_in_field_names(ea):
+    actual = {
+        'a': {
+            'b.c': 'd',
+            'e': {
+                'f': {
+                    'g.h': 0
+                }
+            }
+        },
+        'i.j.k': 1,
+        'l': {
+            'm': 2
+        }
+    }
+    expected = {
+        'a': {
+            'b_c': 'd',
+            'e': {
+                'f': {
+                    'g_h': 0
+                }
+            }
+        },
+        'i_j_k': 1,
+        'l': {
+            'm': 2
+        }
+    }
+    assert replace_dots_in_field_names(actual) == expected
+    assert replace_dots_in_field_names({'a': 0, 1: 2}) == {'a': 0, 1: 2}


### PR DESCRIPTION
When ElastAlert is used with Elasticsearch 2.x [1], elastalert writes to the writeback index fail when match_body contains fields with dots in their name (e.g., a frequency rule with a query_key containing dots).

Example Error

ERROR:root:Error writing alert info to Elasticsearch: TransportError(400, {u'root_cause': [{u'reason': u"Field name [d.ip.raw] cannot contain '.'", u'type': u'mapper_parsing_exception'}], u'type': u'mapper_parsing_exception', u'reason': u"Field name [d.ip.raw] cannot contain '.'"})

This PR adds support to replace any dots in field names with an underscore before writing to Elasticsearch. The default is off.

[1] https://www.elastic.co/guide/en/elasticsearch/reference/2.4/dots-in-names.html