### PR TITLE
Respect absolute path for rule imports

### DIFF
--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -127,7 +127,10 @@ def load_rule_yaml(filename):
         rule = loaded
         if 'import' in rule:
             # Find the path of the next file.
-            filename = os.path.join(os.path.dirname(filename), rule['import'])
+            if os.path.isabs(rule['import']):
+                filename = rule['import']
+            else:
+                filename = os.path.join(os.path.dirname(filename), rule['import'])
             del(rule['import'])  # or we could go on forever!
         else:
             break

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -92,6 +92,29 @@ def test_import_import():
         assert rules['filter'] == import_rule['filter']
 
 
+def test_import_absolute_import():
+    import_rule = copy.deepcopy(test_rule)
+    del(import_rule['es_host'])
+    del(import_rule['es_port'])
+    import_rule['import'] = '/importme.ymlt'
+    import_me = {
+        'es_host': 'imported_host',
+        'es_port': 12349,
+        'email': 'ignored@email',  # overwritten by the email in import_rule
+    }
+
+    with mock.patch('elastalert.config.yaml_loader') as mock_open:
+        mock_open.side_effect = [import_rule, import_me]
+        rules = load_configuration('blah.yaml', test_config)
+        assert mock_open.call_args_list[0][0] == ('blah.yaml',)
+        assert mock_open.call_args_list[1][0] == ('/importme.ymlt',)
+        assert len(mock_open.call_args_list) == 2
+        assert rules['es_port'] == 12349
+        assert rules['es_host'] == 'imported_host'
+        assert rules['email'] == ['test@test.test']
+        assert rules['filter'] == import_rule['filter']
+
+
 def test_import_filter():
     # Check that if a filter is specified the rules are merged:
 


### PR DESCRIPTION
This shouldn't change existing behavior, but will allow for imports to be referenced by absolute path.