### PR TITLE
Individualized run_every period for each rule

### DIFF
--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -168,6 +168,8 @@ def load_options(rule, conf, filename, args=None):
             rule['query_delay'] = datetime.timedelta(**rule['query_delay'])
         if 'buffer_time' in rule:
             rule['buffer_time'] = datetime.timedelta(**rule['buffer_time'])
+        if 'run_every' in rule:
+            rule['run_every'] = datetime.timedelta(**rule['run_every'])
         if 'bucket_interval' in rule:
             rule['bucket_interval_timedelta'] = datetime.timedelta(**rule['bucket_interval'])
         if 'exponential_realert' in rule:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -873,7 +873,7 @@ class ElastAlerter():
             if prop not in rule:
                 continue
             new_rule[prop] = rule[prop]
-        self.scheduler.add_job(self.handle_rule_execution, 'interval', args=[new_rule] ,seconds=self.run_every.total_seconds(), id=new_rule['name'], next_run_time=datetime.datetime.now())
+        self.scheduler.add_job(self.handle_rule_execution, 'interval', args=[new_rule] ,seconds=new_rule['run_every'].total_seconds(), id=new_rule['name'], next_run_time=datetime.datetime.now())
 
         return new_rule
 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     packages=find_packages(),
     package_data={'elastalert': ['schema.yaml']},
     install_requires=[
+        'apscheduler>=3.3.0',
         'aws-requests-auth>=0.3.0',
         'blist>=1.3.6',
         'boto3>=1.4.4',


### PR DESCRIPTION
Changes to allow rules to have individualized run_every periods. Still very much in beta needs much review for thread safety etc, plus figure out how to hand reloaded rules who's name have changed etc.. 

Main changes are as follows
1) Update config code to load run_every from rule_file.yaml if present 
2) Replace certain EA instance attributes with thread_local storage (counters and es_clients)
3) Split run_all into separate functions for sending pending alerts, reloading config and executing a single rule instance. 
4) Added APScheduler to schedule each rule in its own job, two further background threads for pending alerts and config_reloads.

This PR should work very nicely with the cron syntax changes in #1114, but at the moment just using a straight up interval scheduling. 