### PR TITLE
Prepare for Python3

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import sphinx_rtd_theme
 
 # -*- coding: utf-8 -*-

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -41,7 +41,7 @@ class DateTimeEncoder(json.JSONEncoder):
         if hasattr(obj, 'isoformat'):
             return obj.isoformat()
         else:
-            return json.JSONEncoder.default(self, obj)
+            return json.JSONEncoder.default(self, obj.decode('UTF-8'))
 
 
 class BasicMatchString(object):
@@ -878,7 +878,7 @@ class HipChatAlerter(Alerter):
 
         # Use appropriate line ending for text/html
         if self.hipchat_message_format == 'html':
-            body = body.replace('\n', '<br />')
+            body = body.replace(b'\n', b'<br />')
 
         # Post to HipChat
         headers = {'content-type': 'application/json'}
@@ -979,18 +979,18 @@ class SlackAlerter(Alerter):
         self.slack_parse_override = self.rule.get('slack_parse_override', 'none')
         self.slack_text_string = self.rule.get('slack_text_string', '')
 
-    def format_body(self, body):
+    def format_body(self, body_str):
         # https://api.slack.com/docs/formatting
-        body = body.encode('UTF-8')
-        body = body.replace('&', '&amp;')
-        body = body.replace('<', '&lt;')
-        body = body.replace('>', '&gt;')
+        body = body_str.encode('UTF-8')
+        body = body.replace(b'&', b'&amp;')
+        body = body.replace(b'<', b'&lt;')
+        body = body.replace(b'>', b'&gt;')
         return body
 
     def alert(self, matches):
-        body = self.create_alert_body(matches)
+        body_str = self.create_alert_body(matches)
 
-        body = self.format_body(body)
+        body = self.format_body(body_str)
         # post to slack
         headers = {'content-type': 'application/json'}
         # set https proxy, if it was provided

--- a/elastalert/auth.py
+++ b/elastalert/auth.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 import os
 import boto3
 from aws_requests_auth.aws_auth import AWSRequestsAuth

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -1,18 +1,20 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import getpass
 import os
 import time
-
 import argparse
+
 import elasticsearch.helpers
 import yaml
-from auth import Auth
 from elasticsearch import RequestsHttpConnection
 from elasticsearch.client import Elasticsearch
 from elasticsearch.client import IndicesClient
+from six.moves import input
+
+from .auth import Auth
 
 
 def main():
@@ -68,20 +70,20 @@ def main():
         username = None
         password = None
         aws_region = args.aws_region
-        host = args.host if args.host else raw_input('Enter Elasticsearch host: ')
-        port = args.port if args.port else int(raw_input('Enter Elasticsearch port: '))
+        host = args.host if args.host else input('Enter Elasticsearch host: ')
+        port = args.port if args.port else int(input('Enter Elasticsearch port: '))
         use_ssl = (args.ssl if args.ssl is not None
-                   else raw_input('Use SSL? t/f: ').lower() in ('t', 'true'))
+                   else input('Use SSL? t/f: ').lower() in ('t', 'true'))
         if use_ssl:
             verify_certs = (args.verify_certs if args.verify_certs is not None
-                            else raw_input('Verify TLS certificates? t/f: ').lower() not in ('f', 'false'))
+                            else input('Verify TLS certificates? t/f: ').lower() not in ('f', 'false'))
         else:
             verify_certs = True
         if args.no_auth is None:
-            username = raw_input('Enter optional basic-auth username (or leave blank): ')
+            username = input('Enter optional basic-auth username (or leave blank): ')
             password = getpass.getpass('Enter optional basic-auth password (or leave blank): ')
         url_prefix = (args.url_prefix if args.url_prefix is not None
-                      else raw_input('Enter optional Elasticsearch URL prefix (prepends a string to the URL of every request): '))
+                      else input('Enter optional Elasticsearch URL prefix (prepends a string to the URL of every request): '))
         send_get_body_as = args.send_get_body_as
 
     timeout = args.timeout
@@ -120,12 +122,12 @@ def main():
     error_mapping = {'elastalert_error': {'properties': {'data': {'type': 'object', 'enabled': False},
                                                          '@timestamp': {'format': 'dateOptionalTime', 'type': 'date'}}}}
 
