### PR TITLE
Fixed a bug that would cause enhancements to run multiple times

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1449,7 +1449,7 @@ class ElastAlerter():
                 else:
                     # If this rule isn't using aggregation, this must be a retry of a failed alert
                     retried = False
-                    if 'aggregation' not in rule:
+                    if not rule.get('aggregation'):
                         retried = True
                     self.alert([match_body], rule, alert_time=alert_time, retried=retried)
 


### PR DESCRIPTION
This fixes a bug that was in https://github.com/Yelp/elastalert/pull/1263

The default value of 'aggregation' is actually timedelta(0) rather than non-existent. https://github.com/Yelp/elastalert/blob/master/elastalert/config.py#L192