### PR TITLE
Support aws credential providers

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,8 +1,7 @@
 FROM ubuntu:latest
 
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get -y install python-setuptools python2.7 git tox
-
+RUN apt-get -y install python-setuptools python python-dev tox gcc
 RUN easy_install pip
 
 WORKDIR /home/elastalert

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -41,6 +41,7 @@ def main():
     else:
         filename = ''
 
+    default_credentials_provider = 'instance-metadata'
     if filename:
         with open(filename) as config_file:
             data = yaml.load(config_file)
@@ -53,6 +54,7 @@ def main():
         verify_certs = args.verify_certs if args.verify_certs is not None else data.get('verify_certs') is not False
         aws_region = data.get('aws_region', None)
         send_get_body_as = data.get('send_get_body_as', 'GET')
+        aws_credentials_provider = data.get('aws_credentials_provider', default_credentials_provider)
     else:
         username = None
         password = None
@@ -72,6 +74,7 @@ def main():
         url_prefix = (args.url_prefix if args.url_prefix is not None
                       else raw_input('Enter optional Elasticsearch URL prefix (prepends a string to the URL of every request): '))
         send_get_body_as = args.send_get_body_as
+        aws_credentials_provider = args.aws_credentials_provider if args.aws_credentials_provider else default_credentials_provider
 
     timeout = args.timeout
     auth = Auth()
@@ -79,7 +82,8 @@ def main():
                      username=username,
                      password=password,
                      aws_region=aws_region,
-                     boto_profile=args.boto_profile)
+                     boto_profile=args.boto_profile,
+                     aws_credentials_provider=aws_credentials_provider)
 
     es = Elasticsearch(
         host=host,

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -270,7 +270,8 @@ def elasticsearch_client(conf):
                                      username=es_conn_conf['es_username'],
                                      password=es_conn_conf['es_password'],
                                      aws_region=es_conn_conf['aws_region'],
-                                     boto_profile=es_conn_conf['boto_profile'])
+                                     boto_profile=es_conn_conf['boto_profile'],
+                                     aws_credentials_provider=es_conn_conf['aws_credentials_provider'])
 
     return Elasticsearch(host=es_conn_conf['es_host'],
                          port=es_conn_conf['es_port'],
@@ -295,6 +296,7 @@ def build_es_conn_config(conf):
     parsed_conf['es_username'] = None
     parsed_conf['es_password'] = None
     parsed_conf['aws_region'] = None
+    parsed_conf['aws_credentials_provider'] = 'instance-metadata'
     parsed_conf['boto_profile'] = None
     parsed_conf['es_host'] = conf['es_host']
     parsed_conf['es_port'] = conf['es_port']
@@ -308,6 +310,9 @@ def build_es_conn_config(conf):
 
     if 'aws_region' in conf:
         parsed_conf['aws_region'] = conf['aws_region']
+
+    if 'aws_credentials_provider' in conf:
+        parsed_conf['aws_credentials_provider'] = conf['aws_credentials_provider']
 
     if 'boto_profile' in conf:
         parsed_conf['boto_profile'] = conf['boto_profile']

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ argparse==1.3.0
 aws-requests-auth==0.2.5
 blist==1.3.6
 boto==2.34.0
-botocore==1.4.5
+botocore==1.4.37
 configparser>=3.3.0r2
 croniter==0.3.8
 elasticsearch


### PR DESCRIPTION
Hi,

this PR allows configuring `aws_credentials_provider` to be either: `instance-metadata`(default) or `container`. If aws_credentials_provider equals `container`, the botocore.ContainerProvider is used to get aws_credentials (see http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html).

P.S. I could not figure out how to run tests locally so I hope Travis will notify me if something is wrong and I will fix it afterwards.