### PR TITLE
Treat summary_table cell values as text

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -262,6 +262,8 @@ class Alerter(object):
             )
             text_table = Texttable(max_width=self.get_aggregation_summary_text__maximum_width())
             text_table.header(summary_table_fields_with_count)
+            # Format all fields as 'text' to avoid long numbers being shown as scientific notation
+            text_table.set_cols_dtype(['t' for i in summary_table_fields_with_count])
             match_aggregation = {}
 
             # Maintain an aggregate count for each unique key encountered in the aggregation period

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -1037,7 +1037,7 @@ def test_wait_until_responsive(ea):
     ]
 
 
-def test_wait_until_responsive_timeout_es_not_available(ea, capsys):
+def test_wait_until_responsive_timeout_es_not_available(ea, caplog):
     """Bail out if ElasticSearch doesn't (quickly) become responsive."""
 
     # Never becomes responsive :-)
@@ -1053,8 +1053,7 @@ def test_wait_until_responsive_timeout_es_not_available(ea, capsys):
         assert exc.value.code == 1
 
     # Ensure we get useful diagnostics.
-    output, errors = capsys.readouterr()
-    assert 'Could not reach ElasticSearch at "es:14900".' in errors
+    assert 'Could not reach ElasticSearch at "es:14900".' in caplog.text
 
     # Slept until we passed the deadline.
     sleep.mock_calls == [
@@ -1064,7 +1063,7 @@ def test_wait_until_responsive_timeout_es_not_available(ea, capsys):
     ]
 
 
-def test_wait_until_responsive_timeout_index_does_not_exist(ea, capsys):
+def test_wait_until_responsive_timeout_index_does_not_exist(ea, caplog):
     """Bail out if ElasticSearch doesn't (quickly) become responsive."""
 
     # Never becomes responsive :-)
@@ -1080,8 +1079,7 @@ def test_wait_until_responsive_timeout_index_does_not_exist(ea, capsys):
         assert exc.value.code == 1
 
     # Ensure we get useful diagnostics.
-    output, errors = capsys.readouterr()
-    assert 'Writeback index "wb" does not exist, did you run `elastalert-create-index`?' in errors
+    assert 'Writeback index "wb" does not exist, did you run `elastalert-create-index`?' in caplog.text
 
     # Slept until we passed the deadline.
     sleep.mock_calls == [


### PR DESCRIPTION
This makes it so that the \_\_str\_\_() of each field is populated in the cells. Without this change, Texttable tries to figure out "automatically" what the type is and represent it the way it thinks is "best". In some cases, it's not the best (e.g. for an AccountId).

I suppose this behavior could be made configurable. I'll leave that exercise to the next person that wants to change the behavior :)

I could also see the argument for NOT making the `count` column text, and to make it automatic, since in that case, a very large number might make sense in scientific notation, but ::shrug:: for now, unless reviewers feel strongly about it.

How I know this works:

```
>>> from texttable import Texttable
>>> t1 = Texttable()
>>> t1.header(['AccountId'])
>>> t1.add_row([1234567890])
>>> print t1.draw()
+----------------+
|    AccountId   |
+================+
| 1.235e+09      |
+----------------+
>>> t2 = Texttable()
>>> t2.header(['AccountId'])
>>> t2.set_cols_dtype(['t'])
>>> t2.add_row([1234567890])
>>> print t2.draw()
+----------------+
|    AccountId   |
+================+
| 1234567890     |
+----------------+
```