-    index = args.index if args.index is not None else raw_input('New index name? (Default elastalert_status) ')
+    index = args.index if args.index is not None else input('New index name? (Default elastalert_status) ')
     if not index:
         index = 'elastalert_status'
 
     old_index = (args.old_index if args.old_index is not None
-                 else raw_input('Name of existing index to copy? (Default None) '))
+                 else input('Name of existing index to copy? (Default None) '))
 
     es_index = IndicesClient(es)
     if es_index.exists(index):

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1379,7 +1379,7 @@ class ElastAlerter():
                     self.alert([match_body], rule, alert_time=alert_time)
 
                 if rule['current_aggregate_id']:
-                    for qk, agg_id in six.iteritems(rule['current_aggregate_id']):
+                    for qk, agg_id in list(six.iteritems(rule['current_aggregate_id'])):
                         if agg_id == _id:
                             rule['current_aggregate_id'].pop(qk)
                             break

--- a/elastalert/kibana.py
+++ b/elastalert/kibana.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import urllib
 
-from util import EAException
+import six
 
+from .util import EAException
 
 dashboard_temp = {'editable': True,
                   u'failover': False,
@@ -212,9 +214,9 @@ def add_filter(dashboard, es_filter):
             kibana_filter['query'] = es_filter['query_string']['query']
     elif 'term' in es_filter:
         kibana_filter['type'] = 'field'
-        f_field, f_query = es_filter['term'].items()[0]
+        f_field, f_query = next(iter(es_filter['term'].items()))
         # Wrap query in quotes, otherwise certain characters cause Kibana to throw errors
-        if isinstance(f_query, basestring):
+        if isinstance(f_query, six.string_types):
             f_query = '"%s"' % (f_query.replace('"', '\\"'))
         if isinstance(f_query, list):
             # Escape quotes
@@ -227,7 +229,7 @@ def add_filter(dashboard, es_filter):
         kibana_filter['query'] = f_query
     elif 'range' in es_filter:
         kibana_filter['type'] = 'range'
-        f_field, f_range = es_filter['range'].items()[0]
+        f_field, f_range = next(iter(es_filter['range'].items()))
         kibana_filter['field'] = f_field
         kibana_filter.update(f_range)
     else:

--- a/elastalert/kibana.py
+++ b/elastalert/kibana.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-import urllib
 
 import six
+from six.moves.urllib.parse import quote
 
 from .util import EAException
 
@@ -281,5 +281,5 @@ def filters_from_dashboard(db):
 
 def kibana4_dashboard_link(dashboard, starttime, endtime):
     time_settings = kibana4_time_temp % (starttime, endtime)
-    time_settings = urllib.quote(time_settings)
+    time_settings = quote(time_settings)
     return "%s?_g=%s" % (dashboard, time_settings)

--- a/elastalert/opsgenie.py
+++ b/elastalert/opsgenie.py
@@ -1,11 +1,16 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 import json
 import logging
+
 import requests
-from alerts import Alerter
-from alerts import BasicMatchString
-from util import EAException
-from util import elastalert_logger
+import six
+
+from .alerts import Alerter
+from .alerts import BasicMatchString
+from .util import EAException
+from .util import elastalert_logger
 
 
 class OpsGenieAlerter(Alerter):
@@ -28,7 +33,7 @@ class OpsGenieAlerter(Alerter):
     def alert(self, matches):
         body = ''
         for match in matches:
-            body += unicode(BasicMatchString(self.rule, match))
+            body += six.text_type(BasicMatchString(self.rule, match))
             # Separate text of aggregated alerts with dashes
             if len(matches) > 1:
                 body += '\n----------------------------------------\n'

--- a/elastalert/rule_from_kibana.py
+++ b/elastalert/rule_from_kibana.py
@@ -9,13 +9,14 @@ import yaml
 from elasticsearch.client import Elasticsearch
 
 from elastalert.kibana import filters_from_dashboard
+from six.moves import input
 
 
 def main():
-    es_host = raw_input("Elasticsearch host: ")
-    es_port = raw_input("Elasticsearch port: ")
-    db_name = raw_input("Dashboard name: ")
-    send_get_body_as = raw_input("Method for querying Elasticsearch[GET]: ") or 'GET'
+    es_host = input("Elasticsearch host: ")
+    es_port = input("Elasticsearch port: ")
+    db_name = input("Dashboard name: ")
+    send_get_body_as = input("Method for querying Elasticsearch[GET]: ") or 'GET'
     es = Elasticsearch(host=es_host, port=es_port, send_get_body_as=send_get_body_as)
     query = {'query': {'term': {'_id': db_name}}}
     res = es.search(index='kibana-int', doc_type='dashboard', body=query, _source_include=['dashboard'])

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -865,8 +865,8 @@ class CardinalityRule(RuleType):
 
     def garbage_collect(self, timestamp):
         """ Remove all occurrence data that is beyond the timeframe away """
-        for qk, terms in self.cardinality_cache.items():
-            for term, last_occurence in terms.items():
+        for qk, terms in list(self.cardinality_cache.items()):
+            for term, last_occurence in list(terms.items()):
                 if timestamp - last_occurence > self.rules['timeframe']:
                     self.cardinality_cache[qk].pop(term)
 

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -1,22 +1,25 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import copy
 import datetime
 import sys
 
+import six
 from blist import sortedlist
-from util import add_raw_postfix
-from util import dt_to_ts
-from util import EAException
-from util import elastalert_logger
-from util import elasticsearch_client
-from util import format_index
-from util import hashable
-from util import lookup_es_key
-from util import new_get_event_ts
-from util import pretty_ts
-from util import total_seconds
-from util import ts_now
-from util import ts_to_dt
+
+from .util import add_raw_postfix
+from .util import dt_to_ts
+from .util import EAException
+from .util import elastalert_logger
+from .util import elasticsearch_client
+from .util import format_index
+from .util import hashable
+from .util import lookup_es_key
+from .util import new_get_event_ts
+from .util import pretty_ts
+from .util import total_seconds
+from .util import ts_now
+from .util import ts_to_dt
 
 
 class RuleType(object):
@@ -202,8 +205,8 @@ class ChangeRule(CompareRule):
         if change:
             extra = {'old_value': change[0],
                      'new_value': change[1]}
-            elastalert_logger.debug("Description of the changed records  " + str(dict(match.items() + extra.items())))
-        super(ChangeRule, self).add_match(dict(match.items() + extra.items()))
+            elastalert_logger.debug("Description of the changed records  " + str(dict(list(match.items()) + list(extra.items()))))
+        super(ChangeRule, self).add_match(dict(list(match.items()) + list(extra.items())))
 
 
 class FrequencyRule(RuleType):
@@ -228,7 +231,7 @@ class FrequencyRule(RuleType):
         self.check_for_match('all')
 
     def add_terms_data(self, terms):
-        for timestamp, buckets in terms.iteritems():
+        for timestamp, buckets in six.iteritems(terms):
             for bucket in buckets:
                 event = ({self.ts_field: timestamp,
                           self.rules['query_key']: bucket['key']}, bucket['doc_count'])
@@ -271,10 +274,11 @@ class FrequencyRule(RuleType):
     def garbage_collect(self, timestamp):
         """ Remove all occurrence data that is beyond the timeframe away """
         stale_keys = []
-        for key, window in self.occurrences.iteritems():
+        for key, window in six.iteritems(self.occurrences):
             if timestamp - lookup_es_key(window.data[-1][0], self.ts_field) > self.rules['timeframe']:
                 stale_keys.append(key)
-        map(self.occurrences.pop, stale_keys)
+        for key in stale_keys:
+            self.occurrences.pop(key)
 
     def get_match_str(self, match):
         lt = self.rules.get('use_local_time')
@@ -381,11 +385,11 @@ class SpikeRule(RuleType):
         """ Add count data to the rule. Data should be of the form {ts: count}. """
         if len(data) > 1:
             raise EAException('add_count_data can only accept one count at a time')
-        for ts, count in data.iteritems():
+        for ts, count in six.iteritems(data):
             self.handle_event({self.ts_field: ts}, count, 'all')
 
     def add_terms_data(self, terms):
-        for timestamp, buckets in terms.iteritems():
+        for timestamp, buckets in six.iteritems(terms):
             for bucket in buckets:
                 count = bucket['doc_count']
                 event = {self.ts_field: timestamp,
@@ -447,7 +451,7 @@ class SpikeRule(RuleType):
         extra_info = {'spike_count': spike_count,
                       'reference_count': reference_count}
 
-        match = dict(match.items() + extra_info.items())
+        match = dict(list(match.items()) + list(extra_info.items()))
 
         super(SpikeRule, self).add_match(match)
 
@@ -549,7 +553,7 @@ class FlatlineRule(FrequencyRule):
         # We add an event with a count of zero to the EventWindow for each key. This will cause the EventWindow
         # to remove events that occurred more than one `timeframe` ago, and call onRemoved on them.
         default = ['all'] if 'query_key' not in self.rules else []
-        for key in self.occurrences.keys() or default:
+        for key in list(self.occurrences.keys()) or default:
             self.occurrences.setdefault(
                 key,
                 EventWindow(self.rules['timeframe'], getTimestamp=self.get_ts)
@@ -585,7 +589,7 @@ class NewTermsRule(RuleType):
             self.get_all_terms(args)
         except Exception as e:
             # Refuse to start if we cannot get existing terms
-            raise EAException('Error searching for existing terms: %s' % (repr(e))), None, sys.exc_info()[2]
+            six.reraise(EAException('Error searching for existing terms: %s' % (repr(e))), None, sys.exc_info()[2])
 
     def get_all_terms(self, args):
         """ Performs a terms aggregation for each field to get every existing term. """
@@ -652,7 +656,7 @@ class NewTermsRule(RuleType):
                 tmp_end = min(tmp_start + step, end)
                 time_filter[self.rules['timestamp_field']] = {'lt': dt_to_ts(tmp_end), 'gte': dt_to_ts(tmp_start)}
 
-            for key, values in self.seen_values.iteritems():
+            for key, values in six.iteritems(self.seen_values):
                 if not values:
                     if type(key) == tuple:
                         # If we don't have any results, it could either be because of the absence of any baseline data
@@ -800,7 +804,7 @@ class NewTermsRule(RuleType):
     def add_terms_data(self, terms):
         # With terms query, len(self.fields) is always 1 and the 0'th entry is always a string
         field = self.fields[0]
-        for timestamp, buckets in terms.iteritems():
+        for timestamp, buckets in six.iteritems(terms):
             for bucket in buckets:
                 if bucket['doc_count']:
                     if bucket['key'] not in self.seen_values[field]:
@@ -917,7 +921,7 @@ class BaseAggregationRule(RuleType):
         raise NotImplementedError()
 
     def add_aggregation_data(self, payload):
-        for timestamp, payload_data in payload.iteritems():
+        for timestamp, payload_data in six.iteritems(payload):
             if 'interval_aggs' in payload_data:
                 self.unwrap_interval_buckets(timestamp, None, payload_data['interval_aggs']['buckets'])
             elif 'bucket_aggs' in payload_data:

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -166,7 +166,8 @@ class MockElastAlerter(object):
                 if field != '_id':
                     if not any([re.match(incl.replace('*', '.*'), field) for incl in rule['include']]):
                         fields_to_remove.append(field)
-            map(doc.pop, fields_to_remove)
+            for field in fields_to_remove:
+                doc.pop(fields_to_remove)
 
         # Separate _source and _id, convert timestamps
         resp = [{'_source': doc, '_id': doc['_id']} for doc in docs]
@@ -186,8 +187,7 @@ class MockElastAlerter(object):
                 if qk is None or doc[rule['query_key']] == qk:
                     buckets.setdefault(doc[key], 0)
                     buckets[doc[key]] += 1
-        counts = buckets.items()
-        counts.sort(key=lambda x: x[1], reverse=True)
+        counts = sorted(buckets.items(), key=lambda x: x[1], reverse=True)
         if size:
             counts = counts[:size]
         buckets = [{'key': value, 'doc_count': count} for value, count in counts]

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 import os
 import datetime
 import logging
 
 import dateutil.parser
 import dateutil.tz
-from auth import Auth
 from elasticsearch import RequestsHttpConnection
 from elasticsearch.client import Elasticsearch
 from six import string_types
+
+from .auth import Auth
 
 logging.basicConfig()
 elastalert_logger = logging.getLogger('elastalert')

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import os
+
 
 from setuptools import find_packages
 from setuptools import setup

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 import datetime
 import json
 import subprocess
-from contextlib import nested
 
 import mock
 import pytest
@@ -418,10 +417,8 @@ def test_jira():
 
     mock_priority = mock.Mock(id='5')
 
-    with nested(
-        mock.patch('elastalert.alerts.JIRA'),
-        mock.patch('elastalert.alerts.yaml_loader')
-    ) as (mock_jira, mock_open):
+    with mock.patch('elastalert.alerts.JIRA') as mock_jira, \
+            mock.patch('elastalert.alerts.yaml_loader') as mock_open:
         mock_open.return_value = {'user': 'jirauser', 'password': 'jirapassword'}
         mock_jira.return_value.priorities.return_value = [mock_priority]
         mock_jira.return_value.fields.return_value = []
@@ -451,10 +448,8 @@ def test_jira():
 
     # Search called if jira_bump_tickets
     rule['jira_bump_tickets'] = True
-    with nested(
-        mock.patch('elastalert.alerts.JIRA'),
-        mock.patch('elastalert.alerts.yaml_loader')
-    ) as (mock_jira, mock_open):
+    with mock.patch('elastalert.alerts.JIRA') as mock_jira, \
+            mock.patch('elastalert.alerts.yaml_loader') as mock_open:
         mock_open.return_value = {'user': 'jirauser', 'password': 'jirapassword'}
         mock_jira.return_value = mock.Mock()
         mock_jira.return_value.search_issues.return_value = []
@@ -469,10 +464,8 @@ def test_jira():
 
     # Remove a field if jira_ignore_in_title set
     rule['jira_ignore_in_title'] = 'test_term'
-    with nested(
-        mock.patch('elastalert.alerts.JIRA'),
-        mock.patch('elastalert.alerts.yaml_loader')
-    ) as (mock_jira, mock_open):
+    with mock.patch('elastalert.alerts.JIRA') as mock_jira, \
+            mock.patch('elastalert.alerts.yaml_loader') as mock_open:
         mock_open.return_value = {'user': 'jirauser', 'password': 'jirapassword'}
         mock_jira.return_value = mock.Mock()
         mock_jira.return_value.search_issues.return_value = []
@@ -485,10 +478,8 @@ def test_jira():
     assert 'test_value' not in mock_jira.mock_calls[3][1][0]
 
     # Issue is still created if search_issues throws an exception
-    with nested(
-        mock.patch('elastalert.alerts.JIRA'),
-        mock.patch('elastalert.alerts.yaml_loader')
-    ) as (mock_jira, mock_open):
+    with mock.patch('elastalert.alerts.JIRA') as mock_jira, \
+            mock.patch('elastalert.alerts.yaml_loader') as mock_open:
         mock_open.return_value = {'user': 'jirauser', 'password': 'jirapassword'}
         mock_jira.return_value = mock.Mock()
         mock_jira.return_value.search_issues.side_effect = JIRAError
@@ -561,10 +552,8 @@ def test_jira_arbitrary_field_support():
         },
     ]
 
-    with nested(
-            mock.patch('elastalert.alerts.JIRA'),
-            mock.patch('elastalert.alerts.yaml_loader')
-    ) as (mock_jira, mock_open):
+    with mock.patch('elastalert.alerts.JIRA') as mock_jira, \
+            mock.patch('elastalert.alerts.yaml_loader') as mock_open:
         mock_open.return_value = {'user': 'jirauser', 'password': 'jirapassword'}
         mock_jira.return_value.priorities.return_value = [mock_priority]
         mock_jira.return_value.fields.return_value = mock_fields
@@ -604,10 +593,8 @@ def test_jira_arbitrary_field_support():
     # Reference an arbitrary string field that is not defined on the JIRA server
     rule['jira_nonexistent_field'] = 'nonexistent field value'
 
-    with nested(
-            mock.patch('elastalert.alerts.JIRA'),
-            mock.patch('elastalert.alerts.yaml_loader')
-    ) as (mock_jira, mock_open):
+    with mock.patch('elastalert.alerts.JIRA') as mock_jira, \
+            mock.patch('elastalert.alerts.yaml_loader') as mock_open:
         mock_open.return_value = {'user': 'jirauser', 'password': 'jirapassword'}
         mock_jira.return_value.priorities.return_value = [mock_priority]
         mock_jira.return_value.fields.return_value = mock_fields
@@ -622,10 +609,8 @@ def test_jira_arbitrary_field_support():
     # Reference a watcher that does not exist
     rule['jira_watchers'] = 'invalid_watcher'
 
-    with nested(
-            mock.patch('elastalert.alerts.JIRA'),
-            mock.patch('elastalert.alerts.yaml_loader')
-    ) as (mock_jira, mock_open):
+    with mock.patch('elastalert.alerts.JIRA') as mock_jira, \
+            mock.patch('elastalert.alerts.yaml_loader') as mock_open:
         mock_open.return_value = {'user': 'jirauser', 'password': 'jirapassword'}
         mock_jira.return_value.priorities.return_value = [mock_priority]
         mock_jira.return_value.fields.return_value = mock_fields

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import print_function
+
 import datetime
 import json
 import subprocess
@@ -6,6 +9,8 @@ from contextlib import nested
 
 import mock
 import pytest
+import six
+
 from jira.exceptions import JIRAError
 
 from elastalert.alerts import Alerter
@@ -31,7 +36,7 @@ class mock_rule:
 def test_basic_match_string(ea):
     ea.rules[0]['top_count_keys'] = ['username']
     match = {'@timestamp': '1918-01-17', 'field': 'value', 'top_events_username': {'bob': 10, 'mallory': 5}}
-    alert_text = unicode(BasicMatchString(ea.rules[0], match))
+    alert_text = six.text_type(BasicMatchString(ea.rules[0], match))
     assert 'anytest' in alert_text
     assert 'some stuff happened' in alert_text
     assert 'username' in alert_text
@@ -40,32 +45,32 @@ def test_basic_match_string(ea):
 
     # Non serializable objects don't cause errors
     match['non-serializable'] = {open: 10}
-    alert_text = unicode(BasicMatchString(ea.rules[0], match))
+    alert_text = six.text_type(BasicMatchString(ea.rules[0], match))
 
     # unicode objects dont cause errors
     match['snowman'] = u'☃'
-    alert_text = unicode(BasicMatchString(ea.rules[0], match))
+    alert_text = six.text_type(BasicMatchString(ea.rules[0], match))
 
     # Pretty printed objects
     match.pop('non-serializable')
     match['object'] = {'this': {'that': [1, 2, "3"]}}
-    alert_text = unicode(BasicMatchString(ea.rules[0], match))
+    alert_text = six.text_type(BasicMatchString(ea.rules[0], match))
     assert '"this": {\n        "that": [\n            1, \n            2, \n            "3"\n        ]\n    }' in alert_text
 
     ea.rules[0]['alert_text'] = 'custom text'
-    alert_text = unicode(BasicMatchString(ea.rules[0], match))
+    alert_text = six.text_type(BasicMatchString(ea.rules[0], match))
     assert 'custom text' in alert_text
     assert 'anytest' not in alert_text
 
     ea.rules[0]['alert_text_type'] = 'alert_text_only'
-    alert_text = unicode(BasicMatchString(ea.rules[0], match))
+    alert_text = six.text_type(BasicMatchString(ea.rules[0], match))
     assert 'custom text' in alert_text
     assert 'some stuff happened' not in alert_text
     assert 'username' not in alert_text
     assert 'field: value' not in alert_text
 
     ea.rules[0]['alert_text_type'] = 'exclude_fields'
-    alert_text = unicode(BasicMatchString(ea.rules[0], match))
+    alert_text = six.text_type(BasicMatchString(ea.rules[0], match))
     assert 'custom text' in alert_text
     assert 'some stuff happened' in alert_text
     assert 'username' in alert_text
@@ -1081,7 +1086,7 @@ def test_alert_text_kw(ea):
         'field': 'field',
     }
     match = {'@timestamp': '1918-01-17', 'field': 'value'}
