### PR TITLE
Add environment variable substitution to use_kibana4_dashboard

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Change Log
 
+
+## Unreleased
+
+### Added
+- Added the ability to expand environment variables in
+  ``use_kibana4_dashboard``, enabling sharing of rules across multiple
+  deployments of ElastAlert and Kibana.
+
 ## v0.1.11 - 2017-04-19
 
 ### Fixed

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -451,7 +451,8 @@ use_kibana4_dashboard
 
 ``use_kibana4_dashboard``: A link to a Kibana 4 dashboard. For example, "https://kibana.example.com/#/dashboard/My-Dashboard".
 This will set the time setting on the dashboard from the match time minus the timeframe, to 10 minutes after the match time.
-Note that this does not support filtering by ``query_key`` like Kibana 3.
+Note that this does not support filtering by ``query_key`` like Kibana 3.  This value can use `$VAR` and `${VAR}` references
+to expand environment variables.
 
 kibana4_start_timedelta
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/elastalert/kibana.py
+++ b/elastalert/kibana.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os.path
 import urllib
 
 from util import EAException
@@ -278,6 +279,7 @@ def filters_from_dashboard(db):
 
 
 def kibana4_dashboard_link(dashboard, starttime, endtime):
+    dashboard = os.path.expandvars(dashboard)
     time_settings = kibana4_time_temp % (starttime, endtime)
     time_settings = urllib.quote(time_settings)
     return "%s?_g=%s" % (dashboard, time_settings)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -3,6 +3,7 @@ import copy
 import datetime
 
 import mock
+import os.path
 import pytest
 
 import elastalert.alerts
@@ -271,6 +272,8 @@ def test_get_file_paths_recursive():
         mock_walk.return_value = walk_paths
         paths = get_file_paths(conf)
 
+    paths = [p.replace(os.path.sep, '/') for p in paths]
+
     assert 'root/rule.yaml' in paths
     assert 'root/folder_a/a.yaml' in paths
     assert 'root/folder_a/ab.yaml' in paths
@@ -288,6 +291,8 @@ def test_get_file_paths():
             mock_path.return_value = True
             mock_list.return_value = files
             paths = get_file_paths(conf)
+
+    paths = [p.replace(os.path.sep, '/') for p in paths]
 
     assert 'root/a.yaml' in paths
     assert 'root/b.yaml' in paths

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 import datetime
 
 import mock
+import os
 import pytest
 
 import elastalert.elastalert
@@ -86,3 +87,13 @@ def ea():
     ea.writeback_es.index.return_value = {'_id': 'ABCD'}
     ea.current_es = mock_es_client('', '')
     return ea
+
+
+@pytest.fixture(scope='function')
+def environ():
+    """py.test fixture to get a fresh mutable environment."""
+    old_env = os.environ
+    new_env = dict(old_env.items())
+    os.environ = new_env
+    yield os.environ
+    os.environ = old_env

--- a/tests/kibana_test.py
+++ b/tests/kibana_test.py
@@ -89,3 +89,16 @@ def test_add_filter():
 def test_url_encoded():
     url = kibana4_dashboard_link('example.com/#/Dashboard', '2015-01-01T00:00:00Z', '2017-01-01T00:00:00Z')
     assert not any([special_char in url for special_char in ["',\":;?&=()"]])
+
+
+def test_url_env_substitution(environ):
+    environ.update({
+        'KIBANA_HOST': 'kibana',
+        'KIBANA_PORT': '5601',
+    })
+    url = kibana4_dashboard_link(
+        'http://$KIBANA_HOST:$KIBANA_PORT/#/Dashboard',
+        '2015-01-01T00:00:00Z',
+        '2017-01-01T00:00:00Z',
+    )
+    assert url.startswith('http://kibana:5601/#/Dashboard')


### PR DESCRIPTION
Without this, the Kibana host is hardcoded in the rule definition and some kind
of external rule templating is required to share the rule across multiple
deployements.  This change allows doing the same without a templating engine:
all we need is for the caller to point environment variables of their choice to
the right location when running ElastAlert.

Fixes #1150 