### PR TITLE
Fixed type error in ServiceNowAlerter Class

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1222,7 +1222,7 @@ class ServiceNowAlerter(Alerter):
     ])
 
     def __init__(self, rule):
-        super(GitterAlerter, self).__init__(rule)
+        super(ServiceNowAlerter, self).__init__(rule)
         self.servicenow_rest_url = self.rule['servicenow_rest_url']
         self.servicenow_proxy = self.rule.get('servicenow_proxy', None)
 


### PR DESCRIPTION
Super for parent alert class called with GitterAlert object, needed to be called with ServiceNowAlerter object.