### PR TITLE
Fix an attributeerror on elasticsearch objects in some versions of th…

### DIFF
--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -393,7 +393,7 @@ def load_rules(args):
     conf = yaml_loader(filename)
     use_rule = args.rule
 
-    for env_var, conf_var in env_settings.values():
+    for env_var, conf_var in env_settings.items():
         if env_var in os.environ:
             conf[conf_var] = os.environ[env_var]
 

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -31,7 +31,11 @@ required_globals = frozenset(['run_every', 'rules_folder', 'es_host', 'es_port',
 required_locals = frozenset(['alert', 'type', 'name', 'index'])
 
 # Settings that can be derived from ENV variables
-env_settings = ('ES_USE_SSL', 'ES_PASSWORD', 'ES_USERNAME', 'ES_HOST', 'ES_PORT')
+env_settings = {'ES_USE_SSL': 'use_ssl',
+                'ES_PASSWORD': 'es_password',
+                'ES_USERNAME': 'es_username',
+                'ES_HOST': 'es_host',
+                'ES_PORT': 'es_port'}
 
 # Used to map the names of rules to their classes
 rules_mapping = {
@@ -389,9 +393,9 @@ def load_rules(args):
     conf = yaml_loader(filename)
     use_rule = args.rule
 
-    for env_var in env_settings:
+    for env_var, conf_var in env_settings.values():
         if env_var in os.environ:
-            conf[env_var.lower()] = os.environ[env_var]
+            conf[conf_var] = os.environ[env_var]
 
     # Make sure we have all required globals
     if required_globals - frozenset(conf.keys()):

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -30,6 +30,9 @@ rule_schema = jsonschema.Draft4Validator(yaml.load(open(os.path.join(os.path.dir
 required_globals = frozenset(['run_every', 'rules_folder', 'es_host', 'es_port', 'writeback_index', 'buffer_time'])
 required_locals = frozenset(['alert', 'type', 'name', 'index'])
 
+# Settings that can be derived from ENV variables
+env_settings = ('ES_USE_SSL', 'ES_PASSWORD', 'ES_USERNAME', 'ES_HOST', 'ES_PORT')
+
 # Used to map the names of rules to their classes
 rules_mapping = {
     'frequency': ruletypes.FrequencyRule,
@@ -385,6 +388,10 @@ def load_rules(args):
     filename = args.config
     conf = yaml_loader(filename)
     use_rule = args.rule
+
+    for env_var in env_settings:
+        if env_var in os.environ:
+            conf[env_var.lower()] = os.environ[env_var]
 
     # Make sure we have all required globals
     if required_globals - frozenset(conf.keys()):

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -640,7 +640,7 @@ class ElastAlerter():
         run_start = time.time()
 
         self.current_es = elasticsearch_client(rule)
-        self.current_es_addr = (self.current_es.host, self.current_es.port)
+        self.current_es_addr = (rule['es_host'], rule['es_port'])
 
         # If there are pending aggregate matches, try processing them
         for x in range(len(rule['agg_matches'])):
@@ -1018,8 +1018,8 @@ class ElastAlerter():
         # Return dashboard URL
         kibana_url = rule.get('kibana_url')
         if not kibana_url:
-            kibana_url = 'http://%s:%s/_plugin/kibana/' % (es.host,
-                                                           es.port)
+            kibana_url = 'http://%s:%s/_plugin/kibana/' % (rule['es_host'],
+                                                           rule['es_port'])
         return kibana_url + '#/dashboard/temp/%s' % (res['_id'])
 
     def get_dashboard(self, rule, db_name):
@@ -1253,7 +1253,7 @@ class ElastAlerter():
 
             # Set current_es for top_count_keys query
             self.current_es = elasticsearch_client(rule)
-            self.current_es_addr = (self.current_es.host, self.current_es.port)
+            self.current_es_addr = (rule['es_host'], rule['es_port'])
 
             # Send the alert unless it's a future alert
             if ts_now() > ts_to_dt(alert_time):


### PR DESCRIPTION
Fixes an error occurring with older versions of elasticsearch library introduced in #1006
```
self.current_es_addr = (self.current_es.host, self.current_es.port)
AttributeError: 'Elasticsearch' object has no attribute 'host'
```

These settings are applied to the global config before schema check, which is then used for the default in rules.