### PR TITLE
Improvements to post alerter

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1621,7 +1621,7 @@ The stomp_destination field depends on the broker, the /queue/ALERT example is t
 HTTP POST
 ~~~~~~~~~
 
-This alert type will send results to a JSON endpoint using HTTP POST. The key names are configurable so this is compatible with almost any endpoint.
+This alert type will send results to a JSON endpoint using HTTP POST. The key names are configurable so this is compatible with almost any endpoint. By default, the JSON will contain al the items from the match, unless you specify http_post_payload, in which case it will only contain those items.
 
 Required:
 
@@ -1634,6 +1634,8 @@ Optional:
 ``http_post_static_payload``: Key:value pairs of static parameters to be sent, along with the Elasticsearch results. Put your authentication or other information here.
 
 ``http_post_proxy``: URL of proxy, if required.
+
+``http_post_all_values``: Boolean of whether or not to include every key value pair from the match in addition to those in http_post_payload and http_post_static_payload. Defaults to True if http_post_payload is not specified, otherwise False.
 
 Example usage::
 

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -146,6 +146,7 @@ def load_options(rule, conf, filename, args=None):
     :param rule: A dictionary of parsed YAML from a rule config file.
     :param conf: The global configuration dictionary, used for populating defaults.
     """
+    adjust_deprecated_values(rule)
 
     try:
         rule_schema.validate(rule)
@@ -466,3 +467,14 @@ def get_rule_hashes(conf, use_rule=None):
         with open(rule_file) as fh:
             rule_mod_times[rule_file] = hashlib.sha1(fh.read()).digest()
     return rule_mod_times
+
+
+def adjust_deprecated_values(rule):
+    # From rename of simple HTTP alerter
+    if rule.get('type') == 'simple':
+        rule['type'] = 'http'
+        if 'simple_proxy' in rule:
+            rule['http_post_proxy'] = rule['simple_proxy']
+        if 'simple_webhook_url' in rule:
+            rule['http_post_url'] = rule['simple_webhook_url']
+        logging.warning('"simple" alerter has been renamed "post" and comptability may be removed in a future release.')

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -472,7 +472,7 @@ def get_rule_hashes(conf, use_rule=None):
 def adjust_deprecated_values(rule):
     # From rename of simple HTTP alerter
     if rule.get('type') == 'simple':
-        rule['type'] = 'http'
+        rule['type'] = 'post'
         if 'simple_proxy' in rule:
             rule['http_post_proxy'] = rule['simple_proxy']
         if 'simple_webhook_url' in rule:


### PR DESCRIPTION
Some improvements on https://github.com/Yelp/elastalert/pull/1207
@brianmpollack 

- Allow nested values
- Allow all values by default + mapped values
- Add backward compatibility with old "simple" alerter