### PR TITLE
Add scheduler for rule execution

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -735,21 +735,22 @@ class ElastAlerter():
             self.set_starttime(rule, endtime)
 
         rule['original_starttime'] = rule['starttime']
-                  
+   
         # Check if scheduler is set and rule is okay with scheduler
         if 'scheduler' in rule:
             croniter._datetime_to_timestamp = cronite_datetime_to_timestamp  # For Python 2.6 compatibility
+            run_every_time = self.conf['run_every'] / 2
             try:
                 iter = croniter(rule['scheduler'], ts_now())
                 alert_time = unix_to_dt(iter.get_next())
             except Exception as e:
                 self.handle_error("Error parsing scheduler send time Cron format %s" % (e), rule['scheduler'])
-            
+
             # Don't run is not scheduled
-            if not alert_time - (self.conf['run_every'] / 2) <= ts_now() <= alert_time + (self.conf['run_every'] / 2) - datetime.timedelta(seconds=1):
+            if not alert_time - run_every_time <= ts_now() <= alert_time + run_every_time - datetime.timedelta(seconds=1):
                 elastalert_logger.info("Not scheduled time to run task, next time is at %s, sleeping instead" % (alert_time))
                 return 0
-                
+
         # Don't run if starttime was set to the future
         if ts_now() <= rule['starttime']:
             logging.warning("Attempted to use query start time in the future (%s), sleeping instead" % (starttime))

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -735,7 +735,7 @@ class ElastAlerter():
             self.set_starttime(rule, endtime)
 
         rule['original_starttime'] = rule['starttime']
-   
+
         # Check if scheduler is set and rule is okay with scheduler
         if 'scheduler' in rule:
             croniter._datetime_to_timestamp = cronite_datetime_to_timestamp  # For Python 2.6 compatibility

--- a/example_rules/example_scheduler_frequency.yaml
+++ b/example_rules/example_scheduler_frequency.yaml
@@ -1,0 +1,61 @@
+# Alert when the rate of events exceeds a threshold
+
+# (Optional)
+# Elasticsearch host
+# es_host: elasticsearch.example.com
+
+# (Optional)
+# Elasticsearch port
+# es_port: 14900
+
+# (OptionaL) Connect with SSL to Elasticsearch
+#use_ssl: True
+
+# (Optional) basic-auth username and password for Elasticsearch
+#es_username: someusername
+#es_password: somepassword
+
+# (Required)
+# Rule name, must be unique
+name: Example frequency rule with scheduler
+
+# (Required)
+# Type of alert.
+# the frequency rule type alerts when num_events events occur with timeframe time
+type: frequency
+
+# (Required)
+# Index to search, wildcard supported
+index: logstash-*
+
+# (Required, frequency specific)
+# Alert when this many documents matching the query occur within a timeframe
+num_events: 50
+
+# (Required, frequency specific)
+# num_events must occur within this amount of time to trigger an alert
+timeframe:
+  hours: 4
+
+# (Optional)
+# Schedule time when to run the task ± configured run_every time
+# Format info: http://www.nncron.ru/help/EN/working/cron-format.htm
+scheduler: '0,15,30,45 0,6,12,18 1,15,31 * 1-5 *'
+
+# (Required)
+# A list of Elasticsearch filters used for find events
+# These filters are joined with AND and nested in a filtered query
+# For more info: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html
+filter:
+- term:
+    some_field: "some_value"
+
+# (Required)
+# The alert is use when a match is found
+alert:
+- "email"
+
+# (required, email specific)
+# a list of email addresses to send alerts to
+email:
+- "elastalert@example.com"


### PR DESCRIPTION
Using croniter and cron like syntax schedule your rule execution time.
Rule will execute if ts_now is between scheduled time ± configured run_every time / 2, to get some time range for rule execution.
Inside rule add `scheduler: 'cron syntax'`
Advantage over using match_enhancements described [here](https://gitter.im/Yelp/elastalert?at=58d01f056701410e5859d081) is that you will not execute Elasticsearch query at all.
There is a also ticket for [this](https://github.com/Yelp/elastalert/issues/588).