### PR TITLE
Run time

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -101,6 +101,10 @@ Rule Configuration Cheat Sheet
 | ``alert_text_args`` (array of strs)                          |           |
 +--------------------------------------------------------------+           |
 | ``alert_text_kw`` (object)                                   |           |
++--------------------------------------------------------------+           |
+| ``runt_time`` (array of strs)                                |           |
++--------------------------------------------------------------+           |
+| ``run_time_format`` (string, default "%H:%M:%S)              |           |
 +--------------------------------------------------------------+-----------+
 
 |
@@ -571,6 +575,25 @@ see above for more details. (Optional, boolean, default True)
 
 Some rules and alerts require additional options, which also go in the top level of the rule configuration file.
 
+run_time
+^^^^^^^^
+
+Configures array of wall clock times (UTC) for running rules. If current time is from ``start`` to ``end``, rule is run, it will be skipped other case.
+Optionally, ``week_day``  ( "mon", "tue", "wed", "thu", "fri", "sat", "sun" ) can be specified.
+
+example: running rule all days from 00:00:00 to 01:00:00 and mondays + fridays from 13:00:00 to 20:00:00
+
+run_time:
+  - start: "00:00:00"
+    end: "01:00:00"
+  - start: "13:00:00"
+    end: "20:00:00"
+    week_day: ["mon", "fri"]
+
+run_time_format
+^^^^^^^^^^^^^^^
+
+Specifies time format for ``start`` and ``end`` properties of ``run_time`` (default "%H:%M:%S")
 
 .. _testing :
 

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -29,6 +29,7 @@ from elasticsearch.exceptions import TransportError
 from enhancements import DropMatchException
 from ruletypes import FlatlineRule
 from util import add_raw_postfix
+from util import checkRunTime
 from util import cronite_datetime_to_timestamp
 from util import dt_to_ts
 from util import dt_to_unix
@@ -1065,6 +1066,9 @@ class ElastAlerter():
         next_run = datetime.datetime.utcnow() + self.run_every
 
         for rule in self.rules:
+            if not checkRunTime(rule.get('run_time'), ts_now()):
+                elastalert_logger.info("Not ran %s because run_time configuration." % (rule['name']))
+                continue
             # Set endtime based on the rule's delay
             delay = rule.get('query_delay')
             if hasattr(self.args, 'end') and self.args.end:

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -24,6 +24,7 @@ definitions:
       schedule: {type: string}
 
   filter: &filter {}
+  run_time: &run_time {}
 
 required: [type, index, alert]
 type: object
@@ -174,6 +175,24 @@ properties:
   match_enhancements: {type: array, items: {type: string}}
   query_key: *arrayOfString
   replace_dots_in_field_names: {type: boolean}
+  run_time_format :
+    type: [ string ]
+  run_time :
+    type: [array, object]
+    items: *run_time
+    properties:
+      week_day:
+        type: [array, string]
+        enum: ["mon","tue", "wed", "thu", "fri", "sat", "sun"]
+      start:
+        type: string
+        format: time
+      end:
+        type: string
+        format: time
+    additionalProperties: false
+    required: ["start","end"]
+
 
   # Alert Content
   alert_text: {type: string} # Python format string
@@ -265,4 +284,3 @@ properties:
   ### Simple
   simple_webhook_url: *arrayOfString
   simple_proxy: {type: string}
-

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -364,3 +364,23 @@ def parse_deadline(value):
     """Convert ``unit=num`` spec into a ``datetime`` object."""
     duration = parse_duration(value)
     return ts_now() + duration
+
+
+def checkRunTime(runTime, currentDatetime=ts_now(), runTimeFormat="%H:%M:%S"):
+    if not runTime:
+        return True
+    days = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+    currentDayWeek = currentDatetime.weekday()
+    currentTime = currentDatetime.time()
+    if not isinstance(runTime, list):
+        runTime = [runTime]
+    for runTimeRule in runTime:
+        ruleWeekday = runTimeRule.get('week_day')
+
+        if ruleWeekday and not days[currentDayWeek] in ruleWeekday:
+            continue
+        start = datetime.datetime.strptime(runTimeRule['start'], runTimeFormat).time()
+        end = datetime.datetime.strptime(runTimeRule['end'], runTimeFormat).time()
+        if start <= currentTime <= end:
+            return True
+    return False


### PR DESCRIPTION
From time to time, we need to run rules only on range time basis, example in working hours. This pull request adds run_time (and run_time_format) to achieve this.

example configuration: running rule all days from 00:00:00 to 01:00:00 and mondays + fridays from 13:00:00 to 20:00:00

run_time:
  - start: "00:00:00"
    end: "01:00:00"
  - start: "13:00:00"
    end: "20:00:00"
    week_day: ["mon", "fri"]
