### PR TITLE
Wait for provisioning

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -35,6 +35,7 @@ from util import elastalert_logger
 from util import elasticsearch_client
 from util import format_index
 from util import lookup_es_key
+from util import parse_deadline
 from util import pretty_ts
 from util import replace_dots_in_field_names
 from util import seconds
@@ -1543,10 +1544,7 @@ class ElastAlerter():
             silence_cache_key = self.rules[0]['name'] + "._silence"
 
         try:
-            unit, num = self.args.silence.split('=')
-            silence_time = datetime.timedelta(**{unit: int(num)})
-            # Double conversion to add tzinfo
-            silence_ts = ts_to_dt(dt_to_ts(silence_time + datetime.datetime.utcnow()))
+            silence_ts = parse_deadline(self.args.silence)
         except (ValueError, TypeError):
             logging.error('%s is not a valid time period' % (self.args.silence))
             exit(1)

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -81,7 +81,7 @@ class ElastAlerter():
         parser.add_argument('--verbose', action='store_true', dest='verbose', help='Increase verbosity without suppressing alerts')
         parser.add_argument('--patience', action='store', dest='timeout',
                             type=parse_duration,
-                            default=datetime.timedelta(seconds=30),
+                            default=datetime.timedelta(),
                             help='Maximum time to wait for ElasticSearch to become responsive.  Usage: '
                             '--patience <units>=<number>. e.g. --patience minutes=5')
         parser.add_argument(
@@ -1015,6 +1015,10 @@ class ElastAlerter():
 
         # Elapsed time is a floating point number of seconds.
         timeout = timeout.total_seconds()
+
+        # Don't poll unless we're asked to.
+        if timeout <= 0.0:
+            return
 
         # Periodically poll ElasticSearch.  Keep going until ElasticSearch is
         # responsive *and* the writeback index exists.

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -136,7 +136,7 @@ class ElastAlerter():
         self.replace_dots_in_field_names = self.conf.get('replace_dots_in_field_names', False)
 
         self.writeback_es = elasticsearch_client(self.conf)
-        self.es_version = self.get_version()
+        self._es_version = None
 
         remove = []
         for rule in self.rules:
@@ -150,6 +150,12 @@ class ElastAlerter():
     def get_version(self):
         info = self.writeback_es.info()
         return info['version']['number']
+
+    @property
+    def es_version(self):
+        if self._es_version is None:
+            self._es_version = self.get_version()
+        return self._es_version
 
     def is_five(self):
         return self.es_version.startswith('5')

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -342,3 +342,15 @@ def build_es_conn_config(conf):
         parsed_conf['es_url_prefix'] = conf['es_url_prefix']
 
     return parsed_conf
+
+
+def parse_duration(value):
+    """Convert ``unit=num`` spec into a ``timedelta`` object."""
+    unit, num = value.split('=')
+    return datetime.timedelta(**{unit: int(num)})
+
+
+def parse_deadline(value):
+    """Convert ``unit=num`` spec into a ``datetime`` object."""
+    duration = parse_duration(value)
+    return ts_now() + duration

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -745,6 +745,7 @@ def test_get_starttime(ea):
     endtime = '2015-01-01T00:00:00Z'
     mock_es = mock.Mock()
     mock_es.search.return_value = {'hits': {'hits': [{'_source': {'endtime': endtime}}]}}
+    mock_es.info.return_value = {'version': {'number': '2.0'}}
     ea.writeback_es = mock_es
 
     # 4 days old, will return endtime

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import datetime
 
+import logging
 import mock
 import os
 import pytest
@@ -12,6 +13,23 @@ from elastalert.util import ts_to_dt
 
 
 mock_info = {'status': 200, 'name': 'foo', 'version': {'number': '2.0'}}
+
+
+@pytest.fixture(scope='function', autouse=True)
+def reset_loggers():
+    """Prevent logging handlers from capturing temporary file handles.
+
+    For example, a test that uses the `capsys` fixture and calls
+    `logging.exception()` will initialize logging with a default handler that
+    captures `sys.stderr`.  When the test ends, the file handles will be closed
+    and `sys.stderr` will be returned to its original handle, but the logging
+    will have a dangling reference to the temporary handle used in the `capsys`
+    fixture.
+
+    """
+    logger = logging.getLogger()
+    for handler in logger.handlers:
+        logger.removeHandler(handler)
 
 
 class mock_es_indices_client(object):
@@ -29,6 +47,7 @@ class mock_es_client(object):
         self.index = mock.Mock()
         self.delete = mock.Mock()
         self.info = mock.Mock(return_value=mock_info)
+        self.ping = mock.Mock(return_value=True)
         self.indices = mock_es_indices_client()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,11 @@ from elastalert.util import ts_to_dt
 mock_info = {'status': 200, 'name': 'foo', 'version': {'number': '2.0'}}
 
 
+class mock_es_indices_client(object):
+    def __init__(self):
+        self.exists = mock.Mock(return_value=True)
+
+
 class mock_es_client(object):
     def __init__(self, host='es', port=14900):
         self.host = host
@@ -24,6 +29,7 @@ class mock_es_client(object):
         self.index = mock.Mock()
         self.delete = mock.Mock()
         self.info = mock.Mock(return_value=mock_info)
+        self.indices = mock_es_indices_client()
 
 
 class mock_ruletype(object):

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,5 +1,44 @@
 # -*- coding: utf-8 -*-
 from elastalert.util import lookup_es_key, set_es_key, add_raw_postfix, replace_dots_in_field_names
+from elastalert.util import (
+    parse_deadline,
+    parse_duration,
+)
+import mock
+import pytest
+from datetime import (
+    datetime,
+    timedelta,
+)
+from dateutil.parser import parse as dt
+
+
+@pytest.mark.parametrize('spec, expected_delta', [
+    ('hours=2',    timedelta(hours=2)),
+    ('minutes=30', timedelta(minutes=30)),
+    ('seconds=45', timedelta(seconds=45)),
+])
+def test_parse_duration(spec, expected_delta):
+    """``unit=num`` specs can be translated into ``timedelta`` instances."""
+    assert parse_duration(spec) == expected_delta
+
+
+@pytest.mark.parametrize('spec, expected_deadline', [
+    ('hours=2',    dt('2017-07-07T12:00:00.000Z')),
+    ('minutes=30', dt('2017-07-07T10:30:00.000Z')),
+    ('seconds=45', dt('2017-07-07T10:00:45.000Z')),
+])
+def test_parse_deadline(spec, expected_deadline):
+    """``unit=num`` specs can be translated into ``datetime`` instances."""
+
+    # Note: Can't mock ``utcnow`` directly because ``datetime`` is a built-in.
+    class MockDatetime(datetime):
+        @staticmethod
+        def utcnow():
+            return dt('2017-07-07T10:00:00.000Z')
+
+    with mock.patch('datetime.datetime', MockDatetime):
+        assert parse_deadline(spec) == expected_deadline
 
 
 def test_setting_keys(ea):


### PR DESCRIPTION
Fixes #1199.

In addition to the new unit tests, I tried testing this manually.  I'm having a hard time building my Docker container against a custom branch, but it works in well in foreground mode (e.g. run in my terminal against an ElasticSearch node inside a Docker container).

It will respect the delay and bail out and you can always CTRL-C/SIGINT at any time if you lose patience before the timeout elapses.

The one thing I find unfortunate is that `elasticsearch-py` is very verbose on connection errors, so the polling spams with exceptions tracebacks until the connection succeeds (there are no tracebacks if it succeeds on the first attempt).  I don't know any way to make this more pleasing without changing the logging inside `elasticsearch-py` itself.
