### PR TITLE
add is_enabled to rule attribute for a rule to be easily disabled

### DIFF
--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -462,6 +462,9 @@ def load_rules(args):
     for rule_file in rule_files:
         try:
             rule = load_configuration(rule_file, conf, args)
+            # By setting "is_enabled: False" in rule file, a rule is easily disabled
+            if 'is_enabled' in rule and not rule['is_enabled']:
+                continue
             if rule['name'] in names:
                 raise EAException('Duplicate rule named %s' % (rule['name']))
         except EAException as e:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -947,6 +947,8 @@ class ElastAlerter():
                 # Rule file was changed, reload rule
                 try:
                     new_rule = load_configuration(rule_file, self.conf)
+                    if 'is_enabled' in new_rule and not new_rule['is_enabled']:
+                        continue
                 except EAException as e:
                     message = 'Could not load rule %s: %s' % (rule_file, e)
                     self.handle_error(message)
@@ -980,6 +982,8 @@ class ElastAlerter():
             for rule_file in set(new_rule_hashes.keys()) - set(self.rule_hashes.keys()):
                 try:
                     new_rule = load_configuration(rule_file, self.conf)
+                    if 'is_enabled' in new_rule and not new_rule['is_enabled']:
+                        continue
                     if new_rule['name'] in [rule['name'] for rule in self.rules]:
                         raise EAException("A rule with the name %s already exists" % (new_rule['name']))
                 except EAException as e:

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -940,6 +940,17 @@ def test_rule_changes(ea):
     assert len(ea.rules) == 3
     assert not any(['new' in rule for rule in ea.rules])
 
+    # A new rule with is_enabled=False wont load
+    new_hashes = copy.copy(new_hashes)
+    new_hashes.update({'rules/rule4.yaml': 'asdf'})
+    with mock.patch('elastalert.elastalert.get_rule_hashes') as mock_hashes:
+        with mock.patch('elastalert.elastalert.load_configuration') as mock_load:
+            mock_load.return_value = {'filter': [], 'name': 'rule4', 'new': 'stuff', 'is_enabled': False, 'rule_file': 'rules/rule4.yaml'}
+            mock_hashes.return_value = new_hashes
+            ea.load_rule_changes()
+    assert len(ea.rules) == 3
+    assert not any(['new' in rule for rule in ea.rules])
+
     # An old rule which didn't load gets reloaded
     new_hashes = copy.copy(new_hashes)
     new_hashes['rules/rule4.yaml'] = 'qwerty'

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -230,6 +230,20 @@ def test_load_ssl_env_true():
                 assert rules['use_ssl'] is True
 
 
+def test_load_disabled_rules():
+    test_rule_copy = copy.deepcopy(test_rule)
+    test_rule_copy['is_enabled'] = False
+    test_config_copy = copy.deepcopy(test_config)
+    with mock.patch('elastalert.config.yaml_loader') as mock_open:
+        mock_open.side_effect = [test_config_copy, test_rule_copy]
+
+        with mock.patch('os.listdir') as mock_ls:
+            mock_ls.return_value = ['testrule.yaml']
+            rules = load_rules(test_args)
+            # The rule is not loaded for it has "is_enabled=False"
+            assert len(rules['rules']) == 0
+
+
 def test_compound_query_key():
     test_rule_copy = copy.deepcopy(test_rule)
     test_rule_copy.pop('use_count_query')


### PR DESCRIPTION
fix https://github.com/Yelp/elastalert/issues/1221

Let `is_enabled` be an attribute of rule, and disable a rule easily by setting `is_enabled: False` in a rule file.

Filter rules in three places:
1. when elastalert client starts, and it calls load_rules to initialize rules
2. when elastalert syncs rules, and it calls load_rules_changes to check current rules
3. when elastalert syncs rules, and it calls load_rules_changes to load newly added rules
