### PR TITLE
allow hipchat_room_id to be an integer

### DIFF
--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -214,7 +214,7 @@ properties:
 
   ### HipChat
   hipchat_auth_token: {type: string}
-  hipchat_room_id: {type: string}
+  hipchat_room_id: {type: [string, integer]}
   hipchat_domain: {type: string}
   hipchat_ignore_ssl_errors: {type: boolean}
   hipchat_notify: {type: boolean}
@@ -265,4 +265,3 @@ properties:
   ### Simple
   simple_webhook_url: *arrayOfString
   simple_proxy: {type: string}
-


### PR DESCRIPTION
hipchat_room_id is supposed to be a number. Strings work too but require you to put quotes around it or else it wouldn't pass the schema.