### PR TITLE
rule names made unique so errors not thrown when running against default folder

### DIFF
--- a/example_rules/example_frequency.yaml
+++ b/example_rules/example_frequency.yaml
@@ -17,7 +17,7 @@
 
 # (Required)
 # Rule name, must be unique
-name: Example rule
+name: Example frequency rule
 
 # (Required)
 # Type of alert.

--- a/example_rules/example_new_term.yaml
+++ b/example_rules/example_new_term.yaml
@@ -18,7 +18,7 @@
 
 # (Required)
 # Rule name, must be unique
-name: Example rule
+name: Example new term rule
 
 # (Required)
 # Type of alert.

--- a/example_rules/example_opsgenie_frequency.yaml
+++ b/example_rules/example_opsgenie_frequency.yaml
@@ -2,11 +2,11 @@
 
 # (Optional)
 # Elasticsearch host
-es_host: localhost
+#es_host: localhost
 
 # (Optional)
 # Elasticsearch port
-es_port: 9200
+#es_port: 9200
 
 # (Required)
 # OpsGenie credentials

--- a/example_rules/example_percentage_match.yaml
+++ b/example_rules/example_percentage_match.yaml
@@ -1,8 +1,8 @@
 name: Example Percentage Match
 type: percentage_match
 
-es_host: localhost
-es_port: 9200
+#es_host: localhost
+#es_port: 9200
 
 index: logstash-http-request-*
 description: "95% of all http requests should be successful"

--- a/example_rules/example_single_metric_agg.yaml
+++ b/example_rules/example_single_metric_agg.yaml
@@ -1,8 +1,8 @@
 name: Metricbeat CPU Spike Rule
 type: metric_aggregation
 
-es_host: localhost
-es_port: 9200
+#es_host: localhost
+#es_port: 9200
 
 index: metricbeat-*
 


### PR DESCRIPTION
On a out-of-the-box installation, invoking:

python -m elastalert.elastalert

Caused the following error because the 'name' field of two rules files had the same value. 

elastalert.util.EAException: Error loading file example_rules/example_new_term.yaml: Duplicate rule named Example rule