### PR TITLE
Allow markdown in slack alerts

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -944,6 +944,7 @@ class SlackAlerter(Alerter):
                     'color': self.slack_msg_color,
                     'title': self.create_title(matches),
                     'text': body,
+                    'mrkdwn_in': ['text', 'pretext'],
                     'fields': []
                 }
             ]

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -771,6 +771,7 @@ def test_slack_uses_custom_title():
                 'color': 'danger',
                 'title': rule['alert_subject'],
                 'text': BasicMatchString(rule, match).__str__(),
+                'mrkdwn_in': ['text', 'pretext'],
                 'fields': []
             }
         ],
@@ -811,6 +812,7 @@ def test_slack_uses_rule_name_when_custom_title_is_not_provided():
                 'color': 'danger',
                 'title': rule['name'],
                 'text': BasicMatchString(rule, match).__str__(),
+                'mrkdwn_in': ['text', 'pretext'],
                 'fields': []
             }
         ],
@@ -852,6 +854,7 @@ def test_slack_uses_custom_slack_channel():
                 'color': 'danger',
                 'title': rule['name'],
                 'text': BasicMatchString(rule, match).__str__(),
+                'mrkdwn_in': ['text', 'pretext'],
                 'fields': []
             }
         ],


### PR DESCRIPTION
Tested in my own environment to ensure that markdown is now
honored by the slack alert type.  One line change, not sure how
much more testing is required.

As a specific example - 
```
alert:
- "slack"
alert_text: |
  A user - {0} - was added to a security group - {1} - by
  operator - {2}.
  *This user will now have access to log in to protected systems.*
  ```This is some inline code```
alert_text_args:
  - event_data.AttributeValue
  - event_data.ObjectDN
  - event_data.SubjectUserName
```

Without this PR, the bold text type and inline code style will be ignored by the slack message.