### PR TITLE
fixed a bug that broke newterm rule

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -593,7 +593,7 @@ class NewTermsRule(RuleType):
         window_size = datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))
         field_name = {"field": "", "size": 2147483647}  # Integer.MAX_VALUE
         query_template = {"aggs": {"values": {"terms": field_name}}}
-        if args and hasattr(args, 'start'):
+        if args and hasattr(args, 'start') and args.start:
             end = ts_to_dt(args.start)
         else:
             end = ts_now()


### PR DESCRIPTION
#1445  broke NewTerm rule when not using a ``--start`` flag.

This fixes that.