-    alert_text = unicode(BasicMatchString(rule, match))
+    alert_text = six.text_type(BasicMatchString(rule, match))
     body = '{field} at {@timestamp}'.format(**match)
     assert body in alert_text
 
@@ -1100,7 +1105,7 @@ def test_alert_text_global_substitution(ea):
         'abc': 'abc from match',
     }
 
-    alert_text = unicode(BasicMatchString(rule, match))
+    alert_text = six.text_type(BasicMatchString(rule, match))
     assert 'Priority: priority from rule' in alert_text
     assert 'Owner: the owner from rule' in alert_text
 
@@ -1126,7 +1131,7 @@ def test_alert_text_kw_global_substitution(ea):
         'abc': 'abc from match',
     }
 
-    alert_text = unicode(BasicMatchString(rule, match))
+    alert_text = six.text_type(BasicMatchString(rule, match))
     assert 'Owner: the owner from rule' in alert_text
     assert 'Foo: foo from rule' in alert_text
 

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 from elastalert.auth import Auth, RefeshableAWSRequestsAuth
 
 

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import contextlib
 import copy
 import datetime
 import json
@@ -208,17 +207,17 @@ def test_run_rule_calls_garbage_collect(ea):
     end_time = '2014-09-26T12:00:00Z'
     ea.buffer_time = datetime.timedelta(hours=1)
     ea.run_every = datetime.timedelta(hours=1)
