### PR TITLE
Ensured run_every is not overwritten when alert is created or modified

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -877,12 +877,13 @@ class ElastAlerter():
                            'aggregate_alert_time',
                            'processed_hits',
                            'starttime',
-                           'minimum_starttime',
-                           'run_every']
+                           'minimum_starttime']
         for prop in copy_properties:
             if prop not in rule:
                 continue
             new_rule[prop] = rule[prop]
+        if 'run_every' not in new_rule:
+            new_rule['run_every'] = rule['run_every']
 
         self.scheduler.add_job(self.handle_rule_execution, 'interval', args=[new_rule],
                                seconds=new_rule['run_every'].total_seconds(), id=new_rule['name'])

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -919,6 +919,7 @@ class ElastAlerter():
             if rule_file not in new_rule_hashes:
                 # Rule file was deleted
                 elastalert_logger.info('Rule file %s not found, stopping rule execution' % (rule_file))
+                self.scheduler.remove_job(rule_file.split("/")[-1].replace(".yaml", ""))
                 self.rules = [rule for rule in self.rules if rule['rule_file'] != rule_file]
                 continue
             if hash_value != new_rule_hashes[rule_file]:

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -286,14 +286,18 @@ class FrequencyRule(RuleType):
                                                                          endtime)
         return message
 
-
 class AnyRule(RuleType):
     """ A rule that will match on any input data """
+    def add_terms_data(self, terms):
+        for timestamp, buckets in terms.iteritems():
+            for bucket in buckets:
+                event = {self.rules['timestamp_field']: timestamp,
+                          self.rules['query_key']: bucket['key'], 'count': bucket['doc_count']}
+                self.add_match(event)
 
     def add_data(self, data):
         for datum in data:
             self.add_match(datum)
-
 
 class EventWindow(object):
     """ A container for hold event counts for rules which need a chronological ordered event window. """


### PR DESCRIPTION
I ensured that run_every is not overwritten. After some tests I found out that all alerts where run at the same time. This happend because when an alert was created or modified the run_every field become self.run_every, completly ignoring the value in alert file.