### PR TITLE
Bump requests dependency to 2.13.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ oauthlib==0.7.2
 PyStaticConfiguration==0.9.0
 python-dateutil==2.4.0
 PyYAML==3.11
-requests==2.5.1
+requests==2.13.0
 requests-oauthlib==0.4.2
 simplejson==3.3.0
 six==1.10.0


### PR DESCRIPTION
This fixes a bug I'm experiencing with SSL certificate verification in requests 2.5.1.