### PR TITLE
add slack_disable_escape_body option

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1503,7 +1503,7 @@ Provide absolute address of the pciture, for example: http://some.address.com/im
 
 ``slack_proxy``: By default ElastAlert will not use a network proxy to send notifications to Slack. Set this option using ``hostname:port`` if you need to use a proxy.
 
-``slack_disable_format_body``: By default ElastAlert will format slack body automatically. Set this option ``True`` if you want to disable formatting.
+``slack_disable_escape_body``: By default ElastAlert will escape slack body automatically. Set this option ``True`` if you want to disable escape.
 
 Telegram
 ~~~~~~~~

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1503,6 +1503,8 @@ Provide absolute address of the pciture, for example: http://some.address.com/im
 
 ``slack_proxy``: By default ElastAlert will not use a network proxy to send notifications to Slack. Set this option using ``hostname:port`` if you need to use a proxy.
 
+``slack_disable_format_body``: By default ElastAlert will format slack body automatically. Set this option ``True`` if you want to disable formatting.
+
 Telegram
 ~~~~~~~~
 Telegram alerter will send a notification to a predefined Telegram username or channel. The body of the notification is formatted the same as with other alerters.

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1045,14 +1045,15 @@ class SlackAlerter(Alerter):
         self.slack_msg_color = self.rule.get('slack_msg_color', 'danger')
         self.slack_parse_override = self.rule.get('slack_parse_override', 'none')
         self.slack_text_string = self.rule.get('slack_text_string', '')
-        self.slack_disable_format_body = self.rule.get('slack_disable_format_body', False)
+        self.slack_disable_escape_body = self.rule.get('slack_disable_escape_body', False)
 
     def format_body(self, body):
         # https://api.slack.com/docs/formatting
         body = body.encode('UTF-8')
-        body = body.replace('&', '&amp;')
-        body = body.replace('<', '&lt;')
-        body = body.replace('>', '&gt;')
+        if not self.slack_disable_escape_body:
+            body = body.replace('&', '&amp;')
+            body = body.replace('<', '&lt;')
+            body = body.replace('>', '&gt;')
         return body
 
     def get_aggregation_summary_text__maximum_width(self):
@@ -1069,8 +1070,7 @@ class SlackAlerter(Alerter):
     def alert(self, matches):
         body = self.create_alert_body(matches)
 
-        if not self.slack_disable_format_body:
-            body = self.format_body(body)
+        body = self.format_body(body)
         # post to slack
         headers = {'content-type': 'application/json'}
         # set https proxy, if it was provided

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1045,6 +1045,7 @@ class SlackAlerter(Alerter):
         self.slack_msg_color = self.rule.get('slack_msg_color', 'danger')
         self.slack_parse_override = self.rule.get('slack_parse_override', 'none')
         self.slack_text_string = self.rule.get('slack_text_string', '')
+        self.slack_disable_format_body = self.rule.get('slack_disable_format_body', False)
 
     def format_body(self, body):
         # https://api.slack.com/docs/formatting
@@ -1068,7 +1069,8 @@ class SlackAlerter(Alerter):
     def alert(self, matches):
         body = self.create_alert_body(matches)
 
-        body = self.format_body(body)
+        if not self.slack_disable_format_body:
+            body = self.format_body(body)
         # post to slack
         headers = {'content-type': 'application/json'}
         # set https proxy, if it was provided

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -235,6 +235,7 @@ properties:
   slack_msg_color: {enum: [good, warning, danger]}
   slack_parse_override: {enum: [none, full]}
   slack_text_string: {type: string}
+  slack_disable_format_body: {type: boolean}
 
   ### PagerDuty
   pagerduty_service_key: {type: string}

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -235,7 +235,7 @@ properties:
   slack_msg_color: {enum: [good, warning, danger]}
   slack_parse_override: {enum: [none, full]}
   slack_text_string: {type: string}
-  slack_disable_format_body: {type: boolean}
+  slack_disable_escape_body: {type: boolean}
 
   ### PagerDuty
   pagerduty_service_key: {type: string}

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -1048,12 +1048,12 @@ def test_slack_uses_custom_slack_channel():
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
-def test_slack_disable_format_body():
+def test_slack_disable_escape_body():
     rule = {
         'name': 'Test Rule',
         'type': 'any',
         'slack_webhook_url': ['http://please.dontgohere.slack'],
-        'slack_disable_format_body': True,
+        'slack_disable_escape_body': True,
         'alert': []
     }
     load_modules(rule)

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -1048,6 +1048,48 @@ def test_slack_uses_custom_slack_channel():
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
+def test_slack_disable_format_body():
+    rule = {
+        'name': 'Test Rule',
+        'type': 'any',
+        'slack_webhook_url': ['http://please.dontgohere.slack'],
+        'slack_disable_format_body': True,
+        'alert': []
+    }
+    load_modules(rule)
+    alert = SlackAlerter(rule)
+    match = {
+        '@timestamp': '2016-01-01T00:00:00',
+        'message': '<https://elastalert|elastalert>'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+
+    expected_data = {
+        'username': 'elastalert',
+        'channel': '',
+        'icon_emoji': ':ghost:',
+        'attachments': [
+            {
+                'color': 'danger',
+                'title': rule['name'],
+                'text': BasicMatchString(rule, match).__str__(),
+                'mrkdwn_in': ['text', 'pretext'],
+                'fields': []
+            }
+        ],
+        'text': '',
+        'parse': 'none'
+    }
+    mock_post_request.assert_called_once_with(
+        rule['slack_webhook_url'][0],
+        data=mock.ANY,
+        headers={'content-type': 'application/json'},
+        proxies=None
+    )
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+
+
 def test_http_alerter_with_payload():
     rule = {
         'name': 'Test HTTP Post Alerter With Payload',


### PR DESCRIPTION
## Problem

Generally [Slack webhook accept hypertext format](https://api.slack.com/docs/message-formatting#linking_to_urls) like `<http://www.foo.com|www.foo.com>`. But elastalert automatically escape `<` and `>`. So, if we send message with `<http://www.foo.com|www.foo.com>`, not become links like followings.

https://github.com/Yelp/elastalert/blob/46d807b3720f3046c3290b019ec0edb2b4f0846a/elastalert/alerts.py#L1049-L1055

- `slack_override_parse: none`

![image](https://user-images.githubusercontent.com/915731/34913970-f2e7f9a6-f94c-11e7-8631-b493f5c32ba0.png)

- `slack_override_parse: full`

![image](https://user-images.githubusercontent.com/915731/34913971-fef13e60-f94c-11e7-9993-179169b712db.png)

## How to change?

add `slack_disable_format_body` option, which disable elastalert formatting.

![image](https://user-images.githubusercontent.com/915731/34913973-0727d620-f94d-11e7-9461-50a9c35658ff.png)
