### PR TITLE
multi es-instances support

### DIFF
--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -2,7 +2,6 @@
 import os
 import datetime
 import logging
-import json
 import dateutil.parser
 import dateutil.tz
 from auth import Auth
@@ -318,7 +317,6 @@ def build_es_conn_config(conf):
             es_port = int(os.environ.get('ES_PORT', conf['es_port']))
         parsed_conf['es_host'] = parse_host(es_host, es_port)
 
-
     if 'es_username' in conf:
         parsed_conf['es_username'] = os.environ.get('ES_USERNAME', conf['es_username'])
         parsed_conf['es_password'] = os.environ.get('ES_PASSWORD', conf['es_password'])
@@ -359,8 +357,6 @@ def parse_host(host, port="9200"):
         return host_list
     else:
         return ["{host}:{port}".format(host=host, port=port)]
-
-
 
 
 def parse_duration(value):

--- a/tests/util_unit_test.py
+++ b/tests/util_unit_test.py
@@ -1,0 +1,11 @@
+from unittest import TestCase
+
+from elastalert.util import parse_host
+
+
+class UtilsTest(TestCase):
+    def test_parse_host(self):
+        self.assertEqual(parse_host("localhost", port="9200"), ["localhost:9200"])
+        self.assertEqual(parse_host('host1:9200,host2:9200, host3:9300'), ["host1:9200",
+                                                                           "host2:9200",
+                                                                           "host3:9300"])


### PR DESCRIPTION
I take advantages of Elasticsearch, make host param as a list.


Host Config Change to 
"host1:port1, host2:port " can handle multi es-instances

while  the original port and host can also work well here 