### PR TITLE
twilio_accout_sid renaming to 'account'?

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1499,7 +1499,7 @@ Twilio alerter will trigger an incident to a mobile phone as sms from your twili
 
 The alerter requires the following option:
 
-``twilio_accout_sid``: This is sid of your twilio account.
+``twilio_account_sid``: This is sid of your twilio account.
 
 ``twilio_auth_token``: Auth token assosiated with your twilio account.
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1116,17 +1116,17 @@ class ExotelAlerter(Alerter):
 
 
 class TwilioAlerter(Alerter):
-    required_options = frozenset(['twilio_accout_sid', 'twilio_auth_token', 'twilio_to_number', 'twilio_from_number'])
+    required_options = frozenset(['twilio_account_sid', 'twilio_auth_token', 'twilio_to_number', 'twilio_from_number'])
 
     def __init__(self, rule):
         super(TwilioAlerter, self).__init__(rule)
-        self.twilio_accout_sid = self.rule['twilio_accout_sid']
+        self.twilio_account_sid = self.rule['twilio_account_sid']
         self.twilio_auth_token = self.rule['twilio_auth_token']
         self.twilio_to_number = self.rule['twilio_to_number']
         self.twilio_from_number = self.rule['twilio_from_number']
 
     def alert(self, matches):
-        client = TwilioClient(self.twilio_accout_sid, self.twilio_auth_token)
+        client = TwilioClient(self.twilio_account_sid, self.twilio_auth_token)
 
         try:
             client.messages.create(body=self.rule['name'],

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -240,7 +240,7 @@ properties:
   exotel_from_number: {type: string}
 
   ### Twilio
-  twilio_accout_sid: {type: string}
+  twilio_account_sid: {type: string}
   twilio_auth_token: {type: string}
   twilio_to_number: {type: string}
   twilio_from_number: {type: string}


### PR DESCRIPTION
- Currently using Elastalert and loving it
- Just figured that maybe there might have been a typo in the naming?
- Kinda thought "account" sounds / seems better than "accout"

Open to all input, thoughts, questions, etc! 