### PR TITLE
Fix dt_to_unix to return a int and avoid scientific notation on serialization

### DIFF
--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -233,7 +233,7 @@ def unix_to_dt(ts):
 
 
 def dt_to_unix(dt):
-    return total_seconds(dt - datetime.datetime(1970, 1, 1, tzinfo=dateutil.tz.tzutc()))
+    return int(total_seconds(dt - datetime.datetime(1970, 1, 1, tzinfo=dateutil.tz.tzutc())))
 
 
 def dt_to_unixms(dt):


### PR DESCRIPTION
This change fixes the epoch_seconds searialization to avoid scientific
notations and parse errors with Elasticsearch as seen before on #996.