### PR TITLE
Add jira request args to the exception message when JIRA ticket creation fails

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -706,7 +706,7 @@ class JiraAlerter(Alerter):
                         raise Exception("Exception encountered when trying to add '{0}' as a watcher. Does the user exist?\n{1}" .format(watcher, ex)), None, sys.exc_info()[2]
 
         except JIRAError as e:
-            raise EAException("Error creating JIRA ticket: %s" % (e))
+            raise EAException("Error creating JIRA ticket using jira_args (%s): %s" % (self.jira_args, e))
         elastalert_logger.info("Opened Jira ticket: %s" % (self.issue))
 
         if self.pipeline is not None:


### PR DESCRIPTION
There is a bunch of crazy heuristics going on with the JIRA alerter to dynamically try and figure out how to create custom fields, which could be done in a number of ways. If the heuristics are wrong, having the actual jira params passed to the jira client will help aide in debugging.