### PR TITLE
Added support to configurable expr evaluation to refine the ts obtained using a custom format

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -534,12 +534,12 @@ timestamp_format_expr
 ^^^^^^^^^^^^^^^^^^^^^
 
 ``timestamp_format_expr``: In case Elasticsearch used custom date format for date type field, this option provides a way to adapt the
-value  obtained converting a datetime with ``timestamp_format``, when the format cannot match perfectly the format defined in Elastisearch.
-When set, this option is evaluated as a Python expression along with a globals dictionary containing the original datetime instance
+value obtained converting a datetime through ``timestamp_format``, when the format cannot match perfectly what defined in Elastisearch.
+When set, this option is evaluated as a Python expression along with a *globals* dictionary containing the original datetime instance
 named ``dt`` and the timestamp to be refined, named ``ts``. The returned value becomes the timestamp obtained from the datetime.
 For example, when the date type field in Elasticsearch uses milliseconds (``yyyy-MM-dd'T'HH:mm:ss.SSS'Z'``) and ``timestamp_format``
-option is ``'%Y-%m-%dT%H:%M:%S.%fZ'``, Elasticsearch would fail to parse query terms as they contain microsecond values, that is
-6 digits instead of 3, since the ``%f`` placeholder stands for microseconds in Python timetamp format.
+option is ``'%Y-%m-%dT%H:%M:%S.%fZ'``, Elasticsearch would fail to parse query terms as they contain microsecond values - that is
+it gets 6 digits instead of 3 - since the ``%f`` placeholder stands for microseconds for Python *strftime* method calls.
 Setting ``timestamp_format_expr: 'ts[:23] + ts[26:]'`` will truncate the value to milliseconds granting Elasticsearch compatibility.
 This option is only valid if ``timestamp_type`` set to ``custom``.
 (Optional, string, no default).

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -94,6 +94,8 @@ Rule Configuration Cheat Sheet
 +--------------------------------------------------------------+           |
 | ``timestamp_format`` (string, default "%Y-%m-%dT%H:%M:%SZ")  |           |
 +--------------------------------------------------------------+           |
+| ``timestamp_format_expr`` (string, no default )              |           |
++--------------------------------------------------------------+           |
 | ``_source_enabled`` (boolean, default True)                  |           |
 +--------------------------------------------------------------+           |
 | ``alert_text_args`` (array of strs)                          |           |
@@ -527,6 +529,20 @@ timestamp_format
 ``timestamp_format``: In case Elasticsearch used custom date format for date type field, this option provides a way to define custom timestamp
 format to match the type used for Elastisearch date type field. This option is only valid if ``timestamp_type`` set to ``custom``.
 (Optional, string, default '%Y-%m-%dT%H:%M:%SZ').
+
+timestamp_format_expr
+^^^^^^^^^^^^^^^^^^^^^
+
+``timestamp_format_expr``: In case Elasticsearch used custom date format for date type field, this option provides a way to adapt the
+value  obtained converting a datetime with ``timestamp_format``, when the format cannot match perfectly the format defined in Elastisearch.
+When set, this option is evaluated as a Python expression along with a globals dictionary containing the original datetime instance
+named ``dt`` and the timestamp to be refined, named ``ts``. The returned value becomes the timestamp obtained from the datetime.
+For example, when the date type field in Elasticsearch uses milliseconds (``yyyy-MM-dd'T'HH:mm:ss.SSS'Z'``) and ``timestamp_format``
+option is ``'%Y-%m-%dT%H:%M:%S.%fZ'``, Elasticsearch would fail to parse query terms as they contain microsecond values, that is
+6 digits instead of 3, since the ``%f`` placeholder stands for microseconds in Python timetamp format.
+Setting ``timestamp_format_expr: 'ts[:23] + ts[26:]'`` will truncate the value to milliseconds granting Elasticsearch compatibility.
+This option is only valid if ``timestamp_type`` set to ``custom``.
+(Optional, string, no default).
 
 _source_enabled
 ^^^^^^^^^^^^^^^

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -199,7 +199,12 @@ def load_options(rule, conf, filename, args=None):
             return ts_to_dt_with_format(ts, ts_format=rule['timestamp_format'])
 
         def _dt_to_ts_with_format(dt):
-            return dt_to_ts_with_format(dt, ts_format=rule['timestamp_format'])
+            ts = dt_to_ts_with_format(dt, ts_format=rule['timestamp_format'])
+            if 'timestamp_format_expr' in rule:
+                # eval expression passing 'ts' and 'dt'
+                return eval(rule['timestamp_format_expr'], {'ts':ts, 'dt':dt})
+            else:
+                return ts
 
         rule['ts_to_dt'] = _ts_to_dt_with_format
         rule['dt_to_ts'] = _dt_to_ts_with_format

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -202,7 +202,7 @@ def load_options(rule, conf, filename, args=None):
             ts = dt_to_ts_with_format(dt, ts_format=rule['timestamp_format'])
             if 'timestamp_format_expr' in rule:
                 # eval expression passing 'ts' and 'dt'
-                return eval(rule['timestamp_format_expr'], {'ts':ts, 'dt':dt})
+                return eval(rule['timestamp_format_expr'], {'ts': ts, 'dt': dt})
             else:
                 return ts
 


### PR DESCRIPTION
I have datetime values in ES formatted with milliseconds: similar to issue #616 but further complicated by the _Zulu_ timezone identifier ('Z' fixed char) after millis (i.e. _2017-04-16T06:32:55.776Z_).
This is a problem because - as far as I know - in python there's no easy way to specify a datetime format with millis precision (it has microsecond precision).

So I've added to elastalert config the support for an optional python expression to be evaluated in order to refine the timestamp obtained from `timestamp_format`.

The expression obtained by the `timestamp_format_expr` config entry, and is considered only when `timestamp_type` is `custom`.
When the expression is set, it gets evaluated with a namespace containing `ts` and `dt` as variables where: 
* `dt` is the datetime instance to convert
* `ts` is the timestamp obtained converting the datetime using `timestamp_format`
The evaluation result is returned.

So in my case I've set 
```
timestamp_type: custom
timestamp_format: '%Y-%m-%dT%H:%M:%S.%fZ'
timestamp_format_expr: 'ts[:23] + ts[26:]'
```