### PR TITLE
Clarify CLI message

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ To get started, check out `Running ElastAlert For The First Time` in the [docume
 
 ``$ python elastalert/elastalert.py [--debug] [--verbose] [--start <timestamp>] [--end <timestamp>] [--rule <filename.yaml>] [--config <filename.yaml>]``
 
-``--debug`` will print additional information to the screen as well as suppresses alerts and instead prints the alert body.
+``--debug`` will print additional information to the screen as well as suppresses alerts and instead prints the alert body. Not compatible with `--verbose`.
 
-``--verbose`` will print additional information without supressing alerts.
+``--verbose`` will print additional information without suppressing alerts. Not compatible with `--debug.`
 
 ``--start`` will begin querying at the given timestamp. By default, ElastAlert will begin querying from the present.
 Timestamp format is ``YYYY-MM-DDTHH-MM-SS[-/+HH:MM]`` (Note the T between date and hour).

--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -201,7 +201,10 @@ Several arguments are available when running ElastAlert:
 
 ``--debug`` will run ElastAlert in debug mode. This will increase the logging verboseness, change
 all alerts to ``DebugAlerter``, which prints alerts and suppresses their normal action, and skips writing
-search and alert metadata back to Elasticsearch.
+search and alert metadata back to Elasticsearch. Not compatible with `--verbose`.
+
+``--verbose`` will increase the logging verboseness, which allows you to see information about the state
+of queries. Not compatible with `--debug`.
 
 ``--start <timestamp>`` will force ElastAlert to begin querying from the given time, instead of the default,
 querying from the present. The timestamp should be ISO8601, e.g.  ``YYYY-MM-DDTHH:MM:SS`` (UTC) or with timezone
@@ -217,9 +220,6 @@ or its subdirectories.
 ``--silence <unit>=<number>`` will silence the alerts for a given rule for a period of time. The rule must be specified using
 ``--rule``. <unit> is one of days, weeks, hours, minutes or seconds. <number> is an integer. For example,
 ``--rule noisy_rule.yaml --silence hours=4`` will stop noisy_rule from generating any alerts for 4 hours.
-
-``--verbose`` will increase the logging verboseness, which allows you to see information about the state
-of queries.
 
 ``--es_debug`` will enable logging for all queries made to Elasticsearch.
 

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -71,14 +71,16 @@ class ElastAlerter():
             dest='config',
             default="config.yaml",
             help='Global config file (default: config.yaml)')
-        parser.add_argument('--debug', action='store_true', dest='debug', help='Suppresses alerts and prints information instead')
+        parser.add_argument('--debug', action='store_true', dest='debug', help='Suppresses alerts and prints information instead. '
+                                                                               'Not compatible with `--verbose`')
         parser.add_argument('--rule', dest='rule', help='Run only a specific rule (by filename, must still be in rules folder)')
         parser.add_argument('--silence', dest='silence', help='Silence rule for a time period. Must be used with --rule. Usage: '
                                                               '--silence <units>=<number>, eg. --silence hours=2')
         parser.add_argument('--start', dest='start', help='YYYY-MM-DDTHH:MM:SS Start querying from this timestamp.'
                                                           'Use "NOW" to start from current time. (Default: present)')
         parser.add_argument('--end', dest='end', help='YYYY-MM-DDTHH:MM:SS Query to this timestamp. (Default: present)')
-        parser.add_argument('--verbose', action='store_true', dest='verbose', help='Increase verbosity without suppressing alerts')
+        parser.add_argument('--verbose', action='store_true', dest='verbose', help='Increase verbosity without suppressing alerts. '
+                                                                                   'Not compatible with `--debug`')
         parser.add_argument('--patience', action='store', dest='timeout',
                             type=parse_duration,
                             default=datetime.timedelta(),
@@ -102,12 +104,18 @@ class ElastAlerter():
         self.debug = self.args.debug
         self.verbose = self.args.verbose
 
+        if self.verbose and self.debug:
+            elastalert_logger.info(
+                "Note: --debug and --verbose flags are set. --debug takes precedent."
+            )
+
         if self.verbose or self.debug:
             elastalert_logger.setLevel(logging.INFO)
 
         if self.debug:
             elastalert_logger.info(
-                "Note: In debug mode, alerts will be logged to console but NOT actually sent. To send them, use --verbose instead of --debug."
+                """Note: In debug mode, alerts will be logged to console but NOT actually sent.
+                To send them but remain verbose, use --verbose instead."""
             )
 
         if not self.args.es_debug:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -107,7 +107,7 @@ class ElastAlerter():
 
         if self.debug:
             elastalert_logger.info(
-                "Note: In debug mode, alerts will be logged to console but NOT actually sent. To send them, use --verbose."
+                "Note: In debug mode, alerts will be logged to console but NOT actually sent. To send them, use --verbose instead of --debug."
             )
 
         if not self.args.es_debug:


### PR DESCRIPTION
This one has always been a little unclear and every time I start a new ElastAlert instance from scratch with new rules, I end up using debug/verbose modes and for some reason I end up thinking they can both run simultaneously. This clarifies the CLI message so I remember sooner.