### PR TITLE
add --config option to elastalert-create-index cli

### DIFF
--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -31,15 +31,13 @@ def main():
     parser.add_argument('--boto-profile', default=None, help='Boto profile to use for signing requests')
     parser.add_argument('--aws-region', default=None, help='AWS Region to use for signing requests')
     parser.add_argument('--timeout', default=60, help='Elasticsearch request timeout')
-    parser.add_argument('--config', default="/etc/elastalert/elastalert.yml", help='path to config file')
+    parser.add_argument('--config', default='config.yml', help='Global config file (default: config.yaml)')
     args = parser.parse_args()
-
-    if os.path.isfile(args.config):
-        filename = args.config
-    elif os.path.isfile('../config.yaml'):
+       
+    if os.path.isfile('../config.yaml'):
         filename = '../config.yaml'
-    elif os.path.isfile('config.yaml'):
-        filename = 'config.yaml'
+    elif os.path.isfile(args.config):
+        filename = args.config
     else:
         filename = ''
 

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -31,7 +31,7 @@ def main():
     parser.add_argument('--boto-profile', default=None, help='Boto profile to use for signing requests')
     parser.add_argument('--aws-region', default=None, help='AWS Region to use for signing requests')
     parser.add_argument('--timeout', default=60, help='Elasticsearch request timeout')
-    parser.add_argument('--config', default='config.yml', help='Global config file (default: config.yaml)')
+    parser.add_argument('--config', default='config.yaml', help='Global config file (default: config.yaml)')
     args = parser.parse_args()
 
     if os.path.isfile('../config.yaml'):

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -31,9 +31,12 @@ def main():
     parser.add_argument('--boto-profile', default=None, help='Boto profile to use for signing requests')
     parser.add_argument('--aws-region', default=None, help='AWS Region to use for signing requests')
     parser.add_argument('--timeout', default=60, help='Elasticsearch request timeout')
+    parser.add_argument('--config', default="/etc/elastalert/elastalert.yml", help='path to config file')
     args = parser.parse_args()
 
-    if os.path.isfile('../config.yaml'):
+    if os.path.isfile(args.config):
+        filename = args.config
+    elif os.path.isfile('../config.yaml'):
         filename = '../config.yaml'
     elif os.path.isfile('config.yaml'):
         filename = 'config.yaml'

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -33,7 +33,7 @@ def main():
     parser.add_argument('--timeout', default=60, help='Elasticsearch request timeout')
     parser.add_argument('--config', default='config.yml', help='Global config file (default: config.yaml)')
     args = parser.parse_args()
-       
+
     if os.path.isfile('../config.yaml'):
         filename = '../config.yaml'
     elif os.path.isfile(args.config):


### PR DESCRIPTION
I am storing tthe global config under `/etc/elastalert/elastalert.yml` and I need to run `elastalert-create-index` in a none interactive mode which is kind of hard to achieve because of `getpass.getpass` in the following block:
```
username = raw_input('Enter optional basic-auth username (or leave blank): ')
password = getpass.getpass('Enter optional basic-auth password (or leave blank): ')
```
Adding a `--config path/to/config` option is the most elegant solution I came up with. 