### PR TITLE
Logging the unique values in values list of NewTermsRule

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -667,7 +667,7 @@ class NewTermsRule(RuleType):
                         elastalert_logger.info('Found no values for %s' % (field))
                     continue
                 self.seen_values[key] = list(set(values))
-                elastalert_logger.info('Found %s unique values for %s' % (len(values), key))
+                elastalert_logger.info('Found %s unique values for %s' % (len(set(values)), key))
 
     def flatten_aggregation_hierarchy(self, root, hierarchy_tuple=()):
         """ For nested aggregations, the results come back in the following format:


### PR DESCRIPTION
Hi, this PR is about New Term Rule type. 

According to this line in `ruletypes.py`, it should get the unique values count of `values` list, but it counts all values in the list. 
```
self.seen_values[key] = list(set(values))
elastalert_logger.info('Found %s unique values for %s' % (len(values), key))
```

I also added another line to print `values` list for debug 
```
elastalert_logger.info('Found %s unique values for %s' % (len(values), key))
elastalert_logger.info(values)
```
![image](https://user-images.githubusercontent.com/17530818/29450205-4834ee92-8430-11e7-914a-d3950ca48aca.png)


So I changed logging.info to print the number of distinct values in `values` list, and print `set(values)` for debug. 
```
elastalert_logger.info('Found %s unique values for %s' % (len(set(values)), key))
elastalert_logger.info(set(values))
```
![image](https://user-images.githubusercontent.com/17530818/29450603-dcf5dd88-8431-11e7-877d-7090562f9d7b.png)


