### PR TITLE
Fix for multiple VictorOps alerts

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1598,9 +1598,9 @@ The alerter requires the following options:
 
 Optional:
 
-``victorops_entity_id``: The identity of the incident used by VictorOps to correlate incidents thoughout the alert lifecycle. If not definied, VictorOps will assign a random string to each alert.
+``victorops_entity_id``: The identity of the incident used by VictorOps to correlate incidents thoughout the alert lifecycle. If not defined, VictorOps will assign a random string to each alert.
 
-``victorops_entity_display_name``: Human-readable name of alerting entity to summerise incidents without affecting the life-cycle workflow.
+``victorops_entity_display_name``: Human-readable name of alerting entity to summerize incidents without affecting the life-cycle workflow.
 
 ``victorops_proxy``: By default ElastAlert will not use a network proxy to send notifications to VictorOps. Set this option using ``hostname:port`` if you need to use a proxy.
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1600,7 +1600,7 @@ Optional:
 
 ``victorops_entity_id``: The identity of the incident used by VictorOps to correlate incidents thoughout the alert lifecycle. If not defined, VictorOps will assign a random string to each alert.
 
-``victorops_entity_display_name``: Human-readable name of alerting entity to summerize incidents without affecting the life-cycle workflow.
+``victorops_entity_display_name``: Human-readable name of alerting entity to summarize incidents without affecting the life-cycle workflow.
 
 ``victorops_proxy``: By default ElastAlert will not use a network proxy to send notifications to VictorOps. Set this option using ``hostname:port`` if you need to use a proxy.
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1598,7 +1598,9 @@ The alerter requires the following options:
 
 Optional:
 
-``victorops_entity_display_name``: Human-readable name of alerting entity. Used by VictorOps to correlate incidents by host througout the alert lifecycle.
+``victorops_entity_id``: The identity of the incident used by VictorOps to correlate incidents thoughout the alert lifecycle. If not definied, VictorOps will assign a random string to each alert.
+
+``victorops_entity_display_name``: Human-readable name of alerting entity to summerise incidents without affecting the life-cycle workflow.
 
 ``victorops_proxy``: By default ElastAlert will not use a network proxy to send notifications to VictorOps. Set this option using ``hostname:port`` if you need to use a proxy.
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1242,6 +1242,7 @@ class VictorOpsAlerter(Alerter):
         self.victorops_api_key = self.rule['victorops_api_key']
         self.victorops_routing_key = self.rule['victorops_routing_key']
         self.victorops_message_type = self.rule['victorops_message_type']
+        self.victorops_entity_id = self.rule.get('victorops_entity_id', None)
         self.victorops_entity_display_name = self.rule.get('victorops_entity_display_name', 'no entity display name')
         self.url = 'https://alert.victorops.com/integrations/generic/20131114/alert/%s/%s' % (
             self.victorops_api_key, self.victorops_routing_key)
@@ -1260,6 +1261,8 @@ class VictorOpsAlerter(Alerter):
             "monitoring_tool": "ElastAlert",
             "state_message": body
         }
+        if self.victorops_entity_id:
+            payload["entity_id"] = self.victorops_entity_id
 
         try:
             response = requests.post(self.url, data=json.dumps(payload, cls=DateTimeEncoder), headers=headers, proxies=proxies)

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -257,6 +257,7 @@ properties:
   victorops_api_key: {type: string}
   victorops_routing_key: {type: string}
   victorops_message_type: {enum: [INFO, WARNING, ACKNOWLEDGEMENT, CRITICAL, RECOVERY]}
+  victorops_entity_id: {type: string}
   victorops_entity_display_name: {type: string}
 
   ### Telegram


### PR DESCRIPTION
The VictorOps alerts rules are incorrectly using `entity_display_name` to link alerts to incidents. This, in fact, should be using the `entity_id` field.

I have updated ElastAlert to allow the `entity_id` field to be used for this purpose, whilst maintaining backward compatibility with existing rules. I have also updated the documentation to reflect these changes.
  