### PR TITLE
Manage docs theme through pip

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,5 @@
+import sphinx_rtd_theme
+
 # -*- coding: utf-8 -*-
 #
 # ElastAlert documentation build configuration file, created by
@@ -86,7 +88,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  Major themes that come with
 # Sphinx are currently 'default' and 'sphinxdoc'.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -94,6 +96,7 @@ html_theme = 'default'
 # html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to


### PR DESCRIPTION
Rather than rely on manually managing _static and overwriting the default theme, manage the choice of theme through a package so we aren't tethered to one point in time, presumably getting access to any theme updates/fixes. This approach does assume an unmodded theme.