### PR TITLE
Fix bucket offset calculation

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -227,8 +227,8 @@ class ElastAlerter():
                     'aggs': metric_agg_element
                 }
             }
-            if rule.get('sync_window_offset'):
-                aggs_element['offset'] = '+%ss' % (rule['sync_window_offset'])
+            if rule.get('bucket_offset_delta'):
+                aggs_element['interval_aggs']['date_histogram']['offset'] = '+%ss' % (rule['bucket_offset_delta'])
         else:
             aggs_element = metric_agg_element
 


### PR DESCRIPTION
When bucket_interval is used (and sync_bucket_interval is false), ensure that the buckets keys align correctly with the query start and endtime from elastalert. Caused by a late rule key name changed in PR not being made in all the correct places. 