### PR TITLE
Use environment variables for configuration

### DIFF
--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -106,16 +106,18 @@ is set to true. Note that back filled data may not always trigger count based al
 ``es_host``: The host name of the Elasticsearch cluster where ElastAlert records metadata about its searches.
 When ElastAlert is started, it will query for information about the time that it was last run. This way,
 even if ElastAlert is stopped and restarted, it will never miss data or look at the same events twice. It will also specify the default cluster for each rule to run on.
+The environment variable ``ES_HOST`` will override this field.
 
-``es_port``: The port corresponding to ``es_host``.
+``es_port``: The port corresponding to ``es_host``. The environment variable ``ES_PORT`` will override this field.
 
 ``use_ssl``: Optional; whether or not to connect to ``es_host`` using TLS; set to ``True`` or ``False``.
+The environment variable ``ES_USE_SSL`` will override this field.
 
 ``verify_certs``: Optional; whether or not to verify TLS certificates; set to ``True`` or ``False``. The default is ``True``.
 
-``es_username``: Optional; basic-auth username for connecting to ``es_host``.
+``es_username``: Optional; basic-auth username for connecting to ``es_host``. The environment variable ``ES_USERNAME`` will override this field.
 
-``es_password``: Optional; basic-auth password for connecting to ``es_host``.
+``es_password``: Optional; basic-auth password for connecting to ``es_host``. The environment variable ``ES_PASSWORD`` will override this field.
 
 ``es_url_prefix``: Optional; URL prefix for the Elasticsearch endpoint.
 
@@ -167,10 +169,12 @@ unless overwritten in the rule config. The default is "localhost".
 ``email_reply_to``: This sets the Reply-To header in emails. The default is the recipient address.
 
 ``aws_region``: This makes ElastAlert to sign HTTP requests when using Amazon Elasticsearch Service. It'll use instance role keys to sign the requests.
+The environment variable ``AWS_DEFAULT_REGION`` will override this field.
 
 ``boto_profile``: Deprecated! Boto profile to use when signing requests to Amazon Elasticsearch Service, if you don't want to use the instance role keys.
 
 ``profile``: AWS profile to use when signing requests to Amazon Elasticsearch Service, if you don't want to use the instance role keys.
+The environment variable ``AWS_DEFAULT_PROFILE`` will override this field.
 
 ``replace_dots_in_field_names``: If ``True``, ElastAlert replaces any dots in field names with an underscore before writing documents to Elasticsearch.
 The default value is ``False``. Elasticsearch 2.0 - 2.3 does not support dots in field names.

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -178,11 +178,13 @@ es_host
 ^^^^^^^
 
 ``es_host``: The hostname of the Elasticsearch cluster the rule will use to query. (Required, string, no default)
+The environment variable ``ES_HOST`` will override this field.
 
 es_port
 ^^^^^^^
 
 ``es_port``: The port of the Elasticsearch cluster. (Required, number, no default)
+The environment variable ``ES_PORT`` will override this field.
 
 index
 ^^^^^
@@ -223,6 +225,7 @@ use_ssl
 ^^^^^^^
 
 ``use_ssl``: Whether or not to connect to ``es_host`` using TLS. (Optional, boolean, default False)
+The environment variable ``ES_USE_SSL`` will override this field.
 
 verify_certs
 ^^^^^^^^^^^^
@@ -232,12 +235,12 @@ verify_certs
 es_username
 ^^^^^^^^^^^
 
-``es_username``: basic-auth username for connecting to ``es_host``. (Optional, string, no default)
+``es_username``: basic-auth username for connecting to ``es_host``. (Optional, string, no default) The environment variable ``ES_USERNAME`` will override this field.
 
 es_password
 ^^^^^^^^^^^
 
-``es_password``: basic-auth password for connecting to ``es_host``. (Optional, string, no default)
+``es_password``: basic-auth password for connecting to ``es_host``. (Optional, string, no default) The environment variable ``ES_PASSWORD`` will override this field.
 
 es_url_prefix
 ^^^^^^^^^^^^^

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -17,11 +17,11 @@ from elasticsearch.client import IndicesClient
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--host', help='Elasticsearch host')
-    parser.add_argument('--port', type=int, help='Elasticsearch port')
+    parser.add_argument('--host', default=os.environ.get('ES_HOST', None), help='Elasticsearch host')
+    parser.add_argument('--port', default=os.environ.get('ES_PORT', None), type=int, help='Elasticsearch port')
     parser.add_argument('--url-prefix', help='Elasticsearch URL prefix')
     parser.add_argument('--no-auth', action='store_const', const=True, help='Suppress prompt for basic auth')
