### PR TITLE
Query key value length option for FrequencyRule

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -118,6 +118,8 @@ Rule Configuration Cheat Sheet
 +----------------------------------------------------+--------+-----------+-----------+--------+-----------+-------+----------+--------+-----------+
 | ``query_key`` (string, no default)                 |   Opt  |           |           |   Req  |    Opt    |  Opt  |   Opt    |  Req   |  Opt      |
 +----------------------------------------------------+--------+-----------+-----------+--------+-----------+-------+----------+--------+-----------+
+| ``query_key_value_length`` (int, default 10000)    |        |           |           |        |    Opt    |       |          |        |           |
++----------------------------------------------------+--------+-----------+-----------+--------+-----------+-------+----------+--------+-----------+
 | ``aggregation_key`` (string, no default)           |   Opt  |           |           |        |           |       |          |        |           |
 +----------------------------------------------------+--------+-----------+-----------+--------+-----------+-------+----------+--------+-----------+
 | ``summary_table_fields`` (list, no default)        |   Opt  |           |           |        |           |       |          |        |           |
@@ -520,6 +522,11 @@ additional alerts for ``{'username': 'bob'}`` will be ignored while other userna
 ``query_key`` will be grouped together. A list of fields may also be used, which will create a compound query key. This compound key is
 treated as if it were a single field whose value is the component values, or "None", joined by commas. A new field with the key
 "field1,field2,etc" will be created in each document and may conflict with existing fields of the same name.
+
+query_key_value_length
+^^^^^^^^^^^^^^^^^^^^^^
+
+``query_key_value_length``: Omitting a ``query_key`` value for aggregate result easily. The default is ``10000``.
 
 aggregation_key
 ^^^^^^^^^^^^^^^

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -229,12 +229,14 @@ class FrequencyRule(RuleType):
         self.check_for_match('all')
 
     def add_terms_data(self, terms):
+        qkv_length = self.rules.get('query_key_value_length', 10000)
         for timestamp, buckets in terms.iteritems():
             for bucket in buckets:
+                bucket_key_value = bucket.get('key', '')[0:qkv_length]
                 event = ({self.ts_field: timestamp,
-                          self.rules['query_key']: bucket['key']}, bucket['doc_count'])
-                self.occurrences.setdefault(bucket['key'], EventWindow(self.rules['timeframe'], getTimestamp=self.get_ts)).append(event)
-                self.check_for_match(bucket['key'])
+                          self.rules['query_key']: bucket_key_value}, bucket['doc_count'])
+                self.occurrences.setdefault(bucket_key_value, EventWindow(self.rules['timeframe'], getTimestamp=self.get_ts)).append(event)
+                self.check_for_match(bucket_key_value)
 
     def add_data(self, data):
         if 'query_key' in self.rules:

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -184,6 +184,33 @@ def test_freq_terms():
     assert rule.matches[1].get('username') == 'userA'
 
 
+def test_freq_query_key_value_length():
+    rules = {'num_events': 10,
+             'timeframe': datetime.timedelta(hours=1),
+             'query_key': 'username',
+             'query_key_value_length': 5}
+    rule = FrequencyRule(rules)
+
+    terms1 = {ts_to_dt('2014-01-01T00:01:00Z'): [{'key': 'userA-1', 'doc_count': 1},
+                                                 {'key': 'userB-1', 'doc_count': 5}]}
+    terms2 = {ts_to_dt('2014-01-01T00:10:00Z'): [{'key': 'userA-2', 'doc_count': 8},
+                                                 {'key': 'userB-2', 'doc_count': 5}]}
+    terms3 = {ts_to_dt('2014-01-01T00:25:00Z'): [{'key': 'userA-3', 'doc_count': 3},
+                                                 {'key': 'userB-3', 'doc_count': 0}]}
+    # Initial data
+    rule.add_terms_data(terms1)
+    assert len(rule.matches) == 0
+
+    # Match for userB
+    rule.add_terms_data(terms2)
+    assert len(rule.matches) == 1
+    assert rule.matches[0].get('username') == 'userB'
+
+    # Match for userA
+    rule.add_terms_data(terms3)
+    assert len(rule.matches) == 2
+    assert rule.matches[1].get('username') == 'userA'
+
 def test_eventwindow():
     timeframe = datetime.timedelta(minutes=10)
     window = EventWindow(timeframe)

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -211,6 +211,7 @@ def test_freq_query_key_value_length():
     assert len(rule.matches) == 2
     assert rule.matches[1].get('username') == 'userA'
 
+
 def test_eventwindow():
     timeframe = datetime.timedelta(minutes=10)
     window = EventWindow(timeframe)


### PR DESCRIPTION
## Motivation

Sometimes messages have different value fields, such as followings.

```
{"unique_key": "this is error message: value=1"}
{"unique_key": "this is error message: value=2"}
{"unique_key": "this is error message: value=3"}
```

I want to count frequency by prefix value `this is error message` as a unique key. 

## How to change

Add `query_key_value_length` option into FrequencyRule and omit value by the length.

