### PR TITLE
Changed the default ordering of alerts

### DIFF
--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -372,7 +372,7 @@ def load_alerts(rule, alert_field):
             alert_field = [alert_field]
 
         alert_field = [normalize_config(x) for x in alert_field]
-        alert_field = sorted(alert_field, key=lambda (a, b): alerts_order.get(a, -1))
+        alert_field = sorted(alert_field, key=lambda (a, b): alerts_order.get(a, 1))
         # Convert all alerts into Alerter objects
         alert_field = [create_alert(a, b) for a, b in alert_field]
 


### PR DESCRIPTION
This will make alerters default to going to the end versus the beginning. We set default for jira and email:
```
alerts_order = {
    'jira': 0,
    'email': 1
}
```
And this will make sure that jira (which uses the pipeline) will always come before something unless it explicitly has -1.