### PR TITLE
change filter:-query to filter:-query_string:

### DIFF
--- a/docs/source/recipes/writing_filters.rst
+++ b/docs/source/recipes/writing_filters.rst
@@ -28,17 +28,13 @@ The query_string type follows the Lucene query format and can be used for partia
 See http://lucene.apache.org/core/2_9_4/queryparsersyntax.html for more information::
 
     filter:
-    - query:
-        query_string:
+    - query_string:
           query: "username: bob"
-    - query:
-        query_string:
+    - query_string:
           query: "_type: login_logs"
-    - query:
-        query_string:
+    - query_string:
           query: "field: value OR otherfield: othervalue"
-    - query:
-        query_string:
+    - query_string:
            query: "this: that AND these: those"
 
 term


### PR DESCRIPTION
following documentation creates this error:
RequestError(400, u'parsing_exception', {u'status': 400, u'error': {u'line': 1, u'root_cause': [{u'reason': u'no [query] registered for [query]', u'type': u'parsing_exception', u'line': 1, u'col': 208}], u'type': u'parsing_exception', u'reason': u'no [query] registered for [query]', u'col': 208}})