### PR TITLE
top_count_keys fixed for ES5

### DIFF
--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -211,11 +211,6 @@ def load_options(rule, conf, args=None):
     include.append(rule['timestamp_field'])
     rule['include'] = list(set(include))
 
-    # Change top_count_keys to .raw
-    if 'top_count_keys' in rule and rule.get('raw_count_keys', True):
-        keys = rule.get('top_count_keys')
-        rule['top_count_keys'] = [key + '.raw' if not key.endswith('.raw') else key for key in keys]
-
     # Check that generate_kibana_url is compatible with the filters
     if rule.get('generate_kibana_link'):
         for es_filter in rule.get('filter'):

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -338,9 +338,9 @@ class ElastAlerter():
         if qk:
             filter_key = rule['query_key']
             if self.is_five():
-                end='.keyword'
+                end = '.keyword'
             else:
-                end='.raw'
+                end = '.raw'
             if rule.get('raw_count_keys', True) and not rule['query_key'].endswith(end) and not self.is_five():
                 filter_key = add_raw_postfix(filter_key, self.is_five())
             rule_filter.extend([{'term': {filter_key: qk}}])

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -761,6 +761,7 @@ class NewTermsRule(RuleType):
         version = self.es.info()['version']['number']
         return version.startswith('5')
 
+
 class CardinalityRule(RuleType):
     """ A rule that matches if cardinality of a field is above or below a threshold within a timeframe """
     required_options = frozenset(['timeframe', 'cardinality_field'])

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -756,12 +756,10 @@ class NewTermsRule(RuleType):
                                  'new_field': field}
                         self.add_match(match)
                         self.seen_values[field].append(bucket['key'])
-                        
+
     def is_five(self):
         version = self.es.info()['version']['number']
         return version.startswith('5')
-
-
 
 class CardinalityRule(RuleType):
     """ A rule that matches if cardinality of a field is above or below a threshold within a timeframe """

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -563,7 +563,7 @@ class NewTermsRule(RuleType):
                 level = query_template['aggs']
                 # Iterate on each part of the composite key and add a sub aggs clause to the elastic search query
                 for i, sub_field in enumerate(field):
-                    level['values']['terms']['field'] = add_raw_postfix(sub_field)
+                    level['values']['terms']['field'] = add_raw_postfix(sub_field, self.is_five())
                     if i < len(field) - 1:
                         # If we have more fields after the current one, then set up the next nested structure
                         level['values']['aggs'] = {'values': {'terms': copy.deepcopy(field_name)}}
@@ -571,7 +571,7 @@ class NewTermsRule(RuleType):
             else:
                 self.seen_values.setdefault(field, [])
                 # For non-composite keys, only a single agg is needed
-                field_name['field'] = add_raw_postfix(field)
+                field_name['field'] = add_raw_postfix(field, self.is_five())
 
             # Query the entire time range in small chunks
             while tmp_start < end:
@@ -756,6 +756,11 @@ class NewTermsRule(RuleType):
                                  'new_field': field}
                         self.add_match(match)
                         self.seen_values[field].append(bucket['key'])
+                        
+    def is_five(self):
+        version = self.es.info()['version']['number']
+        return version.startswith('5')
+
 
 
 class CardinalityRule(RuleType):

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -248,7 +248,7 @@ def add_raw_postfix(field, is_five):
     if is_five:
         end = '.keyword'
     else:
-        end =  '.raw'
+        end = '.raw'
     if not field.endswith(end):
         field += end
     return field

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -244,9 +244,13 @@ def cronite_datetime_to_timestamp(self, d):
     return total_seconds((d - datetime.datetime(1970, 1, 1)))
 
 
-def add_raw_postfix(field):
-    if not field.endswith('.raw'):
-        field += '.raw'
+def add_raw_postfix(field, is_five):
+    if is_five:
+        end = '.keyword'
+    else:
+        end =  '.raw'
+    if not field.endswith(end):
+        field += end
     return field
 
 

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -475,6 +475,7 @@ def test_new_term():
     with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
