### PR TITLE
Adding opsgenie alert subject with num_hits

### DIFF
--- a/elastalert/opsgenie.py
+++ b/elastalert/opsgenie.py
@@ -6,6 +6,7 @@ from alerts import Alerter
 from alerts import BasicMatchString
 from util import EAException
 from util import elastalert_logger
+from util import lookup_es_key
 
 
 class OpsGenieAlerter(Alerter):
@@ -22,6 +23,8 @@ class OpsGenieAlerter(Alerter):
         self.tags = self.rule.get('opsgenie_tags', []) + ['ElastAlert', self.rule['name']]
         self.to_addr = self.rule.get('opsgenie_addr', 'https://api.opsgenie.com/v1/json/alert')
         self.custom_message = self.rule.get('opsgenie_message')
+        self.opsgenie_subject = self.rule.get('opsgenie_subject')
+        self.opsgenie_subject_args = self.rule.get('opsgenie_subject_args')
         self.alias = self.rule.get('opsgenie_alias')
         self.opsgenie_proxy = self.rule.get('opsgenie_proxy', None)
 
@@ -34,7 +37,7 @@ class OpsGenieAlerter(Alerter):
                 body += '\n----------------------------------------\n'
 
         if self.custom_message is None:
-            self.message = self.create_default_title(matches)
+            self.message = self.create_title(matches)
         else:
             self.message = self.custom_message.format(**matches[0])
 
@@ -82,6 +85,30 @@ class OpsGenieAlerter(Alerter):
                 subject += ' - %s' % (qk)
 
         return subject
+
+    def create_title(self, matches):
+        """ Creates custom alert title to be used as subject for opsgenie alert."""
+        if self.opsgenie_subject:
+            return self.create_custom_title(matches)
+
+        return self.create_default_title(matches)
+
+    def create_custom_title(self, matches):
+        opsgenie_subject = unicode(self.rule['opsgenie_subject'])
+
+        if self.opsgenie_subject_args:
+            opsgenie_subject_values = [lookup_es_key(matches[0], arg) for arg in self.opsgenie_subject_args]
+
+            for i in xrange(len(opsgenie_subject_values)):
+                if opsgenie_subject_values[i] is None:
+                    alert_value = self.rule.get(self.opsgenie_subject_args[i])
+                    if alert_value:
+                        opsgenie_subject_values[i] = alert_value
+
+            opsgenie_subject_values = ['<MISSING VALUE>' if val is None else val for val in opsgenie_subject_values]
+            return opsgenie_subject.format(*opsgenie_subject_values)
+
+        return opsgenie_subject
 
     def get_info(self):
         ret = {'type': 'opsgenie'}


### PR DESCRIPTION
Currently opsgenie alert only allows custom message or default title with query_key to be added to subject. 

* Adding num_hits with opsgenie_subject and opsgenie_subject_args . Tested and works in our opsgenie alerting system.