### PR TITLE
By default, start aggregations based on current time

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -303,6 +303,18 @@ Then, for the same sample data shown above listing alice and bob's events, Elast
     |      alice       |   something else   |
     +------------------+--------------------+
 
+
+.. note::
+   By default, aggregation time is relative to the current system time, not the time of the match. This means that running elastalert over
+   past events will result in different alerts than if elastalert had been running while those events occured. This behavior can be changed
+   by setting ``aggregate_by_match_time``.
+
+aggregate_by_match_time
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Setting this to true will cause aggregations to be created relative to the timestamp of the first event, rather than the current time. This
+is useful for querying over historic data or if using a very large buffer_time and you want multiple aggregations to occur from a single query. 
+
 realert
 ^^^^^^^
 

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1137,13 +1137,14 @@ class ElastAlerter():
                 if aggregated_matches:
                     matches = [match_body] + [agg_match['match_body'] for agg_match in aggregated_matches]
                     self.alert(matches, rule, alert_time=alert_time)
-                    if rule['current_aggregate_id']:
-                        for qk, id in rule['current_aggregate_id'].iteritems():
-                            if id == _id:
-                                rule['current_aggregate_id'].pop(qk)
-                                break
                 else:
                     self.alert([match_body], rule, alert_time=alert_time)
+
+                if rule['current_aggregate_id']:
+                    for qk, id in rule['current_aggregate_id'].iteritems():
+                        if id == _id:
+                            rule['current_aggregate_id'].pop(qk)
+                            break
 
                 # Delete it from the index
                 try:
@@ -1227,7 +1228,6 @@ class ElastAlerter():
                 elastalert_logger.info('Adding alert for %s to aggregation(id: %s, aggregation_key: %s), next alert at %s' % (rule['name'], agg_id, aggregation_key_value, alert_time))
             else:
                 # First match, set alert_time
-                match_time = ts_to_dt(lookup_es_key(match, rule['timestamp_field']))
                 alert_time = ''
                 if isinstance(rule['aggregation'], dict) and rule['aggregation'].get('schedule'):
                     croniter._datetime_to_timestamp = cronite_datetime_to_timestamp  # For Python 2.6 compatibility
@@ -1237,7 +1237,11 @@ class ElastAlerter():
                     except Exception as e:
                         self.handle_error("Error parsing aggregate send time Cron format %s" % (e), rule['aggregation']['schedule'])
                 else:
-                    alert_time = match_time + rule['aggregation']
+                    if rule.get('aggregate_by_match_time', False):
+                        match_time = ts_to_dt(lookup_es_key(match, rule['timestamp_field']))
+                        alert_time = match_time + rule['aggregation']
+                    else:
+                        alert_time = ts_now() + rule['aggregation']
 
                 rule['aggregate_alert_time'][aggregation_key_value] = alert_time
                 agg_id = None

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1141,8 +1141,8 @@ class ElastAlerter():
                     self.alert([match_body], rule, alert_time=alert_time)
 
                 if rule['current_aggregate_id']:
-                    for qk, id in rule['current_aggregate_id'].iteritems():
-                        if id == _id:
+                    for qk, agg_id in rule['current_aggregate_id'].iteritems():
+                        if agg_id == _id:
                             rule['current_aggregate_id'].pop(qk)
                             break
 


### PR DESCRIPTION
Two major changes.

1. By default, instead of aggregating by the document time, use the current time. 

2. Fixes a bug where if aggregation is less than query_delay, aggregations will fail to send completely and get stuck. This is because the first document will immediately trigger an alert, and rule['current_aggregate_id'] will never get cleared, creating orphaned alerts.