### PR TITLE
fix for must_not

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -210,7 +210,9 @@ class ElastAlerter():
         starttime = to_ts_func(starttime)
         endtime = to_ts_func(endtime)
         filters = copy.copy(filters)
-        es_filters = {'filter': {'bool': {'must': filters}}}
+        must_filters = [x for x in filters if 'must_not' not in x]
+        must_not_filters = [x for x in filters if 'must_not' in x]
+        es_filters = {'filter': {'bool': {'must': must_filters, 'must_not': must_not_filters}}}
         if starttime and endtime:
             es_filters['filter']['bool']['must'].insert(0, {'range': {timestamp_field: {'gt': starttime,
                                                                                         'lte': endtime}}})


### PR DESCRIPTION
You could not say:
filter:
     must_not: 
              other_criteria

because everything would go under a global "must": array. This fix addresses the issue, essentially exposing the must_not part of the DSL to ElastAlert. Any other type of query is treated as before, going inside the "must" array. 