### PR TITLE
Add support for Elasticsearch after 5.0(including new version 6.0.0)

### DIFF
--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -135,8 +135,6 @@ def main():
     error_mapping = {'elastalert_error': {'properties': {'data': {'type': 'object', 'enabled': False},
                                                          '@timestamp': {'format': 'dateOptionalTime', 'type': 'date'}}}}
 
-
-
     index = args.index if args.index is not None else raw_input('New index name? (Default elastalert_status) ')
     if not index:
         index = 'elastalert_status'

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -117,25 +117,25 @@ def main():
         ca_certs=ca_certs,
         client_key=client_key)
 
-    silence_mapping = {'silence': {'properties': {'rule_name': { 'type': 'keyword'},
+    silence_mapping = {'silence': {'properties': {'rule_name': {'type': 'keyword'},
                                                   'until': {'type': 'date', 'format': 'dateOptionalTime'},
                                                   '@timestamp': {'format': 'dateOptionalTime', 'type': 'date'}}}}
-    ess_mapping = {'elastalert_status': {'properties': {'rule_name': { 'type': 'keyword'},
+    ess_mapping = {'elastalert_status': {'properties': {'rule_name': {'type': 'keyword'},
                                                         '@timestamp': {'format': 'dateOptionalTime', 'type': 'date'}}}}
-    es_mapping = {'elastalert': {'properties': {'rule_name': { 'type': 'keyword'},
+    es_mapping = {'elastalert': {'properties': {'rule_name': {'type': 'keyword'},
                                                 '@timestamp': {'format': 'dateOptionalTime', 'type': 'date'},
                                                 'alert_time': {'format': 'dateOptionalTime', 'type': 'date'},
                                                 'match_time': {'format': 'dateOptionalTime', 'type': 'date'},
                                                 'match_body': {'enabled': False, 'type': 'object'},
-                                                'aggregate_id': { 'type': 'keyword'}}}}
-    past_mapping = {'past_elastalert': {'properties': {'rule_name': { 'type': 'keyword'},
+                                                'aggregate_id': {'type': 'keyword'}}}}
+    past_mapping = {'past_elastalert': {'properties': {'rule_name': {'type': 'keyword'},
                                                        'match_body': {'enabled': False, 'type': 'object'},
                                                        '@timestamp': {'format': 'dateOptionalTime', 'type': 'date'},
-                                                       'aggregate_id': { 'type': 'keyword'}}}}
+                                                       'aggregate_id': {'type': 'keyword'}}}}
     error_mapping = {'elastalert_error': {'properties': {'data': {'type': 'object', 'enabled': False},
                                                          '@timestamp': {'format': 'dateOptionalTime', 'type': 'date'}}}}
-	
-		# mappings = { 'mappings' : 
+
+
 
     index = args.index if args.index is not None else raw_input('New index name? (Default elastalert_status) ')
     if not index:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -176,7 +176,7 @@ class ElastAlerter():
 
     def is_five(self):
         """actually `is_five` means version >= 5 now"""
-        version = self.es.info()['version']['number'][0:1]
+        version = self.es_version[0:1]
         return int(version) >= 5
 
     @staticmethod

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1367,13 +1367,12 @@ class ElastAlerter():
 
     def writeback(self, doc_type, body):
         # ES 2.0 - 2.3 does not support dots in field names.
-		
         writeback_index = doc_type
         if writeback_index == 'silence':
-		    writeback_index = 'elastalert_silence'
+            writeback_index = 'elastalert_silence'
         elif writeback_index == 'past_elastalert':
-		    writeback_index = 'elastalert_past'
-		
+            writeback_index = 'elastalert_past'
+        
         if self.replace_dots_in_field_names:
             writeback_body = replace_dots_in_field_names(body)
         else:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1372,7 +1372,7 @@ class ElastAlerter():
             writeback_index = 'elastalert_silence'
         elif writeback_index == 'past_elastalert':
             writeback_index = 'elastalert_past'
-        
+            
         if self.replace_dots_in_field_names:
             writeback_body = replace_dots_in_field_names(body)
         else:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -175,7 +175,9 @@ class ElastAlerter():
         return self._es_version
 
     def is_five(self):
-        return self.es_version.startswith('5')
+        """actually `is_five` means version >= 5 now"""
+        version = self.es.info()['version']['number'][0:1]
+        return int(version) >= 5
 
     @staticmethod
     def get_index(rule, starttime=None, endtime=None):

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1372,7 +1372,7 @@ class ElastAlerter():
             writeback_index = 'elastalert_silence'
         elif writeback_index == 'past_elastalert':
             writeback_index = 'elastalert_past'
-            
+
         if self.replace_dots_in_field_names:
             writeback_body = replace_dots_in_field_names(body)
         else:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -918,7 +918,8 @@ class ElastAlerter():
     def modify_rule_for_ES5(new_rule):
         # Get ES version per rule
         rule_es = elasticsearch_client(new_rule)
-        if rule_es.info()['version']['number'].startswith('5'):
+        version = rule_es.info()['version']['number'][0:1]
+        if int(version) >= 5:
             new_rule['five'] = True
         else:
             new_rule['five'] = False

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -813,8 +813,9 @@ class NewTermsRule(RuleType):
                         self.seen_values[field].append(bucket['key'])
 
     def is_five(self):
-        version = self.es.info()['version']['number']
-        return version.startswith('5')
+        """actually `is_five` means version >= 5 now"""
+        version = self.es.info()['version']['number'][0:1]
+        return int(version) >= 5
 
 
 class CardinalityRule(RuleType):

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -54,7 +54,8 @@ class MockElastAlerter(object):
         es_client = elasticsearch_client(conf)
 
         try:
-            is_five = es_client.info()['version']['number'].startswith('5')
+            version = es_client.info()['version']['number'][0:1]
+            is_five = int(version) >= 5
         except Exception as e:
             print("Error connecting to ElasticSearch:", file=sys.stderr)
             print(repr(e)[:2048], file=sys.stderr)


### PR DESCRIPTION
Elasticsearch 6.0.0 was Released.    
Changed the way of judging version of es, in order to support version after 5.x including 6.x.