-    parser.add_argument('--ssl', action='store_true', default=None, help='Use TLS')
+    parser.add_argument('--ssl', action='store_true', default=os.environ.get('ES_USE_SSL', None), help='Use TLS')
     parser.add_argument('--no-ssl', dest='ssl', action='store_false', help='Do not use TLS')
     parser.add_argument('--verify-certs', action='store_true', default=None, help='Verify TLS certificates')
     parser.add_argument('--no-verify-certs', dest='verify_certs', action='store_false', help='Do not verify TLS certificates')

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -637,7 +637,7 @@ class ElastAlerter():
         run_start = time.time()
 
         self.current_es = elasticsearch_client(rule)
-        self.current_es_addr = (rule['es_host'], rule['es_port'])
+        self.current_es_addr = (self.current_es.host, self.current_es.port)
 
         # If there are pending aggregate matches, try processing them
         for x in range(len(rule['agg_matches'])):
@@ -1014,8 +1014,8 @@ class ElastAlerter():
         # Return dashboard URL
         kibana_url = rule.get('kibana_url')
         if not kibana_url:
-            kibana_url = 'http://%s:%s/_plugin/kibana/' % (rule['es_host'],
-                                                           rule['es_port'])
+            kibana_url = 'http://%s:%s/_plugin/kibana/' % (es.host,
+                                                           es.port)
         return kibana_url + '#/dashboard/temp/%s' % (res['_id'])
 
     def get_dashboard(self, rule, db_name):
@@ -1249,7 +1249,7 @@ class ElastAlerter():
 
             # Set current_es for top_count_keys query
             self.current_es = elasticsearch_client(rule)
-            self.current_es_addr = (rule['es_host'], rule['es_port'])
+            self.current_es_addr = (self.current_es.host, self.current_es.port)
 
             # Send the alert unless it's a future alert
             if ts_now() > ts_to_dt(alert_time):

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 import datetime
 import logging
 
@@ -298,22 +299,22 @@ def build_es_conn_config(conf):
     with properly initialized values for 'es_host', 'es_port', 'use_ssl' and 'http_auth' which
     will be a basicauth username:password formatted string """
     parsed_conf = {}
-    parsed_conf['use_ssl'] = False
+    parsed_conf['use_ssl'] = os.environ.get('ES_USE_SSL', False)
     parsed_conf['verify_certs'] = True
     parsed_conf['http_auth'] = None
     parsed_conf['es_username'] = None
     parsed_conf['es_password'] = None
     parsed_conf['aws_region'] = None
     parsed_conf['profile'] = None
-    parsed_conf['es_host'] = conf['es_host']
-    parsed_conf['es_port'] = conf['es_port']
+    parsed_conf['es_host'] = os.environ.get('ES_HOST', conf['es_host'])
+    parsed_conf['es_port'] = int(os.environ.get('ES_PORT', conf['es_port']))
     parsed_conf['es_url_prefix'] = ''
     parsed_conf['es_conn_timeout'] = conf.get('es_conn_timeout', 20)
     parsed_conf['send_get_body_as'] = conf.get('es_send_get_body_as', 'GET')
 
     if 'es_username' in conf:
-        parsed_conf['es_username'] = conf['es_username']
-        parsed_conf['es_password'] = conf['es_password']
+        parsed_conf['es_username'] = os.envion.get('ES_USERNAME', conf['es_username'])
+        parsed_conf['es_password'] = os.environ.get('ES_PASSWORD', conf['es_password'])
 
     if 'aws_region' in conf:
         parsed_conf['aws_region'] = conf['aws_region']

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -607,6 +607,8 @@ def test_kibana(ea):
         mock_create = mock.Mock(return_value={'_id': 'ABCDEFGH'})
         mock_es_inst = mock.Mock()
         mock_es_inst.index = mock_create
+        mock_es_inst.host = 'test.testing'
+        mock_es_inst.port = 12345
         mock_es.return_value = mock_es_inst
         link = ea.generate_kibana_db(rule, match)
 


### PR DESCRIPTION
The following environment variables are supported in the main configuration, and override any values specified in the configuration:
- `ES_HOST`
- `ES_PORT`
- `ES_USERNAME`
- `ES_PASSWORD`
- `ES_USE_SSL`

I chose to have environment variables override configuration values, so that schema enforcement of the configuration doesn't change. This should probably be reworked at some point, so that schema enforcement can happen _after_ interpreting environment variables.