### PR TITLE
Fix default type for composite keys

### DIFF
--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -4,6 +4,7 @@ import datetime
 import hashlib
 import logging
 import os
+import sys
 
 import alerts
 import enhancements
@@ -313,7 +314,7 @@ def load_modules(rule, args=None):
     try:
         rule['type'] = rule['type'](rule, args)
     except (KeyError, EAException) as e:
-        raise EAException('Error initializing rule %s: %s' % (rule['name'], e))
+        raise EAException('Error initializing rule %s: %s' % (rule['name'], e)), None, sys.exc_info[2]
     # Instantiate alert
     rule['alert'] = load_alerts(rule, alert_field=rule['alert'])
 

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -630,7 +630,10 @@ class NewTermsRule(RuleType):
                         keys = [bucket['key'] for bucket in buckets]
                         self.seen_values[field] += keys
                 else:
-                    self.seen_values.setdefault(field, [])
+                    if type(field) == list:
+                        self.seen_values.setdefault(tuple(field), [])
+                    else:
+                        self.seen_values.setdefault(field, [])
                 if tmp_start == tmp_end:
                     break
                 tmp_start = tmp_end

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import copy
 import datetime
+import sys
 
 from blist import sortedlist
 from util import add_raw_postfix
@@ -573,7 +574,7 @@ class NewTermsRule(RuleType):
             self.get_all_terms(args)
         except Exception as e:
             # Refuse to start if we cannot get existing terms
-            raise EAException('Error searching for existing terms: %s' % (repr(e)))
+            raise EAException('Error searching for existing terms: %s' % (repr(e))), None, sys.exc_info[2]
 
     def get_all_terms(self, args):
         """ Performs a terms aggregation for each field to get every existing term. """


### PR DESCRIPTION
This fixes the `TypeError("unhashable type: 'list'",)` error that can happen when using a composite key in the `new_rule` AND there were no existing matches.

Additionally, this bug was difficult to triage because the original stack trace was being lost. I fixed this particular execution path to propagate the original stack trace. There are many more places that this can/should be done, but I've ticketed that as [1085](https://github.com/Yelp/elastalert/issues/1085)