### PR TITLE
Apply ES5 filter fix when using test rule

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -657,15 +657,19 @@ class ElastAlerter():
                 continue
             new_rule[prop] = rule[prop]
 
-        # In ES5, filters starting with 'query' should have the top wrapper removed
         if self.is_five():
-            for es_filter in copy.copy(new_rule.get('filter', [])):
-                if es_filter.get('query'):
-                    new_filter = es_filter['query']
-                    new_rule['filter'].append(new_filter)
-                    new_rule['filter'].remove(es_filter)
+            self.modify_rule_for_ES5(new_rule)
 
         return new_rule
+
+    @staticmethod
+    def modify_rule_for_ES5(new_rule):
+        # In ES5, filters starting with 'query' should have the top wrapper removed
+        for es_filter in new_rule.get('filter', []):
+            if es_filter.get('query'):
+                new_filter = es_filter['query']
+                new_rule['filter'].append(new_filter)
+                new_rule['filter'].remove(es_filter)
 
     def load_rule_changes(self):
         ''' Using the modification times of rule config files, syncs the running rules

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -59,6 +59,9 @@ class MockElastAlerter(object):
             print(repr(e)[:2048], file=sys.stderr)
             return None
 
+        if is_five:
+            ElastAlerter.modify_rule_for_ES5(conf)
+
         start_time = ts_now() - datetime.timedelta(days=args.days)
         end_time = ts_now()
         ts = conf.get('timestamp_field', '@timestamp')


### PR DESCRIPTION
When using elastalert-test-rule on elasticsearch v5 an error will be thrown that running your filter failed despite the test continuing to run successfully

![image](https://cloud.githubusercontent.com/assets/385251/23174868/a4b9eefe-f855-11e6-9254-9a0c09e4d06e.png)

It seems to keep backward syntax compatibility code was added to trim filters if using ES5 (https://github.com/Yelp/elastalert/pull/820/commits/bb09323ad893b22d17e0d7cb2aa50c52db18f80d) but this was only done inside the ElastAlerter class and not for MockElastAlerter. Not sure on preferred way to approach this but abstracted the code fix and used it in test_file() aswell fixing the error. Comments appreciated :-)

