### PR TITLE
hipchat: support @mention specific users on Hipchat

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1431,6 +1431,13 @@ text - Message is treated just like a message sent by a user. Can include @menti
 Valid values: html, text.
 Defaults to 'html'.
 
+``hipchat_mentions``: When using a ``html`` message format, it's not possible to mentions specific users using the ``@user`` syntax.
+In that case, you can set ``hipchat_mentions`` to a list of users which will be first mentioned using a single text message, then the normal ElastAlert message will be sent to Hipchat.
+If set, it will mention the users, no matter if the original message format is set to HTML or text.
+Valid values: list of strings.
+Defaults to ``[]``.
+
+
 Stride
 ~~~~~~~
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -946,6 +946,22 @@ class HipChatAlerter(Alerter):
         try:
             if self.hipchat_ignore_ssl_errors:
                 requests.packages.urllib3.disable_warnings()
+
+            if self.rule.get('hipchat_mentions', []):
+                ping_users = self.rule.get('hipchat_mentions', [])
+                ping_msg = payload.copy()
+                ping_msg['message'] = "ping {}".format(
+                        ", ".join("@{}".format(user) for user in ping_users)
+                )
+                ping_msg['message_format'] = "text"
+
+                response = requests.post(
+                        self.url,
+                        data=json.dumps(ping_msg, cls=DateTimeEncoder),
+                        headers=headers,
+                        verify=not self.hipchat_ignore_ssl_errors,
+                        proxies=proxies)
+
             response = requests.post(self.url, data=json.dumps(payload, cls=DateTimeEncoder), headers=headers,
                                      verify=not self.hipchat_ignore_ssl_errors,
                                      proxies=proxies)

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -219,6 +219,7 @@ properties:
   hipchat_ignore_ssl_errors: {type: boolean}
   hipchat_notify: {type: boolean}
   hipchat_from: {type: string}
+  hipchat_mentions: {type: array, items: {type: string}}
 
   ### Stride
   stride_access_token: {type: string}


### PR DESCRIPTION
When sending HTML messages to Hipchat, we can't use @mention to ping users, due to limitation (feature) in the Hipchat API.

This new option, if defined in the configuration, will first pings the users specified using a "text" message format (which triggers the ``@mentions`` mechanism and notify users directly, if configured as such) then send the actual HTML message.