### PR TITLE
percentage_match: fix query for Elasticsearch 5

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -1019,7 +1019,11 @@ class PercentageMatchRule(BaseAggregationRule):
                     'filters': {
                         'match_bucket': {
                             'bool': {
-                                'must': self.match_bucket_filter
+                                'must': {
+                                    "query_string": {
+                                        "query": self.match_bucket_filter
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Following some testing with elastalert I stumbled across a bug in the implementation of the `percentage_match` alert on ES5.

The rule was crafted with the query directly as string to the must argument which is no longer a viable solution for ES5 and will throw and error such as: 

```
Error running query: TransportError(400, u"parsing_exception", u"[bool] query does not support [must]")
```

To fix this, I just updated the query to use the correct way of doing so which is compatible with ES2 and ES5.
