### PR TITLE
Use writeback_index from config file in create-elastalert-index

### DIFF
--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -73,6 +73,8 @@ def main():
         ca_certs = data.get('ca_certs')
         client_cert = data.get('client_cert')
         client_key = data.get('client_key')
+        index = args.index if args.index is not None else data.get('writeback_index')
+        old_index = args.old_index if args.old_index is not None else None
     else:
         username = args.username if args.username else None
         password = args.password if args.password else None
@@ -95,6 +97,11 @@ def main():
         ca_certs = None
         client_cert = None
         client_key = None
+        index = args.index if args.index is not None else raw_input('New index name? (Default elastalert_status) ')
+        if not index:
+            index = 'elastalert_status'
+        old_index = (args.old_index if args.old_index is not None
+                     else raw_input('Name of existing index to copy? (Default None) '))
 
     timeout = args.timeout
     auth = Auth()
@@ -134,13 +141,6 @@ def main():
                                                        'aggregate_id': {'index': 'not_analyzed', 'type': 'string'}}}}
     error_mapping = {'elastalert_error': {'properties': {'data': {'type': 'object', 'enabled': False},
                                                          '@timestamp': {'format': 'dateOptionalTime', 'type': 'date'}}}}
-
-    index = args.index if args.index is not None else raw_input('New index name? (Default elastalert_status) ')
-    if not index:
-        index = 'elastalert_status'
-
-    old_index = (args.old_index if args.old_index is not None
-                 else raw_input('Name of existing index to copy? (Default None) '))
 
     es_index = IndicesClient(es)
     if es_index.exists(index):


### PR DESCRIPTION
If config file passed, we can use `writeback_index` from config file for elastalert index creation and use `old_index` only if it was explicitly passed as command line option. 
This can be useful for docker image creation because we need to create index on first run,  so it helps to avoid hacks such as copying `writeback_index` (as envvar an config option) and  `--old-index=""`