### PR TITLE
Fix wrong link encoding in slack message body

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1048,11 +1048,7 @@ class SlackAlerter(Alerter):
 
     def format_body(self, body):
         # https://api.slack.com/docs/formatting
-        body = body.encode('UTF-8')
-        body = body.replace('&', '&amp;')
-        body = body.replace('<', '&lt;')
-        body = body.replace('>', '&gt;')
-        return body
+        return body.encode('UTF-8')
 
     def get_aggregation_summary_text__maximum_width(self):
         width = super(SlackAlerter, self).get_aggregation_summary_text__maximum_width()


### PR DESCRIPTION
Removes escaping of `>`, `<` and `&` characters from slack message body as this leads to non-interpreted links as described here: https://github.com/Yelp/elastalert/issues/660#issuecomment-315151378