### PR TITLE
Read logging configuration from config file

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -62,3 +62,53 @@ writeback_index: elastalert_status
 # sending the alert until this time period has elapsed
 alert_time_limit:
   days: 2
+
+# Custom logging configuration
+# If you want to setup your own logging configuration to log into
+# files as well or to Logstash and/or modify log levels, use
+# the configuration below and adjust to your needs.
+# Note: if you run ElastAlert with --verbose/--debug, the log level of
+# the "elastalert" logger is changed to INFO, if not already INFO/DEBUG.
+#logging:
+#  version: 1
+#  incremental: false
+#  disable_existing_loggers: false
+#  formatters:
+#    logline:
+#      format: '%(asctime)s %(levelname)+8s %(name)+20s %(message)s'
+#
+#    handlers:
+#      console:
+#        class: logging.StreamHandler
+#        formatter: logline
+#        level: DEBUG
+#        stream: ext://sys.stderr
+#
+#      file:
+#        class : logging.FileHandler
+#        formatter: logline
+#        level: DEBUG
+#        filename: elastalert.log
+#
+#    loggers:
+#      elastalert:
+#        level: WARN
+#        handlers: []
+#        propagate: true
+#
+#      elasticsearch:
+#        level: WARN
+#        handlers: []
+#        propagate: true
+#
+#      elasticsearch.trace:
+#        level: WARN
+#        handlers: []
+#        propagate: true
+#
+#      '':  # root logger
+#        level: WARN
+#          handlers:
+#            - console
+#            - file
+#        propagate: false

--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -194,6 +194,20 @@ The default value is ``.raw`` for Elasticsearch 2 and ``.keyword`` for Elasticse
 
 ``skip_invalid``: If ``True``, skip invalid files instead of exiting.
 
+=======
+Logging
+-------
+
+By default, ElastAlert uses a simple basic logging configuration to print log messages to standard error.
+You can change the log level to ``INFO`` messages by using the ``--verbose`` or ``--debug`` command line options.
+
+If you need a more sophisticated logging configuration, you can provide a full logging configuration
+in the config file. This way you can also configure logging to a file, to Logstash and
+adjust the logging format.
+
+For details, see the end of ``config.yaml.example`` where you can find an example logging
+configuration.
+
 
 .. _runningelastalert:
 

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -105,28 +105,6 @@ class ElastAlerter():
         self.debug = self.args.debug
         self.verbose = self.args.verbose
 
-        if self.verbose and self.debug:
-            elastalert_logger.info(
-                "Note: --debug and --verbose flags are set. --debug takes precedent."
-            )
-
-        if self.verbose or self.debug:
-            elastalert_logger.setLevel(logging.INFO)
-
-        if self.debug:
-            elastalert_logger.info(
-                """Note: In debug mode, alerts will be logged to console but NOT actually sent.
-                To send them but remain verbose, use --verbose instead."""
-            )
-
-        if not self.args.es_debug:
-            logging.getLogger('elasticsearch').setLevel(logging.WARNING)
-
-        if self.args.es_debug_trace:
-            tracer = logging.getLogger('elasticsearch.trace')
-            tracer.setLevel(logging.INFO)
-            tracer.addHandler(logging.FileHandler(self.args.es_debug_trace))
-
         self.conf = load_rules(self.args)
         self.max_query_size = self.conf['max_query_size']
         self.scroll_keepalive = self.conf['scroll_keepalive']

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -45,6 +45,7 @@ test_args = mock.Mock()
 test_args.config = 'test_config'
 test_args.rule = None
 test_args.debug = False
+test_args.es_debug_trace = None
 
 
 def test_import_rules():


### PR DESCRIPTION
Support reading a whole dict logging configuration from the config file
and configure the logging framework accordingly.
Move special logging configuration via command line options
(--verbose, --debug) into load_rules() as it needs to be set after the
logging framework has been reconfigured.

This should keep the previous behavior as close as possible when no
logging setup is provided in the configuration and mimic the desired log
level adjustments where appropriate even if a custom logging config
is given.

My main motivation was to add a custom log format, especially including
a timestamp (I don't like logs without timestamps).
Furthermore, with a full logging config, you can easily log your
ElastAlert logs into Logstash with https://github.com/eht16/python-logstash-async/, e.g. https://gist.github.com/eht16/b2183e1ce8373b8916b72dfa985a20c6.