### PR TITLE
add socks5 proxy support for sending email

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1258,6 +1258,8 @@ by the smtp server.
 
 ``bcc``: This adds the BCC emails to the list of recipients but does not show up in the email message. By default, this is left empty.
 
+``socks5addr``: Socks5 proxy addr to send email, eg: 10.0.0.1:1080
+
 Jira
 ~~~~
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -3,6 +3,8 @@ import copy
 import datetime
 import json
 import logging
+import smtplib
+import socks
 import subprocess
 import sys
 import warnings
@@ -387,6 +389,12 @@ class EmailAlerter(Alerter):
         add_suffix = self.rule.get('email_add_domain')
         if add_suffix and not add_suffix.startswith('@'):
             self.rule['email_add_domain'] = '@' + add_suffix
+
+        # set socks5 addr for sending email if set
+        if self.conf['socks5addr'] :
+            tl = self.conf['socks5addr']
+            socks.setdefaultproxy(socks.PROXY_TYPE_SOCKS5, tl[0], int(tl[1]))
+            socks.wrapmodule(smtplib)
 
     def alert(self, matches):
         body = self.create_alert_body(matches)

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -6,6 +6,8 @@ import json
 import logging
 import os
 import signal
+import smtplib
+import socks
 import sys
 import time
 import timeit
@@ -154,6 +156,12 @@ class ElastAlerter():
 
         self.writeback_es = elasticsearch_client(self.conf)
         self._es_version = None
+
+        # set socks5 addr for sending email if set
+        if self.conf['socks5addr'] :
+            tl = self.conf['socks5addr']
+            socks.setdefaultproxy(socks.PROXY_TYPE_SOCKS5, tl[0], int(tl[1]))
+            socks.wrapmodule(smtplib)
 
         remove = []
         for rule in self.rules:


### PR DESCRIPTION
Sometimes elastalert is deployed in a machine doesn't has direct internet access. Thus a socks proxy is necessary, this merge add the support of socks5 proxy.