### PR TITLE
Added ability to use nested fields in command alerter

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -27,6 +27,7 @@ from twilio.base.exceptions import TwilioRestException
 from twilio.rest import Client as TwilioClient
 from util import EAException
 from util import elastalert_logger
+from util import extend_flatten
 from util import lookup_es_key
 from util import pretty_ts
 from util import ts_now
@@ -818,10 +819,11 @@ class CommandAlerter(Alerter):
     def alert(self, matches):
         # Format the command and arguments
         try:
+            flattened_dict = extend_flatten(matches[0])
             if self.new_style_string_format:
-                command = [command_arg.format(match=matches[0]) for command_arg in self.rule['command']]
+                command = [command_arg.format(match=flattened_dict) for command_arg in self.rule['command']]
             else:
-                command = [command_arg % matches[0] for command_arg in self.rule['command']]
+                command = [command_arg % flattened_dict for command_arg in self.rule['command']]
             self.last_command = command
         except KeyError as e:
             raise EAException("Error formatting command: %s" % (e))

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import copy
 import datetime
 import logging
 import os
@@ -364,3 +365,26 @@ def parse_deadline(value):
     """Convert ``unit=num`` spec into a ``datetime`` object."""
     duration = parse_duration(value)
     return ts_now() + duration
+
+
+def flatten_dict(dct, delim='.', prefix='', level=0, max_level=0):
+    ret = {}
+    for key, val in dct.items():
+        if type(val) == dict and (not max_level or level < max_level):
+            ret.update(flatten_dict(val, delim, prefix + key + delim, level + 1, max_level))
+        else:
+            ret[prefix + key] = val
+    return ret
+
+
+def extend_flatten(dct, delim='.', levels=3):
+    """ Flattens a dictionary using a delimiter while also maintaining the original structure.
+    Also contains partially flattening up to a level.
+    Returns a deepcopy of the original dictionary.
+    {'a': {'b': {'c': 'd'}}} ->
+    {'a': {'b': 'c'}, 'a.b': 'c', 'a.b.c': 'd'}
+    """
+    flattened = copy.deepcopy(dct)
+    for x in range(levels):
+        flattened.update(flatten_dict(dct, max_level=x))
+    return flattened

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,20 +1,22 @@
 # -*- coding: utf-8 -*-
-from elastalert.util import lookup_es_key, set_es_key, add_raw_postfix, replace_dots_in_field_names
-from elastalert.util import (
-    parse_deadline,
-    parse_duration,
-)
+from datetime import datetime
+from datetime import timedelta
+
 import mock
 import pytest
-from datetime import (
-    datetime,
-    timedelta,
-)
 from dateutil.parser import parse as dt
+
+from elastalert.util import add_raw_postfix
+from elastalert.util import extend_flatten
+from elastalert.util import lookup_es_key
+from elastalert.util import parse_deadline
+from elastalert.util import parse_duration
+from elastalert.util import replace_dots_in_field_names
+from elastalert.util import set_es_key
 
 
 @pytest.mark.parametrize('spec, expected_delta', [
-    ('hours=2',    timedelta(hours=2)),
+    ('hours=2', timedelta(hours=2)),
     ('minutes=30', timedelta(minutes=30)),
     ('seconds=45', timedelta(seconds=45)),
 ])
@@ -24,7 +26,7 @@ def test_parse_duration(spec, expected_delta):
 
 
 @pytest.mark.parametrize('spec, expected_deadline', [
-    ('hours=2',    dt('2017-07-07T12:00:00.000Z')),
+    ('hours=2', dt('2017-07-07T12:00:00.000Z')),
     ('minutes=30', dt('2017-07-07T10:30:00.000Z')),
     ('seconds=45', dt('2017-07-07T10:00:45.000Z')),
 ])
@@ -139,3 +141,10 @@ def test_replace_dots_in_field_names(ea):
     }
     assert replace_dots_in_field_names(actual) == expected
     assert replace_dots_in_field_names({'a': 0, 1: 2}) == {'a': 0, 1: 2}
+
+
+def test_extend_flatten():
+    original = {'a': {'b': {'c': 'd'}, 'e': {'f': 'g'}}, 'h': {'i': 'j'}}
+    expected = {'a': {'b': {'c': 'd'}, 'e': {'f': 'g'}}, 'a.e': {'f': 'g'},
+                'a.b.c': 'd', 'a.b': {'c': 'd'}, 'h.i': 'j', 'h': {'i': 'j'}, 'a.e.f': 'g'}
+    assert extend_flatten(original) == expected


### PR DESCRIPTION
Add a function to flatten dictionaries to allow basic string formatters to work.

Ex:

match = {'a': {'b': 'c'}}

command = ['echo', '%(a.b)s']
=
``echo c``

command = ['echo', '%(a)s']
=
``echo {'b': 'c'}``

