### PR TITLE
When running in debug mode, don't instantiate alerts

### DIFF
--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -343,8 +343,10 @@ def load_modules(rule, args=None):
         rule['type'] = rule['type'](rule, args)
     except (KeyError, EAException) as e:
         raise EAException('Error initializing rule %s: %s' % (rule['name'], e)), None, sys.exc_info()[2]
-    # Instantiate alert
-    rule['alert'] = load_alerts(rule, alert_field=rule['alert'])
+    # Instantiate alerts only if we're not in debug mode
+    # In debug mode alerts are not actually sent so don't bother instantiating them
+    if not args or not args.debug:
+        rule['alert'] = load_alerts(rule, alert_field=rule['alert'])
 
 
 def isyaml(filename):

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -204,7 +204,11 @@ class MockElastAlerter(object):
         """ Creates an ElastAlert instance and run's over for a specific rule using either real or mock data. """
 
         # Load and instantiate rule
-        load_modules(rule)
+        # Pass an args containing the context of whether we're alerting or not
+        # It is needed to prevent unnecessary initialization of unused alerters
+        load_modules_args = argparse.Namespace()
+        load_modules_args.debug = not args.alert
+        load_modules(rule, load_modules_args)
         conf['rules'] = [rule]
 
         # If using mock data, make sure it's sorted and find appropriate time range

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -44,6 +44,7 @@ test_rule = {'es_host': 'test_host',
 test_args = mock.Mock()
 test_args.config = 'test_config'
 test_args.rule = None
+test_args.debug = False
 
 
 def test_import_rules():


### PR DESCRIPTION
`elastalert-test-rule` allows you to test a rule from your development environment without actually sending alerts. Elastalert always initializes the alerts from the rules even when running in debug mode. Some alerts have external dependencies (e.g. `jira_creds_file`) and will make the `elastalert-test-rule` tool error out when those resources are not present from the testing machine.

This change propagates the intention of the `--alert` parameter in `elastalert-test-rule` to elastalert's `--debug` parameter, and has elastalert skip initializing the alerts when running in debug mode.

`make test` works right now. I'll try to add an explicit test for the new functionality too.

I also verified that with these changes, I can successfully run a rule that uses a jira alert:

```
$ # Should still fail if we pass the --alert flag, since this will preserve the existing behavior
$ elastalert-test-rule --alert my_rule.yaml
Successfully loaded Test rule

Got 30 hits from the last 1 day

Available terms in first hit:
        @timestamp
        [...]

Traceback (most recent call last):
  File "/home/dpopes/test/venv/bin/elastalert-test-rule", line 11, in <module>
    sys.exit(main())
  File "/home/dpopes/test/venv/local/lib/python2.7/site-packages/elastalert/test_rule.py", line 378, in main
    test_instance.run_rule_test()
  File "/home/dpopes/test/venv/local/lib/python2.7/site-packages/elastalert/test_rule.py", line 373, in run_rule_test
    self.run_elastalert(rule_yaml, conf, args)
  File "/home/dpopes/test/venv/local/lib/python2.7/site-packages/elastalert/test_rule.py", line 211, in run_elastalert
    load_modules(rule, load_modules_args)
  File "/home/dpopes/test/venv/local/lib/python2.7/site-packages/elastalert/config.py", line 347, in load_modules
    rule['alert'] = load_alerts(rule, alert_field=rule['alert'])
  File "/home/dpopes/test/venv/local/lib/python2.7/site-packages/elastalert/config.py", line 405, in load_alerts
    alert_field = [create_alert(a, b) for a, b in alert_field]
  File "/home/dpopes/test/venv/local/lib/python2.7/site-packages/elastalert/config.py", line 396, in create_alert
    return alert_class(alert_config)
  File "/home/dpopes/test/venv/local/lib/python2.7/site-packages/elastalert/alerts.py", line 506, in __init__
    self.get_account(self.rule['jira_account_file'])
  File "/home/dpopes/test/venv/local/lib/python2.7/site-packages/elastalert/alerts.py", line 288, in get_account
    account_conf = yaml_loader(account_file)
  File "/home/dpopes/test/venv/local/lib/python2.7/site-packages/staticconf/loader.py", line 167, in yaml_loader
    with open(filename) as fh:
IOError: [Errno 2] No such file or directory: '/code/jira_creds.yaml'

$ # if we don't pass the --alert flag, then the alerts will not be created and the rule can be executed
$ elastalert-test-rule my_rule.yaml
Successfully loaded Google - Gmail Settings Change

Got 30 hits from the last 1 day

Available terms in first hit:
        @timestamp
        [...]

INFO:elastalert:Note: In debug mode, alerts will be logged to console but NOT actually sent.
                To send them but remain verbose, use --verbose instead.
INFO:elastalert:Queried rule Test rule from 2017-11-03 12:39 PDT to 2017-11-03 13:24 PDT: 0 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-03 13:24 PDT to 2017-11-03 14:09 PDT: 1 / 1 hits
INFO:elastalert:Queried rule Test rule from 2017-11-03 14:09 PDT to 2017-11-03 14:54 PDT: 5 / 4 hits
INFO:elastalert:Queried rule Test rule from 2017-11-03 14:54 PDT to 2017-11-03 15:39 PDT: 11 / 6 hits
INFO:elastalert:Queried rule Test rule from 2017-11-03 15:39 PDT to 2017-11-03 16:24 PDT: 26 / 15 hits
INFO:elastalert:Queried rule Test rule from 2017-11-03 16:24 PDT to 2017-11-03 17:09 PDT: 29 / 3 hits
INFO:elastalert:Queried rule Test rule from 2017-11-03 17:09 PDT to 2017-11-03 17:54 PDT: 29 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-03 17:54 PDT to 2017-11-03 18:39 PDT: 29 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-03 18:39 PDT to 2017-11-03 19:24 PDT: 29 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-03 19:24 PDT to 2017-11-03 20:09 PDT: 29 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-03 20:09 PDT to 2017-11-03 20:54 PDT: 29 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-03 20:54 PDT to 2017-11-03 21:39 PDT: 29 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-03 21:39 PDT to 2017-11-03 22:24 PDT: 29 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-03 22:24 PDT to 2017-11-03 23:09 PDT: 29 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-03 23:09 PDT to 2017-11-03 23:54 PDT: 29 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-03 23:54 PDT to 2017-11-04 00:39 PDT: 29 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-04 00:39 PDT to 2017-11-04 01:24 PDT: 29 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-04 01:24 PDT to 2017-11-04 02:09 PDT: 29 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-04 02:09 PDT to 2017-11-04 02:54 PDT: 29 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-04 02:54 PDT to 2017-11-04 03:39 PDT: 29 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-04 03:39 PDT to 2017-11-04 04:24 PDT: 29 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-04 04:24 PDT to 2017-11-04 05:09 PDT: 29 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-04 05:09 PDT to 2017-11-04 05:54 PDT: 29 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-04 05:54 PDT to 2017-11-04 06:39 PDT: 30 / 1 hits
INFO:elastalert:Queried rule Test rule from 2017-11-04 06:39 PDT to 2017-11-04 07:24 PDT: 30 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-04 07:24 PDT to 2017-11-04 08:09 PDT: 30 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-04 08:09 PDT to 2017-11-04 08:54 PDT: 30 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-04 08:54 PDT to 2017-11-04 09:39 PDT: 30 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-04 09:39 PDT to 2017-11-04 10:24 PDT: 30 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-04 10:24 PDT to 2017-11-04 11:09 PDT: 30 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-04 11:09 PDT to 2017-11-04 11:54 PDT: 30 / 0 hits
INFO:elastalert:Queried rule Test rule from 2017-11-04 11:54 PDT to 2017-11-04 12:39 PDT: 30 / 0 hits
INFO:elastalert:Alert for Test rule at 2017-11-03T21:03:04Z:
INFO:elastalert:Sample Alert Text

@ingestionTime: 2017-11-03T21:03:04Z
_id: c5a905f225da0fa2cb8f6635d8ff6d83c967f941
_index: my_index.2017.11
_type: test
event_time: 2017-10-20T21:00:44.608000+00:00
event_data: {
    field: "value"
}
num_hits: 30
num_matches: 30

[...]

Would have written the following documents to writeback index (default is elastalert_status):

elastalert_status - {'hits': 30, 'matches': 30, '@timestamp': datetime.datetime(2017, 11, 4, 19, 39, 50, 30508, tzinfo=tzutc()), 'rule_name': 'Test rule', 'starttime': datetime.datetime(2017, 11, 3, 19, 39, 48, 897737, tzinfo=tzutc()), 'endtime': datetime.datetime(2017, 11, 4, 19, 39, 48, 897737, tzinfo=tzutc()), 'time_taken': 1.1091699600219727}
```

edit:
`make test` didn't actually work :( I fixed it though :)