### PR TITLE
Add support for sending notifications to Microsoft Teams channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Currently, we have support built in for the following alert types:
 - OpsGenie
 - Commands
 - HipChat
+- MS Teams
 - Slack
 - Telegram
 - AWS SNS

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1387,6 +1387,26 @@ text - Message is treated just like a message sent by a user. Can include @menti
 Valid values: html, text.
 Defaults to 'html'.
 
+MS Teams
+~~~~~~~~
+
+MS Teams alerter will send a notification to a predefined Microsoft Teams channel.
+
+The alerter requires the following options:
+
+``ms_teams_webhook_url``: The webhook URL that includes your auth data and the ID of the channel you want to post to. Go to the Connectors
+menu in your channel and configure an Incoming Webhook, then copy the resulting URL. You can use a list of URLs to send to multiple channels.
+
+``ms_teams_alert_summary``: Summary should be configured according to `MS documentation <https://docs.microsoft.com/en-us/outlook/actionable-messages/card-reference>`_, although it seems not displayed by Teams currently.
+
+Optional:
+
+``ms_teams_theme_color``: By default the alert will be posted without any color line. To add color, set this attribute to a HTML color value e.g. ``#ff0000`` for red.
+
+``ms_teams_proxy``: By default ElastAlert will not use a network proxy to send notifications to MS Teams. Set this option using ``hostname:port`` if you need to use a proxy.
+
+``ms_teams_alert_fixed_width``: By default this is ``False`` and the notification will be sent to MS Teams as-is. Teams supports a partial Markdown implementation, which means asterisk, underscore and other characters may be interpreted as Markdown. Currenlty, Teams does not fully implement code blocks. Setting this attribute to ``True`` will enable line by line code blocks. It is recommended to enable this to get clearer notifications in Teams.
+
 Slack
 ~~~~~
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -900,6 +900,60 @@ class HipChatAlerter(Alerter):
                 'hipchat_room_id': self.hipchat_room_id}
 
 
+class MsTeamsAlerter(Alerter):
+    """ Creates a Microsoft Teams Conversation Message for each alert """
+    required_options = frozenset(['ms_teams_webhook_url', 'ms_teams_alert_summary'])
+
+    def __init__(self, rule):
+        super(MsTeamsAlerter, self).__init__(rule)
+        self.ms_teams_webhook_url = self.rule['ms_teams_webhook_url']
+        if isinstance(self.ms_teams_webhook_url, basestring):
+            self.ms_teams_webhook_url = [self.ms_teams_webhook_url]
+        self.ms_teams_proxy = self.rule.get('ms_teams_proxy', None)
+        self.ms_teams_alert_summary = self.rule.get('ms_teams_alert_summary', 'ElastAlert Message')
+        self.ms_teams_alert_fixed_width = self.rule.get('ms_teams_alert_fixed_width', False)
+        self.ms_teams_theme_color = self.rule.get('ms_teams_theme_color', '')
+
+    def format_body(self, body):
+        body = body.encode('UTF-8')
+        if self.ms_teams_alert_fixed_width:
+            body = body.replace('`', "'")
+            body = "```{0}```".format('```\n\n```'.join(x for x in body.split('\n'))).replace('\n``````', '')
+        return body
+
+    def alert(self, matches):
+        body = self.create_alert_body(matches)
+
+        body = self.format_body(body)
+        # post to Teams
+        headers = {'content-type': 'application/json'}
+        # set https proxy, if it was provided
+        proxies = {'https': self.ms_teams_proxy} if self.ms_teams_proxy else None
+        payload = {
+            '@type': 'MessageCard',
+            '@context': 'http://schema.org/extensions',
+            'summary': self.ms_teams_alert_summary,
+            'title': self.create_title(matches),
+            'text': body
+        }
+        if self.ms_teams_theme_color != '':
+            payload['themeColor'] = self.ms_teams_theme_color
+
+        elastalert_logger.info(json.dumps(payload, cls=DateTimeEncoder))
+
+        for url in self.ms_teams_webhook_url:
+            try:
+                response = requests.post(url, data=json.dumps(payload, cls=DateTimeEncoder), headers=headers, proxies=proxies)
+                response.raise_for_status()
+            except RequestException as e:
+                raise EAException("Error posting to ms teams: %s" % e)
+        elastalert_logger.info("Alert sent to MS Teams")
+
+    def get_info(self):
+        return {'type': 'ms_teams',
+                'ms_teams_webhook_url': self.ms_teams_webhook_url}
+
+
 class SlackAlerter(Alerter):
     """ Creates a Slack room message for each alert """
     required_options = frozenset(['slack_webhook_url'])

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -939,8 +939,6 @@ class MsTeamsAlerter(Alerter):
         if self.ms_teams_theme_color != '':
             payload['themeColor'] = self.ms_teams_theme_color
 
-        elastalert_logger.info(json.dumps(payload, cls=DateTimeEncoder))
-
         for url in self.ms_teams_webhook_url:
             try:
                 response = requests.post(url, data=json.dumps(payload, cls=DateTimeEncoder), headers=headers, proxies=proxies)

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -63,6 +63,7 @@ alerts_mapping = {
     'command': alerts.CommandAlerter,
     'sns': alerts.SnsAlerter,
     'hipchat': alerts.HipChatAlerter,
+    'ms_teams': alerts.MsTeamsAlerter,
     'slack': alerts.SlackAlerter,
     'pagerduty': alerts.PagerDutyAlerter,
     'exotel': alerts.ExotelAlerter,


### PR DESCRIPTION
Add support for sending notifications to Microsoft Teams channels.

![20170529-ms-teams](https://cloud.githubusercontent.com/assets/813929/26531812/0c2645c8-4424-11e7-93f9-b9b7d4d1d644.jpg)

