### PR TITLE
Changed default realert to 0 if aggregation set

### DIFF
--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -147,7 +147,10 @@ def load_options(rule, conf, filename, args=None):
         if 'realert' in rule:
             rule['realert'] = datetime.timedelta(**rule['realert'])
         else:
-            rule['realert'] = datetime.timedelta(minutes=1)
+            if 'aggregation' in rule:
+                rule['realert'] = datetime.timedelta(minutes=0)
+            else:
+                rule['realert'] = datetime.timedelta(minutes=1)
         if 'aggregation' in rule and not rule['aggregation'].get('schedule'):
             rule['aggregation'] = datetime.timedelta(**rule['aggregation'])
         if 'query_delay' in rule:


### PR DESCRIPTION
Fixes #819 

The 1 minute realert default makes no sense when using aggregation. It causes confusion because people expect everything to be present in the aggregated alert.