### PR TITLE
Added wrapper for AWS request signing

### DIFF
--- a/elastalert/auth.py
+++ b/elastalert/auth.py
@@ -1,6 +1,39 @@
 # -*- coding: utf-8 -*-
+import os
 import boto3
 from aws_requests_auth.aws_auth import AWSRequestsAuth
+
+
+class RefeshableAWSRequestsAuth(AWSRequestsAuth):
+    """
+    A class ensuring that AWS request signing uses a refreshed credential
+    """
+
+    def __init__(self,
+                 refreshable_credential,
+                 aws_host,
+                 aws_region,
+                 aws_service):
+        """
+        :param refreshable_credential: A credential class that refreshes STS or IAM Instance Profile credentials
+        :type refreshable_credential: :class:`botocore.credentials.RefreshableCredentials`
+        """
+        self.refreshable_credential = refreshable_credential
+        self.aws_host = aws_host
+        self.aws_region = aws_region
+        self.service = aws_service
+
+    @property
+    def aws_access_key(self):
+        return self.refreshable_credential.access_key
+
+    @property
+    def aws_secret_access_key(self):
+        return self.refreshable_credential.secret_key
+
+    @property
+    def aws_token(self):
+        return self.refreshable_credential.token
 
 
 class Auth(object):
@@ -17,13 +50,13 @@ class Auth(object):
         if username and password:
             return username + ':' + password
 
-        session = boto3.session.Session(profile_name=profile_name, region_name=aws_region)
-        credentials = session.get_credentials()
+        if not aws_region and not os.environ.get('AWS_DEFAULT_REGION'):
+            return None
 
-        return AWSRequestsAuth(
-            aws_access_key=credentials.access_key,
-            aws_secret_access_key=credentials.secret_key,
-            aws_token=credentials.token,
+        session = boto3.session.Session(profile_name=profile_name, region_name=aws_region)
+
+        return RefeshableAWSRequestsAuth(
+            refreshable_credential=session.get_credentials(),
             aws_host=host,
             aws_region=session.region_name,
             aws_service='es')

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from elastalert.auth import Auth, RefeshableAWSRequestsAuth
+
+
+def test_auth_none():
+
+    auth = Auth()(
+        host='localhost:8080',
+        username=None,
+        password=None,
+        aws_region=None,
+        profile_name=None
+    )
+
+    assert not auth
+
+
+def test_auth_username_password():
+
+    auth = Auth()(
+        host='localhost:8080',
+        username='user',
+        password='password',
+        aws_region=None,
+        profile_name=None
+    )
+
+    assert auth == 'user:password'
+
+
+def test_auth_aws_region():
+
+    auth = Auth()(
+        host='localhost:8080',
+        username=None,
+        password=None,
+        aws_region='us-east-1',
+        profile_name=None
+    )
+
+    assert type(auth) == RefeshableAWSRequestsAuth
+    assert auth.aws_region == 'us-east-1'


### PR DESCRIPTION
* All aws requests signed will now call the refreshable credential and
get the correct acces_key, secret_key, and token. Before,
AWSRequestAuth was just being passed the value of the refreshable
credential, and thus was not refreshing.

Now every signed request will call the appropriate credential.

Fixes #983
Fixes #989