### PR TITLE
Mock writeback_es because there are no longer any checks if it is None

### DIFF
--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -239,8 +239,10 @@ class MockElastAlerter(object):
         if args.json:
             self.mock_elastalert(client)
 
-        # Mock writeback for both real data and json data
-        client.writeback_es = None
+        # Mock writeback to return empty results
+        client.writeback_es = mock.MagicMock()
+        client.writeback_es.search.return_value = {"hits": {"hits": []}}
+
         with mock.patch.object(client, 'writeback') as mock_writeback:
             client.run_rule(rule, endtime, starttime)
 
@@ -272,7 +274,7 @@ class MockElastAlerter(object):
         # Mock configuration. This specifies the base values for attributes, unless supplied otherwise.
         conf_default = {
             'rules_folder': 'rules',
-            'es_host': 'es',
+            'es_host': 'localhost',
             'es_port': 14900,
             'writeback_index': 'wb',
             'max_query_size': 10000,


### PR DESCRIPTION
Fixes #915 

This was introduced by #892

Also, switched default (if no config.yaml specified or found) hostname to localhost instead of the confusing "es".