-    with contextlib.nested(mock.patch.object(ea.rules[0]['type'], 'garbage_collect'),
-                           mock.patch.object(ea, 'run_query')) as (mock_gc, mock_get_hits):
+    with mock.patch.object(ea.rules[0]['type'], 'garbage_collect') as mock_gc, \
+            mock.patch.object(ea, 'run_query'):
         ea.run_rule(ea.rules[0], ts_to_dt(end_time), ts_to_dt(start_time))
 
-    # Running ElastAlert every hour for 12 hours, we should see self.garbage_collect called 12 times.
-    assert mock_gc.call_count == 12
+        # Running ElastAlert every hour for 12 hours, we should see self.garbage_collect called 12 times.
+        assert mock_gc.call_count == 12
 
-    # The calls should be spaced 1 hour apart
-    expected_calls = [ts_to_dt(start_time) + datetime.timedelta(hours=i) for i in range(1, 13)]
-    for e in expected_calls:
-        mock_gc.assert_any_call(e)
+        # The calls should be spaced 1 hour apart
+        expected_calls = [ts_to_dt(start_time) + datetime.timedelta(hours=i) for i in range(1, 13)]
+        for e in expected_calls:
+            mock_gc.assert_any_call(e)
 
 
 def run_rule_query_exception(ea, mock_es):
