### PR TITLE
Add match_time to alert

### DIFF
--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -111,6 +111,7 @@ def main():
     es_mapping = {'elastalert': {'properties': {'rule_name': {'index': 'not_analyzed', 'type': 'string'},
                                                 '@timestamp': {'format': 'dateOptionalTime', 'type': 'date'},
                                                 'alert_time': {'format': 'dateOptionalTime', 'type': 'date'},
+                                                'match_time': {'format': 'dateOptionalTime', 'type': 'date'},
                                                 'match_body': {'enabled': False, 'type': 'object'},
                                                 'aggregate_id': {'index': 'not_analyzed', 'type': 'string'}}}}
     past_mapping = {'past_elastalert': {'properties': {'rule_name': {'index': 'not_analyzed', 'type': 'string'},

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1334,12 +1334,19 @@ class ElastAlerter():
                 agg_id = res['_id']
 
     def get_alert_body(self, match, rule, alert_sent, alert_time, alert_exception=None):
-        body = {'match_body': match}
-        body['rule_name'] = rule['name']
+        body = {
+            'match_body': match,
+            'rule_name': rule['name'],
+            'alert_info': rule['alert'][0].get_info(),
+            'alert_sent': alert_sent,
+            'alert_time': alert_time
+        }
+
+        match_time = lookup_es_key(match, rule['timestamp_field'])
+        if match_time is not None:
+            body['match_time'] = match_time
+
         # TODO record info about multiple alerts
-        body['alert_info'] = rule['alert'][0].get_info()
-        body['alert_sent'] = alert_sent
-        body['alert_time'] = alert_time
 
         # If the alert failed to send, record the exception
         if not alert_sent:


### PR DESCRIPTION
Currently, Kibana can only query alerts by their creation time, not the time of the event. The event time is stored in the match_body, however that is not indexed. 

This change adds the match_time field to an alert, and adds it as indexed field to the ElasticSearch index. In order to make use of the indexin feature, you will have to reindex.