+        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'} }
         call_args = []
 
         # search is called with a mutable dict containing timestamps, this is required to test
@@ -526,6 +527,7 @@ def test_new_term():
     with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
+        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'} }
         rule = NewTermsRule(rules)
     rule.add_data([{'@timestamp': ts_now(), 'a': 'key2'}])
     assert len(rule.matches) == 1
@@ -542,6 +544,7 @@ def test_new_term_nested_field():
     with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
+        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'} }
         rule = NewTermsRule(rules)
 
         assert rule.es.search.call_count == 60
@@ -565,6 +568,7 @@ def test_new_term_with_terms():
     with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
+        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'} }
         rule = NewTermsRule(rules)
 
         # Only 15 queries because of custom step size
@@ -633,6 +637,7 @@ def test_new_term_with_composite_fields():
     with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
+        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'} }
         rule = NewTermsRule(rules)
 
         assert rule.es.search.call_count == 60
@@ -669,6 +674,7 @@ def test_new_term_with_composite_fields():
     with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
+        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'} }
         rule = NewTermsRule(rules)
     rule.add_data([{'@timestamp': ts_now(), 'a': 'key2'}])
     assert len(rule.matches) == 2

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -475,7 +475,7 @@ def test_new_term():
     with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
-        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'} }
+        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'}}
         call_args = []
 
         # search is called with a mutable dict containing timestamps, this is required to test
@@ -527,7 +527,7 @@ def test_new_term():
     with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
-        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'} }
+        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'}}
         rule = NewTermsRule(rules)
     rule.add_data([{'@timestamp': ts_now(), 'a': 'key2'}])
     assert len(rule.matches) == 1
@@ -544,7 +544,7 @@ def test_new_term_nested_field():
     with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
-        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'} }
+        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'}}
         rule = NewTermsRule(rules)
 
         assert rule.es.search.call_count == 60
@@ -568,7 +568,7 @@ def test_new_term_with_terms():
     with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
-        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'} }
+        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'}}
         rule = NewTermsRule(rules)
 
         # Only 15 queries because of custom step size
@@ -637,7 +637,7 @@ def test_new_term_with_composite_fields():
     with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
-        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'} }
+        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'}}
         rule = NewTermsRule(rules)
 
         assert rule.es.search.call_count == 60
@@ -674,7 +674,7 @@ def test_new_term_with_composite_fields():
     with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
-        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'} }
+        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'}}
         rule = NewTermsRule(rules)
     rule.add_data([{'@timestamp': ts_now(), 'a': 'key2'}])
     assert len(rule.matches) == 2
@@ -755,7 +755,6 @@ def test_flatline_count():
     assert len(rule.matches) == 0
     rule.add_count_data({ts_to_dt('2014-10-11T00:00:35'): 0})
     assert len(rule.matches) == 1
-
 
 def test_flatline_query_key():
     rules = {'timeframe': datetime.timedelta(seconds=30),

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -756,6 +756,7 @@ def test_flatline_count():
     rule.add_count_data({ts_to_dt('2014-10-11T00:00:35'): 0})
     assert len(rule.matches) == 1
 
+
 def test_flatline_query_key():
     rules = {'timeframe': datetime.timedelta(seconds=30),
              'threshold': 1,

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -62,8 +62,11 @@ def test_looking_up_nested_composite_keys(ea):
 
 def test_add_raw_postfix(ea):
     expected = 'foo.raw'
-    assert add_raw_postfix('foo') == expected
-    assert add_raw_postfix('foo.raw') == expected
+    assert add_raw_postfix('foo', False) == expected
+    assert add_raw_postfix('foo.raw', False) == expected
+    expected = 'foo.keyword'
+    assert add_raw_postfix('foo', True) == expected
+    assert add_raw_postfix('foo.keyword', True) == expected
 
 
 def test_replace_dots_in_field_names(ea):


### PR DESCRIPTION
Fix ".raw" fields in es5 when using top_count_keys