### PR TITLE
add alert_missing_value config to override <MISSING VALUE>

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -101,6 +101,8 @@ Rule Configuration Cheat Sheet
 | ``alert_text_args`` (array of strs)                          |           |
 +--------------------------------------------------------------+           |
 | ``alert_text_kw`` (object)                                   |           |
++--------------------------------------------------------------+           |
+| ``alert_missing_value`` (string, default "<MISSING VALUE>")  |           |
 +--------------------------------------------------------------+-----------+
 
 |
@@ -1118,7 +1120,7 @@ It is mandatory to enclose the ``@timestamp`` field in quotes since in YAML form
 
 In case the rule matches multiple objects in the index, only the first match is used to populate the arguments for the formatter.
 
-If the field(s) mentioned in the arguments list are missing, the email alert will have the text ``<MISSING VALUE>`` in place of its expected value. This will also occur if ``use_count_query`` is set to true.
+If the field(s) mentioned in the arguments list are missing, the email alert will have the text ``alert_missing_value`` in place of its expected value. This will also occur if ``use_count_query`` is set to true.
 
 Alert Content
 ~~~~~~~~~~~~~
@@ -1135,7 +1137,7 @@ There are several ways to format the body text of the various types of events. I
 
 Similarly to ``alert_subject``, ``alert_text`` can be further formatted using standard Python formatting syntax.
 The field names whose values will be used as the arguments can be passed with ``alert_text_args`` or ``alert_text_kw``.
-You may also refer to any top-level rule property in the ``alert_subject_args``, ``alert_text_args``, and ``alert_text_kw fields``.  However, if the matched document has a key with the same name, that will take preference over the rule property.
+You may also refer to any top-level rule property in the ``alert_subject_args``, ``alert_text_args``, ``alert_missing_value``, and ``alert_text_kw fields``.  However, if the matched document has a key with the same name, that will take preference over the rule property.
 
 By default::
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -53,7 +53,7 @@ class BasicMatchString(object):
             self.text += '\n'
 
     def _add_custom_alert_text(self):
-        missing = '<MISSING VALUE>'
+        missing = self.rule.get('alert_missing_value', '<MISSING VALUE>')
         alert_text = unicode(self.rule.get('alert_text', ''))
         if 'alert_text_args' in self.rule:
             alert_text_args = self.rule.get('alert_text_args')
@@ -231,7 +231,8 @@ class Alerter(object):
                     if alert_value:
                         alert_subject_values[i] = alert_value
 
-            alert_subject_values = ['<MISSING VALUE>' if val is None else val for val in alert_subject_values]
+            missing = self.rule.get('alert_missing_value', '<MISSING VALUE>')
+            alert_subject_values = [missing if val is None else val for val in alert_subject_values]
             return alert_subject.format(*alert_subject_values)
 
         return alert_subject
@@ -1168,7 +1169,8 @@ class PagerDutyAlerter(Alerter):
                     if key_value:
                         incident_key_values[i] = key_value
 
-            incident_key_values = ['<MISSING VALUE>' if val is None else val for val in incident_key_values]
+            missing = self.rule.get('alert_missing_value', '<MISSING VALUE>')
+            incident_key_values = [missing if val is None else val for val in incident_key_values]
             return self.pagerduty_incident_key.format(*incident_key_values)
         else:
             return self.pagerduty_incident_key

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -180,6 +180,7 @@ properties:
   alert_text_args: {type: array, items: {type: string}}
   alert_text_kw: {type: object}
   alert_text_type: {enum: [alert_text_only, exclude_fields]}
+  alert_missing_value: {type: string}
   timestamp_field: {type: string}
   field: {}
 

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -319,7 +319,8 @@ def test_email_with_args():
         'alert_subject': 'Test alert for {0} {1}',
         'alert_subject_args': ['test_term', 'test.term'],
         'alert_text': 'Test alert for {0} and {1} {2}',
-        'alert_text_args': ['test_arg1', 'test_arg2', 'test.arg3']
+        'alert_text_args': ['test_arg1', 'test_arg2', 'test.arg3'],
+        'alert_missing_value': '<CUSTOM MISSING VALUE>'
     }
     with mock.patch('elastalert.alerts.SMTP') as mock_smtp:
         mock_smtp.return_value = mock.Mock()
@@ -339,7 +340,7 @@ def test_email_with_args():
         body_text = body.split('\n\n')[-1][:-1].decode('base64')
 
         assert 'testing' in body_text
-        assert '<MISSING VALUE>' in body_text
+        assert '<CUSTOM MISSING VALUE>' in body_text
         assert '☃' in body_text
 
         assert 'Reply-To: test@example.com' in body


### PR DESCRIPTION
## Motivation

`<MISSING VALUE>` cut url in slack full parse webhook.
I want to change default missing value.

## How to change?

Add `alert_missing_value` parameter to override `<MISSING VALUE>`