### PR TITLE
Fix spike rules with alert_on_new_data and query_key

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -393,7 +393,6 @@ class SpikeRule(RuleType):
 
     def clear_windows(self, qk, event):
         # Reset the state and prevent alerts until windows filled again
-        self.cur_windows[qk].clear()
         self.ref_windows[qk].clear()
         self.first_event.pop(qk)
         self.skip_checks[qk] = event[self.ts_field] + self.rules['timeframe'] * 2

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -404,6 +404,58 @@ def test_spike_terms():
     assert rule.matches[0]['username'] == 'userD'
 
 
+def test_spike_terms_query_key_alert_on_new_data():
+    rules = {'spike_height': 1.5,
+             'timeframe': datetime.timedelta(minutes=10),
+             'spike_type': 'both',
+             'use_count_query': False,
+             'timestamp_field': 'ts',
+             'query_key': 'username',
+             'use_term_query': True,
+             'alert_on_new_data': True}
+
+    terms1 = {ts_to_dt('2014-01-01T00:01:00Z'): [{'key': 'userA', 'doc_count': 10}]}
+    terms2 = {ts_to_dt('2014-01-01T00:06:00Z'): [{'key': 'userA', 'doc_count': 10}]}
+    terms3 = {ts_to_dt('2014-01-01T00:11:00Z'): [{'key': 'userA', 'doc_count': 10}]}
+    terms4 = {ts_to_dt('2014-01-01T00:21:00Z'): [{'key': 'userA', 'doc_count': 20}]}
+    terms5 = {ts_to_dt('2014-01-01T00:26:00Z'): [{'key': 'userA', 'doc_count': 20}]}
+    terms6 = {ts_to_dt('2014-01-01T00:31:00Z'): [{'key': 'userA', 'doc_count': 20}]}
+    terms7 = {ts_to_dt('2014-01-01T00:36:00Z'): [{'key': 'userA', 'doc_count': 20}]}
+    terms8 = {ts_to_dt('2014-01-01T00:41:00Z'): [{'key': 'userA', 'doc_count': 20}]}
+
+    rule = SpikeRule(rules)
+
+    # Initial input
+    rule.add_terms_data(terms1)
+    assert len(rule.matches) == 0
+
+    # No spike for UserA because windows not filled
+    rule.add_terms_data(terms2)
+    assert len(rule.matches) == 0
+
+    rule.add_terms_data(terms3)
+    assert len(rule.matches) == 0
+
+    rule.add_terms_data(terms4)
+    assert len(rule.matches) == 0
+
+    # Spike
+    rule.add_terms_data(terms5)
+    assert len(rule.matches) == 1
+
+    rule.matches[:] = []
+
+    # There will be no more spikes since all terms have the same doc_count
+    rule.add_terms_data(terms6)
+    assert len(rule.matches) == 0
+
+    rule.add_terms_data(terms7)
+    assert len(rule.matches) == 0
+
+    rule.add_terms_data(terms8)
+    assert len(rule.matches) == 0
+
+
 def test_blacklist():
     events = [{'@timestamp': ts_to_dt('2014-09-26T12:34:56Z'), 'term': 'good'},
               {'@timestamp': ts_to_dt('2014-09-26T12:34:57Z'), 'term': 'bad'},


### PR DESCRIPTION
Fix false alerting on terms that have the same query key that previously matched
terms with enabled alert_on_new_data.

Changed windows moving algorithm. Do not clean current window for query key on
matched terms.
This change would also help to handle spike that was occurred right after the
previous one.