### PR TITLE
Add optional new_style_string_format option to CommandAlert

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1021,17 +1021,23 @@ in the case of an aggregated alert, as a JSON array, to the stdin of the process
 
 This alert requires one option:
 
-``command``: A list of arguments to execute or a string to execute. If in list format, the first argument is the name of the program to execute. If passing a
-string, the command will be executed through the shell. The command string or args will be formatted using Python's % string format syntax with the
-match passed the format argument. This means that a field can be accessed with ``%(field_name)s``. In an aggregated alert, these fields will come
-from the first match.
+``command``: A list of arguments to execute or a string to execute. If in list format, the first argument is the name of the program to execute. If passed a
+string, the command is executed through the shell.
+
+Strings can be formatted using the old-style format (``%``) or the new-style format (``.format()``). When the old-style format is used, fields are accessed
+using ``%(field_name)s``. When the new-style format is used, fields are accessed using ``{match[field_name]}``. New-style formatting allows accessing nested
+fields (e.g., ``{match[field_1_name][field_2_name]}``).
+
+In an aggregated alert, these fields come from the first match.
 
 Optional:
+
+``new_style_string_format``: If True, arguments are formatted using ``.format()`` rather than ``%``. The default is False.
 
 ``pipe_match_json``: If true, the match will be converted to JSON and passed to stdin of the command. Note that this will cause ElastAlert to block
 until the command exits or sends an EOF to stdout.
 
-Example usage::
+Example usage using old-style format::
 
     alert:
       - command
@@ -1041,6 +1047,12 @@ Example usage::
 
     Executing commmands with untrusted data can make it vulnerable to shell injection! If you use formatted data in
     your command, it is highly recommended that you use a args list format instead of a shell string.
+
+Example usage using new-style format::
+
+    alert:
+      - command
+    command: ["/bin/send_alert", "--username", "{match[username]}"]
 
 
 Email

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -746,7 +746,9 @@ class CommandAlerter(Alerter):
 
     def __init__(self, *args):
         super(CommandAlerter, self).__init__(*args)
+
         self.last_command = []
+
         self.shell = False
         if isinstance(self.rule['command'], basestring):
             self.shell = True
@@ -754,10 +756,17 @@ class CommandAlerter(Alerter):
                 logging.warning('Warning! You could be vulnerable to shell injection!')
             self.rule['command'] = [self.rule['command']]
 
+        self.new_style_string_format = False
+        if 'new_style_string_format' in self.rule and self.rule['new_style_string_format']:
+            self.new_style_string_format = True
+
     def alert(self, matches):
         # Format the command and arguments
         try:
-            command = [command_arg % matches[0] for command_arg in self.rule['command']]
+            if self.new_style_string_format:
+                command = [command_arg.format(match=matches[0]) for command_arg in self.rule['command']]
+            else:
+                command = [command_arg % matches[0] for command_arg in self.rule['command']]
             self.last_command = command
         except KeyError as e:
             raise EAException("Error formatting command: %s" % (e))

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -600,24 +600,51 @@ def test_command():
     rule = {'command': ['/bin/test/', '--arg', '%(somefield)s']}
     alert = CommandAlerter(rule)
     match = {'@timestamp': '2014-01-01T00:00:00',
-             'somefield': 'foobarbaz'}
+             'somefield': 'foobarbaz',
+             'nested': {'field': 1}}
     with mock.patch("elastalert.alerts.subprocess.Popen") as mock_popen:
         alert.alert([match])
     assert mock_popen.called_with(['/bin/test', '--arg', 'foobarbaz'], stdin=subprocess.PIPE, shell=False)
 
-    # Test command as string with formatted arg
+    # Test command as string with formatted arg (old-style string format)
     rule = {'command': '/bin/test/ --arg %(somefield)s'}
     alert = CommandAlerter(rule)
     with mock.patch("elastalert.alerts.subprocess.Popen") as mock_popen:
         alert.alert([match])
     assert mock_popen.called_with('/bin/test --arg foobarbaz', stdin=subprocess.PIPE, shell=False)
 
-    # Test command as string without formatted arg
+    # Test command as string without formatted arg (old-style string format)
     rule = {'command': '/bin/test/foo.sh'}
     alert = CommandAlerter(rule)
     with mock.patch("elastalert.alerts.subprocess.Popen") as mock_popen:
         alert.alert([match])
     assert mock_popen.called_with('/bin/test/foo.sh', stdin=subprocess.PIPE, shell=True)
+
+    # Test command as string with formatted arg (new-style string format)
+    rule = {'command': '/bin/test/ --arg {match[somefield]}', 'new_style_string_format': True}
+    alert = CommandAlerter(rule)
+    with mock.patch("elastalert.alerts.subprocess.Popen") as mock_popen:
+        alert.alert([match])
+    assert mock_popen.called_with('/bin/test --arg foobarbaz', stdin=subprocess.PIPE, shell=False)
+
+    rule = {'command': '/bin/test/ --arg {match[nested][field]}', 'new_style_string_format': True}
+    alert = CommandAlerter(rule)
+    with mock.patch("elastalert.alerts.subprocess.Popen") as mock_popen:
+        alert.alert([match])
+    assert mock_popen.called_with('/bin/test --arg 1', stdin=subprocess.PIPE, shell=False)
+
+    # Test command as string without formatted arg (new-style string format)
+    rule = {'command': '/bin/test/foo.sh', 'new_style_string_format': True}
+    alert = CommandAlerter(rule)
+    with mock.patch("elastalert.alerts.subprocess.Popen") as mock_popen:
+        alert.alert([match])
+    assert mock_popen.called_with('/bin/test/foo.sh', stdin=subprocess.PIPE, shell=True)
+
+    rule = {'command': '/bin/test/foo.sh {{bar}}', 'new_style_string_format': True}
+    alert = CommandAlerter(rule)
+    with mock.patch("elastalert.alerts.subprocess.Popen") as mock_popen:
+        alert.alert([match])
+    assert mock_popen.called_with('/bin/test/foo.sh {bar}', stdin=subprocess.PIPE, shell=True)
 
     # Test command with pipe_match_json
     rule = {'command': ['/bin/test/', '--arg', '%(somefield)s'],


### PR DESCRIPTION
This PR adds a new optional option to CommandAlert: new_style_string_format. When True, strings are formatted using Python's `.format()` rather than `%`.

New-style formatting allows accessing nested fields (e.g., `{match[d][ip]}`). The default is to use old-style formatting to avoid breaking existing CommandAlerts.

This PR should help address #663.