### PR TITLE
Lowered the default bump_after_inactivity settings to 0 days

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1315,6 +1315,9 @@ Example usage::
     jira_bump_in_statuses:
       - Open
 
+``jira_bump_after_inactivity``: If this is set, ElastAlert will only comment on tickets that have been inactive for at least this many days.
+It only applies if ``jira_bump_tickets`` is true. Default is 0 days.
+
 Arbitrary Jira fields:
 
 ElastAlert supports setting any arbitrary JIRA field that your jira issue supports. For example, if you had a custom field, called "Affected User", you can set it by providing that field name in ``snake_case`` prefixed with ``jira_``.  These fields can contain primitive strings or arrays of strings. Note that when you create a custom field in your JIRA server, internally, the field is represented as ``customfield_1111``. In elastalert, you may refer to either the public facing name OR the internal representation.

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -518,7 +518,7 @@ class JiraAlerter(Alerter):
         self.bump_tickets = self.rule.get('jira_bump_tickets', False)
         self.bump_not_in_statuses = self.rule.get('jira_bump_not_in_statuses')
         self.bump_in_statuses = self.rule.get('jira_bump_in_statuses')
-        self.bump_after_inactivity = self.rule.get('jira_bump_after_inactivity', self.max_age)
+        self.bump_after_inactivity = self.rule.get('jira_bump_after_inactivity', 0)
         self.watchers = self.rule.get('jira_watchers')
 
         if self.bump_in_statuses and self.bump_not_in_statuses:


### PR DESCRIPTION
This had a really bad default, that would prevent ticket bumping. When not set, it takes the default of max age, which effectively prevents ANY ticket bumping at all from happening.

Also added documentation.