### PR TITLE
Upgraded to Boto3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,13 +2,16 @@ config.yaml
 .tox/
 .coverage
 .idea/*
+.cache/
 __pycache__/
 *.pyc
 virtualenv_run/
 *.egg-info/
 dist/
 venv/
+env/
 docs/build/
 build/
 
 my_rules
+*.swp

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -19,6 +19,14 @@ es_host: elasticsearch.example.com
 # The Elasticsearch port
 es_port: 9200
 
+# The AWS region to use. Set this when using AWS-managed elasticsearch
+#aws_region: us-east-1
+
+# The AWS profile to use. Use this if you are using an aws-cli profile.
+# See http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html
+# for details
+#profile: test
+
 # Optional URL prefix for Elasticsearch
 #es_url_prefix: elasticsearch
 

--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -94,14 +94,14 @@ to the alerter. See :ref:`Enhancements` for more information.
 .. _configuration:
 
 Configuration
-==============
+=============
 
 ElastAlert has a global configuration file, ``config.yaml``, which defines several aspects of its operation:
 
 ``buffer_time``: ElastAlert will continuously query against a window from the present to ``buffer_time`` ago.
 This way, logs can be back filled up to a certain extent and ElastAlert will still process the events. This
 may be overridden by individual rules. This option is ignored for rules where ``use_count_query`` or ``use_terms_query``
- is set to true. Note that back filled data may not always trigger count based alerts as if it was queried in real time.
+is set to true. Note that back filled data may not always trigger count based alerts as if it was queried in real time.
 
 ``es_host``: The host name of the Elasticsearch cluster where ElastAlert records metadata about its searches.
 When ElastAlert is started, it will query for information about the time that it was last run. This way,
@@ -168,7 +168,9 @@ unless overwritten in the rule config. The default is "localhost".
 
 ``aws_region``: This makes ElastAlert to sign HTTP requests when using Amazon Elasticsearch Service. It'll use instance role keys to sign the requests.
 
-``boto_profile``: Boto profile to use when signing requests to Amazon Elasticsearch Service, if you don't want to use the instance role keys.
+``boto_profile``: Deprecated! Boto profile to use when signing requests to Amazon Elasticsearch Service, if you don't want to use the instance role keys.
+
+``profile``: AWS profile to use when signing requests to Amazon Elasticsearch Service, if you don't want to use the instance role keys.
 
 ``replace_dots_in_field_names``: If ``True``, ElastAlert replaces any dots in field names with an underscore before writing documents to Elasticsearch.
 The default value is ``False``. Elasticsearch 2.0 - 2.3 does not support dots in field names.

--- a/docs/source/elastalert_status.rst
+++ b/docs/source/elastalert_status.rst
@@ -64,7 +64,7 @@ an alert with ``realert`` is triggered, a ``silence`` record will be written wit
 - ``rule_name``: The name of the corresponding rule.
 - ``until``: The timestamp when alerts will begin being sent again.
 - ``exponent``: The exponential factor which multiplies ``realert``. The length of this silence is equal to ``realert`` * 2**exponent. This will
-be 0 unless ``exponential_realert`` is set.
+  be 0 unless ``exponential_realert`` is set.
 
 Whenever an alert is triggered, ElastAlert will check for a matching ``silence`` document, and if the ``until`` timestamp is in the future, it will ignore
 the alert completely. See the :ref:`Running ElastAlert <runningelastalert>` section for information on how to silence an alert.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,7 @@ Contents:
    recipes/adding_alerts
    recipes/writing_filters
    recipes/adding_enhancements
+   recipes/signing_requests
 
 Indices and Tables
 ==================

--- a/docs/source/recipes/adding_alerts.rst
+++ b/docs/source/recipes/adding_alerts.rst
@@ -1,7 +1,7 @@
 .. _writingalerts:
 
 Adding a New Alerter
-=====================
+====================
 
 Alerters are subclasses of ``Alerter``, found in ``elastalert/alerts.py``. They are given matches
 and perform some action based on that. Your alerter needs to implement two member functions, and will look
@@ -20,7 +20,7 @@ You can import alert types by specifying the type as ``module.file.AlertName``, 
 and file is the name of the python file containing a ``Alerter`` subclass named ``AlertName``.
 
 Basics
--------
+------
 
 The alerter class will be instantiated when ElastAlert starts, and be periodically passed
 matches through the ``alert`` method. ElastAlert also writes back info about the alert into

--- a/docs/source/recipes/adding_rules.rst
+++ b/docs/source/recipes/adding_rules.rst
@@ -1,7 +1,7 @@
 .. _writingrules:
 
 Adding a New Rule Type
-=======================
+======================
 
 This document describes how to create a new rule type. Built in rule types live in ``elastalert/ruletypes.py``
 and are subclasses of ``RuleType``. At the minimum, your rule needs to implement ``add_data``.
@@ -23,7 +23,7 @@ You can import new rule types by specifying the type as ``module.file.RuleName``
 containing ``__init__.py``, and file is the name of the Python file containing a ``RuleType`` subclass named ``RuleName``.
 
 Basics
--------
+------
 
 The ``RuleType`` instance remains in memory while ElastAlert is running, receives data, keeps track of its state,
 and generates matches. Several important member properties are created in the ``__init__`` method of ``RuleType``:
@@ -41,14 +41,14 @@ recommended that you use ``self.add_match(match)`` to add matches. In addition t
 ensure that all of these fields exist before trying to instantiate a ``RuleType`` instance.
 
 add_data(self, data):
-----------------------
+---------------------
 
 When ElastAlert queries Elasticsearch, it will pass all of the hits to the rule type by calling ``add_data``.
 ``data`` is a list of dictionary objects which contain all of the fields in ``include``, ``query_key`` and ``compare_key``
 if they exist, and ``@timestamp`` as a datetime object. They will always come in chronological order sorted by '@timestamp'.
 
 get_match_str(self, match):
-------------------------------
+---------------------------
 
 Alerts will call this function to get a human readable string about a match for an alert. Match will be the same
 object that was added to ``self.matches``, and ``rules`` the same as ``self.rules``. The ``RuleType`` base implementation

--- a/docs/source/recipes/signing_requests.rst
+++ b/docs/source/recipes/signing_requests.rst
@@ -1,21 +1,38 @@
 .. _signingrequests:
 
 Signing requests to Amazon Elasticsearch service
-============
+================================================
 
-When using Amazon Elasticsearch service, you need to secure your Elasticsearch from the outside.
-Currently, there is no way to secure your Elasticsearch using network firewall rules, so the only way is to signing the requests using the access key and secret key for a role or user with permissions on the Elasticsearch service.
+When using Amazon Elasticsearch service, you need to secure your Elasticsearch
+from the outside. Currently, there is no way to secure your Elasticsearch using
+network firewall rules, so the only way is to signing the requests using the
+access key and secret key for a role or user with permissions on the
+Elasticsearch service.
 
-We offer two different options to sign ElastAlert requests to Elasticsearch: using instance roles and boto profiles.
+You can sign requests to AWS using any of the standard AWS methods of providing
+credentials.
+- Environment Variables, ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY``
+- AWS Config or Credential Files, ``~/.aws/config`` and ``~/.aws/credentials``
+- AWS Instance Profiles, uses the EC2 Metadata service
 
-Using instance role
--------------------
-Typically, you'll deploy ElastAlert on a running EC2 instance on AWS. You can assign a role to this instance that gives it permissions to read from and write to the Elasticsearch service.
-Then you just need to add the ``aws_region`` option to the configuration file. This will tell ElastAlert to sign the requests to Elasticsearch.
+Using an Instance Profile
+-------------------------
 
-Using boto profiles
---------------------
-You can also create a user with permissions on the Elasticsearch service and tell ElastAlert to authenticate itself using that user.
-First, create a boto profile in the machine where you'd like to run ElastAlert for the user with permissions. Then, just add two options to the configuration file:
-- ``aws_region``: that tells ElastAlert to sign the requests to Elasticsearch. It's the AWS region where you want to operate.
-- ``boto_profile``: with the name of the boto profile to use to sign the requests.
+Typically, you'll deploy ElastAlert on a running EC2 instance on AWS. You can
+assign a role  to this instance that gives it permissions to read from and write
+to the Elasticsearch service. When using an Instance Profile, you will need to
+specify the ``aws_region`` in the configuration file or set the
+``AWS_DEFAULT_REGION`` environment variable.
+
+Using AWS profiles
+------------------
+
+You can also create a user with permissions on the Elasticsearch service and
+tell ElastAlert to authenticate itself using that user. First, create an AWS
+profile in the machine where you'd like to run ElastAlert for the user with
+permissions.
+
+You can use the environment variables ``AWS_DEFAULT_PROFILE`` and
+``AWS_DEFAULT_REGION`` or add two options to the configuration file:
+- ``aws_region``: The AWS region where you want to operate.
+- ``profile``: The name of the AWS profile to use to sign the requests.

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -245,7 +245,7 @@ es_url_prefix
 ``es_url_prefix``: URL prefix for the Elasticsearch endpoint. (Optional, string, no default)
 
 es_send_get_body_as
-^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^
 
 ``es_send_get_body_as``: Method for querying Elasticsearch. (Optional, string, default "GET")
 
@@ -361,12 +361,12 @@ query_delay
 This is useful if the data is Elasticsearch doesn't get indexed immediately. (Optional, time)
 
 owner
-^^^^^^^^^^^
+^^^^^
 
 ``owner``: This value will be used to identify the stakeholder of the alert. Optionally, this field can be included in any alert type. (Optional, string)
 
 priority
-^^^^^^^^^^^
+^^^^^^^^
 
 ``priority``: This value will be used to identify the relative priority of the alert. Optionally, this field can be included in any alert type (e.g. for use in email subject/body text). (Optional, int, default 2)
 
@@ -505,7 +505,7 @@ aggregation_key
 ``aggregation_key``: Having an aggregation key in conjunction with an aggregation will make it so that each new value encountered for the aggregation_key field will result in a new, separate aggregation window.
 
 summary_table_fields
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^
 
 ``summary_table_fields``: Specifying the summmary_table_fields in conjunction with an aggregation will make it so that each aggregated alert will contain a table summarizing the values for the specified fields in all the matches that were aggregated together.
 
@@ -539,7 +539,7 @@ Some rules and alerts require additional options, which also go in the top level
 .. _testing :
 
 Testing Your Rule
-====================
+=================
 
 Once you've written a rule configuration, you will want to validate it. To do so, you can either run ElastAlert in debug mode,
 or use ``elastalert-test-rule``, which is a script that makes various aspects of testing easier.
@@ -636,7 +636,7 @@ guaranteed to have the exact same results as with Elasticsearch. For example, an
 .. _ruletypes:
 
 Rule Types
-===========
+==========
 
 The various ``RuleType`` classes, defined in ``elastalert/ruletypes.py``, form the main logic behind ElastAlert. An instance
 is held in memory for each rule, passed all of the data returned by querying Elasticsearch with a given filter, and generates
@@ -734,7 +734,7 @@ all with the same value of ``query_key``, will trigger an alert.
 the 3rd event will trigger the alert on itself and add the other 2 events in a key named ``related_events`` that can be accessed in the alerter.
 
 Spike
-~~~~~~
+~~~~~
 
 ``spike``: This rule matches when the volume of events during a given time period is ``spike_height`` times larger or smaller
 than during the previous time period. It uses two sliding windows to compare the current and reference frequency
@@ -921,7 +921,7 @@ than regular searching if there is a large number of documents. If this is used,
 that if a new term appears but there are at least 50 terms which appear more frequently, it will not be found.
 
 Cardinality
-~~~~~~~~
+~~~~~~~~~~~
 
 ``cardinality``: This rule matches when a the total number of unique values for a certain field within a time frame is higher or lower
 than a threshold.
@@ -946,7 +946,7 @@ Optional:
 ``query_key``: Group cardinality counts by this field. For each unique value of the ``query_key`` field, cardinality will be counted separately.
 
 Metric Aggregation
-~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 ``metric_aggregation``: This rule matches when the value of a metric within the calculation window is higher or lower than a threshold. By 
 default this is ``buffer_time``.
@@ -992,7 +992,7 @@ See: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggr
 more comprehensive explaination.
 
 Percentage Match
-~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 ``percentage_match``: This rule matches when the percentage of document in the match bucket within a calculation window is higher or lower 
 than a threshold. By default the calculation window is ``buffer_time``.
@@ -1026,7 +1026,7 @@ evaluated separately against the threshold(s).
 .. _alerts:
 
 Alerts
-========
+======
 
 Each rule may have any number of alerts attached to it. Alerts are subclasses of ``Alerter`` and are passed
 a dictionary, or list of dictionaries, from ElastAlert which contain relevant information. They are configured
@@ -1064,7 +1064,7 @@ In case the rule matches multiple objects in the index, only the first match is 
 If the field(s) mentioned in the arguments list are missing, the email alert will have the text ``<MISSING VALUE>`` in place of its expected value. This will also occur if ``use_count_query`` is set to true.
 
 Alert Content
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 There are several ways to format the body text of the various types of events. In EBNF::
 
@@ -1202,7 +1202,7 @@ by the smtp server.
 ``bcc``: This adds the BCC emails to the list of recipients but does not show up in the email message. By default, this is left empty.
 
 Jira
-~~~~~
+~~~~
 
 The JIRA alerter will open a ticket on jira whenever an alert is triggered. You must have a service account for ElastAlert to connect with.
 The credentials of the service account are loaded from a separate file. The ticket number will be written to the alert pipeline, and if it
@@ -1318,9 +1318,9 @@ Optional:
 SNS
 ~~~
 
-The SNS alerter will send an SNS notification. The body of the notification is formatted the same as with other alerters. The SNS alerter
-uses boto and can use credentials in the rule yaml or in a standard boto credential file.
-See http://boto.readthedocs.org/en/latest/boto_config_tut.html#details for details.
+The SNS alerter will send an SNS notification. The body of the notification is formatted the same as with other alerters.
+The SNS alerter uses boto3 and can use credentials in the rule yaml, in a standard AWS credential and config files, or
+via environment variables. See http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html for details.
 
 SNS requires one option:
 
@@ -1334,7 +1334,7 @@ Optional:
 
 ``aws_region``: The AWS region in which the SNS resource is located. Default is us-east-1
 
-``boto_profile``: The boto profile to use. If none specified, the default will be used.
+``profile``: The AWS profile to use. If none specified, the default will be used.
 
 HipChat
 ~~~~~~~
@@ -1395,7 +1395,7 @@ Provide absolute address of the pciture, for example: http://some.address.com/im
 ``slack_proxy``: By default ElastAlert will not use a network proxy to send notifications to Slack. Set this option using ``hostname:port`` if you need to use a proxy.
 
 Telegram
-~~~~~
+~~~~~~~~
 Telegram alerter will send a notification to a predefined Telegram username or channel. The body of the notification is formatted the same as with other alerters.
 
 The alerter requires the following two options:
@@ -1500,7 +1500,7 @@ Optional:
 ``gitter_proxy``: By default ElastAlert will not use a network proxy to send notifications to Gitter. Set this option using ``hostname:port`` if you need to use a proxy.
 
 ServiceNow
-~~~~~~
+~~~~~~~~~~
 
 The ServiceNow alerter will create a ne Incident in ServiceNow. The body of the notification is formatted the same as with other alerters.
 
@@ -1533,7 +1533,7 @@ Optional:
 
 
 Debug
-~~~~~~
+~~~~~
 
 The debug alerter will log the alert information using the Python logger at the info level. It is logged into a Python Logger object with the name ``elastalert`` that can be easily accessed using the ``getLogger`` command.
 

--- a/docs/source/running_elastalert.rst
+++ b/docs/source/running_elastalert.rst
@@ -106,7 +106,7 @@ Each rule defines a query to perform, parameters on what triggers a match, and a
 
 ``type``: Each rule has a different type which may take different parameters. The ``frequency`` type means "Alert when more than ``num_events`` occur within ``timeframe``." For information other types, see :ref:`Rule types <ruletypes>`.
 
-``index``: The name of the index(es) to query. If you are using Logstash, by default the indexes will match "logstash-*".
+``index``: The name of the index(es) to query. If you are using Logstash, by default the indexes will match ``"logstash-*"``.
 
 ``num_events``: This parameter is specific to ``frequency`` type and is the threshold for when an alert is triggered.
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -14,7 +14,7 @@ from smtplib import SMTPAuthenticationError
 from smtplib import SMTPException
 from socket import error
 
-import boto.sns as sns
+import boto3
 import requests
 import stomp
 from exotel import Exotel
@@ -805,10 +805,11 @@ class SnsAlerter(Alerter):
     def __init__(self, *args):
         super(SnsAlerter, self).__init__(*args)
         self.sns_topic_arn = self.rule.get('sns_topic_arn', '')
-        self.aws_access_key = self.rule.get('aws_access_key', '')
-        self.aws_secret_key = self.rule.get('aws_secret_key', '')
+        self.aws_access_key_id = self.rule.get('aws_access_key_id')
+        self.aws_secret_access_key = self.rule.get('aws_secret_access_key')
         self.aws_region = self.rule.get('aws_region', 'us-east-1')
-        self.boto_profile = self.rule.get('boto_profile', '')
+        self.profile = self.rule.get('boto_profile', None)  # Deprecated
+        self.profile = self.rule.get('aws_profile', None)
 
     def create_default_title(self, matches):
         subject = 'ElastAlert: %s' % (self.rule['name'])
@@ -817,18 +818,13 @@ class SnsAlerter(Alerter):
     def alert(self, matches):
         body = self.create_alert_body(matches)
 
-        # use aws_access_key and aws_secret_key if specified; then use boto profile if specified;
-        # otherwise use instance role
-        if not self.aws_access_key and not self.aws_secret_key:
-            if not self.boto_profile:
-                sns_client = sns.connect_to_region(self.aws_region)
-            else:
-                sns_client = sns.connect_to_region(self.aws_region,
-                                                   profile_name=self.boto_profile)
-        else:
-            sns_client = sns.connect_to_region(self.aws_region,
-                                               aws_access_key_id=self.aws_access_key,
-                                               aws_secret_access_key=self.aws_secret_key)
+        session = boto3.Session(
+            aws_access_key_id=self.aws_access_key_id,
+            aws_secret_access_key=self.aws_secret_access_key,
+            region_name=self.aws_region,
+            profile_name=self.profile
+        )
+        sns_client = session.client('sns')
         sns_client.publish(self.sns_topic_arn, body, subject=self.create_title(matches))
         elastalert_logger.info("Sent sns notification to %s" % (self.sns_topic_arn))
 

--- a/elastalert/auth.py
+++ b/elastalert/auth.py
@@ -1,49 +1,29 @@
 # -*- coding: utf-8 -*-
-import os
-import configparser
-
+import boto3
 from aws_requests_auth.aws_auth import AWSRequestsAuth
-
-from botocore.credentials import InstanceMetadataProvider, InstanceMetadataFetcher
 
 
 class Auth(object):
 
-    def __call__(self, host, username, password, aws_region, boto_profile):
-        """ Return the authorization header. If 'boto_profile' is passed, it'll be used. Otherwise it'll sign requests
-        with instance role.
+    def __call__(self, host, username, password, aws_region, profile_name):
+        """ Return the authorization header.
 
         :param host: Elasticsearch host.
         :param username: Username used for authenticating the requests to Elasticsearch.
         :param password: Password used for authenticating the requests to Elasticsearch.
         :param aws_region: AWS Region to use. Only required when signing requests.
-        :param boto_profile: Boto profile to use for connecting. Only required when signing requests.
+        :param profile_name: AWS profile to use for connecting. Only required when signing requests.
         """
         if username and password:
             return username + ':' + password
 
-        if not aws_region:
-            return None
+        session = boto3.session.Session(profile_name=profile_name, region_name=aws_region)
+        credentials = session.get_credentials().get_frozen_credentials()
 
-        if boto_profile:
-            # Executing ElastAlert from machine with aws credentials
-            config = configparser.ConfigParser()
-            config.read(os.path.expanduser('~') + '/.aws/credentials')
-            aws_access_key_id = str(config[boto_profile]['aws_access_key_id'])
-            aws_secret_access_key = str(config[boto_profile]['aws_secret_access_key'])
-            aws_token = None
-        else:
-            # Executing ElastAlert from machine deployed with specific role
-            provider = InstanceMetadataProvider(
-                iam_role_fetcher=InstanceMetadataFetcher(timeout=1000, num_attempts=2))
-            aws_credentials = provider.load()
-            aws_access_key_id = str(aws_credentials.access_key)
-            aws_secret_access_key = str(aws_credentials.secret_key)
-            aws_token = str(aws_credentials.token)
-
-        return AWSRequestsAuth(aws_access_key=aws_access_key_id,
-                               aws_secret_access_key=aws_secret_access_key,
-                               aws_token=aws_token,
-                               aws_host=host,
-                               aws_region=aws_region,
-                               aws_service='es')
+        return AWSRequestsAuth(
+            aws_access_key=credentials.access_key,
+            aws_secret_access_key=credentials.secret_key,
+            aws_token=credentials.token,
+            aws_host=host,
+            aws_region=session.region_name,
+            aws_service='es')

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -28,8 +28,9 @@ def main():
     parser.add_argument('--index', help='Index name to create')
     parser.add_argument('--old-index', help='Old index name to copy')
     parser.add_argument('--send_get_body_as', default='GET', help='Method for querying Elasticsearch - POST, GET or source')
-    parser.add_argument('--boto-profile', default=None, help='Boto profile to use for signing requests')
-    parser.add_argument('--aws-region', default=None, help='AWS Region to use for signing requests')
+    parser.add_argument('--boto-profile', default=None, dest='profile', help='DEPRECATED: (use --profile) Boto profile to use for signing requests')
+    parser.add_argument('--profile', default=None, help='AWS profile to use for signing requests. Optionally use the AWS_DEFAULT_PROFILE environment variable')
+    parser.add_argument('--aws-region', default=None, help='AWS Region to use for signing requests. Optionally use the AWS_DEFAULT_REGION environment variable')
     parser.add_argument('--timeout', default=60, help='Elasticsearch request timeout')
     parser.add_argument('--config', default='config.yaml', help='Global config file (default: config.yaml)')
     args = parser.parse_args()
@@ -79,7 +80,7 @@ def main():
                      username=username,
                      password=password,
                      aws_region=aws_region,
-                     boto_profile=args.boto_profile)
+                     profile_name=args.profile)
 
     es = Elasticsearch(
         host=host,

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -279,7 +279,7 @@ def elasticsearch_client(conf):
                                      username=es_conn_conf['es_username'],
                                      password=es_conn_conf['es_password'],
                                      aws_region=es_conn_conf['aws_region'],
-                                     boto_profile=es_conn_conf['boto_profile'])
+                                     profile_name=es_conn_conf['profile'])
 
     return Elasticsearch(host=es_conn_conf['es_host'],
                          port=es_conn_conf['es_port'],
@@ -304,7 +304,7 @@ def build_es_conn_config(conf):
     parsed_conf['es_username'] = None
     parsed_conf['es_password'] = None
     parsed_conf['aws_region'] = None
-    parsed_conf['boto_profile'] = None
+    parsed_conf['profile'] = None
     parsed_conf['es_host'] = conf['es_host']
     parsed_conf['es_port'] = conf['es_port']
     parsed_conf['es_url_prefix'] = ''
@@ -318,8 +318,13 @@ def build_es_conn_config(conf):
     if 'aws_region' in conf:
         parsed_conf['aws_region'] = conf['aws_region']
 
+    # Deprecated
     if 'boto_profile' in conf:
-        parsed_conf['boto_profile'] = conf['boto_profile']
+        logging.warning('Found deprecated "boto_profile", use "profile" instead!')
+        parsed_conf['profile'] = conf['boto_profile']
+
+    if 'profile' in conf:
+        parsed_conf['profile'] = conf['profile']
 
     if 'use_ssl' in conf:
         parsed_conf['use_ssl'] = conf['use_ssl']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 argparse==1.3.0
 aws-requests-auth==0.2.5
 blist==1.3.6
-boto==2.34.0
-botocore==1.4.5
+boto3
 configparser>=3.3.0r2
 croniter==0.3.8
 elasticsearch

--- a/setup.py
+++ b/setup.py
@@ -31,15 +31,14 @@ setup(
         'PyStaticConfiguration',
         'pyyaml',
         'simplejson',
-        'boto',
-        'botocore',
+        'boto3',
         'blist',
         'croniter',
         'configparser',
         'aws-requests-auth',
         'texttable',
         'exotel',
-        'twilio',
+        'twilio<6.0.0',
         'stomp.py'
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ envdir = virtualenv_run
 commands =
 
 [pytest]
-norecursedirs = .* virtualenv_run docs build
+norecursedirs = .* virtualenv_run docs build venv env
 
 [testenv:docs]
 deps = {[testenv]deps}
@@ -32,7 +32,7 @@ commands = sphinx-build -b html -d build/doctrees source build/html
 [flake8]
 # ignore certain violations
 # E501 - long lines
-exclude = .git,__pycache__,.tox,docs,virtualenv_run,modules
+exclude = .git,__pycache__,.tox,docs,virtualenv_run,modules,venv,env
 ignore = E501
 max-line-length = 140
 


### PR DESCRIPTION
* Adds support for AWS environment variables (key pairs, profile, and
region)
* Keeps support for `boto_profile`, but marked as deprecated
* Fixed sphinx doc warnings
* Added aws config example
* Updated documentation for `boto_profile` —> `profile`
* uses boto3 instead of boto

Fixes #981 