### PR TITLE
Bump to the latest and greatest version of exotel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ configparser>=3.3.0r2
 croniter==0.3.8
 cryptography==1.4
 elasticsearch
-exotel==0.1.1
+exotel==0.1.4
 jira==0.32
 jsonschema==2.2.0
 mock==1.0.0


### PR DESCRIPTION
Fixes #1023

Looking into [the differences between the two named versions of exotel](https://github.com/sarathsp06/exotel-py/compare/v0.1.1...0.1.4#diff-8ac6a8d81969d13add45696f1bfc73c8R44), it's mostly project and doc changes, with one backwards compatible change to the codebase itself.

Tried running this branch within a Docker container or two, and managed to eliminate errors that I could reproduce previously regarding `requests` conflicts