@@ -281,8 +280,8 @@ def test_match_with_enhancements_first(ea):
     with mock.patch('elastalert.elastalert.elasticsearch_client'):
         with mock.patch.object(ea, 'add_aggregated_alert') as add_alert:
             ea.run_rule(ea.rules[0], END, START)
-    mod.process.assert_called_with({'@timestamp': END, 'num_hits': 0, 'num_matches': 1})
-    assert add_alert.call_count == 1
+            mod.process.assert_called_with({'@timestamp': END, 'num_hits': 0, 'num_matches': 1})
+            assert add_alert.call_count == 1
 
     # Assert that dropmatchexception behaves properly
     mod.process = mock.MagicMock(side_effect=DropMatchException)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import print_function
+
 import copy
 import datetime
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 import datetime
 
 import mock

--- a/tests/kibana_test.py
+++ b/tests/kibana_test.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import copy
 import json
 

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 import copy
 import datetime
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 from elastalert.util import lookup_es_key, set_es_key, add_raw_postfix, replace_dots_in_field_names
 
 


### PR DESCRIPTION
Plenty of progress towards Python2/Python3 compatibility.
This code still works with Python2, but has been made compatible
with Python3.

Some of our dependencies have to be migrated before we can announce
Python3 support, and there are other problems to solve.

50% of the work was done automatically by
python-modernize/python-modernize .

The most important change was adding `absolute_import`