### PR TITLE
Set shards and replicas settings for index creation

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -55,3 +55,8 @@ writeback_index: elastalert_status
 # sending the alert until this time period has elapsed
 alert_time_limit:
   days: 2
+
+# Set shards and replicas settings for index creation
+#index_settings:
+#  shards: 1
+#  replicas: 0


### PR DESCRIPTION
Hi,

This PR is intended to give the option to set shards and replicas for the elastalert index creation, this could be useful in environments with one elasticsearch node.

Best Regards