### PR TITLE
Support sub aggregations for the metric_aggregation ruletype

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -258,7 +258,8 @@ class ElastAlerter():
             aggs_element = metric_agg_element
 
         if query_key is not None:
-            aggs_element = {'bucket_aggs': {'terms': {'field': query_key, 'size': terms_size}, 'aggs': aggs_element}}
+            for idx, key in reversed(list(enumerate(query_key.split(',')))):
+                aggs_element = {'bucket_aggs' : {'terms': {'field': key, 'size': terms_size}, 'aggs': aggs_element}}
 
         if not rule['five']:
             query_element['filtered'].update({'aggs': aggs_element})

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -259,7 +259,7 @@ class ElastAlerter():
 
         if query_key is not None:
             for idx, key in reversed(list(enumerate(query_key.split(',')))):
-                aggs_element = {'bucket_aggs' : {'terms': {'field': key, 'size': terms_size}, 'aggs': aggs_element}}
+                aggs_element = {'bucket_aggs': {'terms': {'field': key, 'size': terms_size}, 'aggs': aggs_element}}
 
         if not rule['five']:
             query_element['filtered'].update({'aggs': aggs_element})

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -976,8 +976,6 @@ class MetricAggregationRule(BaseAggregationRule):
 
     def check_matches(self, timestamp, query_key, aggregation_data):
         if "compound_query_key" in self.rules:
-            #self.add_match({'cpu_pct_avg': 0.91, 'qk': 'qk_val', '@timestamp': datetime.datetime.now(), 'sub_qk': 'sub_qk_val1'})
-            #self.add_match({'cpu_pct_avg': 0.95, 'qk': 'qk_val', '@timestamp': datetime.datetime.now(), 'sub_qk': 'sub_qk_val2'})
             self.check_matches_recursive(timestamp, query_key, aggregation_data, self.rules['compound_query_key'], dict())
 
         else:

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -54,11 +54,8 @@ class RuleType(object):
         ts = self.rules.get('timestamp_field')
         if ts in event:
             event[ts] = dt_to_ts(event[ts])
-        
-        print "appending: '%s' to matches" % event
-        print "before: length: '%d' value: %s" % (len(self.matches), self.matches)
+
         self.matches.append(copy.deepcopy(event))
-        print "after: length: '%d' value: %s" % (len(self.matches), self.matches)
 
     def get_match_str(self, match):
         """ Returns a string that gives more context about a match.
@@ -1011,6 +1008,10 @@ class MetricAggregationRule(BaseAggregationRule):
             if self.crossed_thresholds(metric_val):
                 match_data[self.rules['timestamp_field']] = timestamp
                 match_data[self.metric_key] = metric_val
+
+                # add compound key to payload to allow alerts to trigger for every unique occurence
+                compound_value = [match_data[key] for key in self.rules['compound_query_key']]
+                match_data[self.rules['query_key']] = ",".join(compound_value)
 
                 self.add_match(match_data)
 

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -1079,6 +1079,7 @@ def test_metric_aggregation():
     rule.check_matches(datetime.datetime.now(), 'qk_val', {'cpu_pct_avg': {'value': 0.95}})
     assert rule.matches[0]['qk'] == 'qk_val'
 
+
 def test_metric_aggregation_complex_query_key():
     rules = {'buffer_time': datetime.timedelta(minutes=5),
              'timestamp_field': '@timestamp',
@@ -1088,8 +1089,14 @@ def test_metric_aggregation_complex_query_key():
              'query_key': 'qk,sub_qk',
              'max_threshold': 0.8}
 
+    query = {"bucket_aggs": {"buckets": [
+        {"cpu_pct_avg": {"value": 0.91}, "key": "sub_qk_val1"},
+        {"cpu_pct_avg": {"value": 0.95}, "key": "sub_qk_val2"},
+        {"cpu_pct_avg": {"value": 0.89}, "key": "sub_qk_val3"}]
+                            }, "key": "qk_val"}
+
     rule = MetricAggregationRule(rules)
-    rule.check_matches(datetime.datetime.now(), 'qk_val', {"bucket_aggs":{"buckets":[{"cpu_pct_avg":{"value":0.91},"key":"sub_qk_val1"},{"cpu_pct_avg":{"value":0.95},"key":"sub_qk_val2"},{"cpu_pct_avg":{"value":0.89},"key":"sub_qk_val3"}]},"key":"qk_val"})
+    rule.check_matches(datetime.datetime.now(), 'qk_val', query)
     assert len(rule.matches) == 3
     assert rule.matches[0]['qk'] == 'qk_val'
     assert rule.matches[1]['qk'] == 'qk_val'


### PR DESCRIPTION
**Summary**
This pull request adds support for compounded query keys to the metric_aggregation rule type by generating sub aggregate queries based on the key values.

**Use Case**
We monitor a lot of dynamic hosts/instances. Rather than creating a rule per host we can use the compound query key functionality to write a single rule that will generate a unique alert for each instance/host that breaks a threshold.

**Example Configuration**
```name: "Disk free threshold"
index: metricbeat-*
type: metric_aggregation

buffer_time:
  minutes: 5

metric_agg_key: system.filesystem.used.pct
metric_agg_type: avg
query_key:
  - meta.cloud.instance_id
  - system.filesystem.device_name

doc_type: metricsets
```

