### PR TITLE
Remove json formatted in jira code blocks

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -148,7 +148,7 @@ class JiraFormattedMatchString(BasicMatchString):
     def _add_match_items(self):
         match_items = dict([(x, y) for x, y in self.match.items() if not x.startswith('top_events_')])
         json_blob = self._pretty_print_as_json(match_items)
-        preformatted_text = u'{{code:json}}{0}{{code}}'.format(json_blob)
+        preformatted_text = u'{{code}}{0}{{code}}'.format(json_blob)
         self.text += preformatted_text
 
 

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -77,7 +77,7 @@ def test_jira_formatted_match_string(ea):
     match = {'foo': {'bar': ['one', 2, 'three']}, 'top_events_poof': 'phew'}
     alert_text = str(JiraFormattedMatchString(ea.rules[0], match))
     tab = 4 * ' '
-    expected_alert_text_snippet = '{code:json}{\n' \
+    expected_alert_text_snippet = '{code}{\n' \
         + tab + '"foo": {\n' \
         + 2 * tab + '"bar": [\n' \
         + 3 * tab + '"one", \n' \


### PR DESCRIPTION
JIRA enforces this formatter and if the text is not real JSON, this causes issues.