### PR TITLE
Fix crash on start if connection error

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -936,8 +936,9 @@ class ElastAlerter():
                         break
 
                 # Initialize the rule that matches rule_file
+                new_rule = self.init_rule(new_rule, False)
                 self.rules = [rule for rule in self.rules if rule['rule_file'] != rule_file]
-                if self.init_rule(new_rule, False):
+                if new_rule:
                     self.rules.append(new_rule)
 
         # Load new rules

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -93,7 +93,7 @@ def test_query(ea):
     ea.current_es.search.assert_called_with(body={
         'query': {'filtered': {'filter': {'bool': {'must': [{'range': {'@timestamp': {'lte': END_TIMESTAMP, 'gt': START_TIMESTAMP}}}]}}}},
         'sort': [{'@timestamp': {'order': 'asc'}}]}, index='idx', _source_include=['@timestamp'], ignore_unavailable=True,
-                                            size=ea.rules[0]['max_query_size'], scroll=ea.conf['scroll_keepalive'])
+        size=ea.rules[0]['max_query_size'], scroll=ea.conf['scroll_keepalive'])
 
 
 def test_query_with_fields(ea):
@@ -103,7 +103,7 @@ def test_query_with_fields(ea):
     ea.current_es.search.assert_called_with(body={
         'query': {'filtered': {'filter': {'bool': {'must': [{'range': {'@timestamp': {'lte': END_TIMESTAMP, 'gt': START_TIMESTAMP}}}]}}}},
         'sort': [{'@timestamp': {'order': 'asc'}}], 'fields': ['@timestamp']}, index='idx', ignore_unavailable=True,
-                                            size=ea.rules[0]['max_query_size'], scroll=ea.conf['scroll_keepalive'])
+        size=ea.rules[0]['max_query_size'], scroll=ea.conf['scroll_keepalive'])
 
 
 def test_query_with_unix(ea):
@@ -1061,8 +1061,8 @@ def test_uncaught_exceptions(ea):
     assert len(ea.disabled_rules) == 1
 
     # Changing the file should re-enable it
-    ea.rule_hashes = {'rule1': 'abc'}
-    new_hashes = {'rule1': 'def'}
+    ea.rule_hashes = {'blah.yaml': 'abc'}
+    new_hashes = {'blah.yaml': 'def'}
     with mock.patch('elastalert.elastalert.get_rule_hashes') as mock_hashes:
         with mock.patch('elastalert.elastalert.load_configuration') as mock_load:
             mock_load.side_effect = [ea.disabled_rules[0]]


### PR DESCRIPTION
If there was an error when trying to get the Elasticsearch version for a given rule on startup, it would go uncaught and crash elastalert. Changes to fix this:

1. Move initial modify_rule_for_es5 and top_count_keys stuff into init_rule
2. Try/except around modify_rule_for_es5 with notification email
3. init_rule can return False on error
4. Modify places where init_rule is called to accept False as a failure
5. Removed a warning that previously should never have been hit, now is expected when a rule fails on startup and then was modified
6. Fixed a test that was mocking the rule_file (rule1 (name) -> blah.yaml (rule_file)) incorrectly and breaking on these changes