### PR TITLE
Fix bug using es 5 plus query_key plus top_count_keys

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1157,7 +1157,7 @@ class ExotelAlerter(Alerter):
             response = client.sms(self.rule['exotel_from_number'], self.rule['exotel_to_number'], message_body)
             if response != 200:
                 raise EAException("Error posting to Exotel, response code is %s" % response)
-        except:
+        except RequestException:
             raise EAException("Error posting to Exotel"), None, sys.exc_info()[2]
         elastalert_logger.info("Trigger sent to Exotel")
 

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -446,7 +446,7 @@ class ElastAlerter():
                 end = '.keyword'
             else:
                 end = '.raw'
-            if rule.get('raw_count_keys', True) and not rule['query_key'].endswith(end) and not rule['five']:
+            if rule.get('raw_count_keys', True) and not rule['query_key'].endswith(end):
                 filter_key = add_raw_postfix(filter_key, rule['five'])
             rule_filter.extend([{'term': {filter_key: qk}}])
         base_query = self.get_query(

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1464,7 +1464,7 @@ class ElastAlerter():
                     self.writeback_es.delete(index=self.writeback_index,
                                              doc_type='elastalert',
                                              id=_id)
-                except:  # TODO: Give this a more relevant exception, try:except: is evil.
+                except ElasticsearchException:  # TODO: Give this a more relevant exception, try:except: is evil.
                     self.handle_error("Failed to delete alert %s at %s" % (_id, alert_time))
 
         # Send in memory aggregated alerts


### PR DESCRIPTION
Fixes #1392 

We need to add '.raw' or '.keyword' to this extra filter, but we were skipping that if ES5 was detected for some reason.