### PR TITLE
Fix to ChangeRule to allow elastalert to search backwards for the last occurrences

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -861,7 +861,7 @@ class ElastAlerter():
         self.writeback('elastalert_status', body)
 
         return num_matches
-		
+
     def init_change_rule_occurrences(self, rule):
         """Check backwards until timeframe, if defined, or the last 10 minutes to update the rule's occurences variable with the latest compare key value for the key values."""
         try:
@@ -880,7 +880,7 @@ class ElastAlerter():
             query_rule['size'] = 1
 
             include = [query_key+".keyword",
-                      timestamp]
+                       timestamp]
             for v in compare_key.split(","):
                 include.append(v)
 
@@ -913,9 +913,9 @@ class ElastAlerter():
             query_rule['_source'] = include
 
             res = self.current_es.search(
-                    index=index_query,
-                    size=size_query,
-                    body = query_rule
+                index=index_query,
+                size=size_query,
+                body=query_rule
                 )
 
         except ElasticsearchException as e:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -863,7 +863,10 @@ class ElastAlerter():
         return num_matches
 
     def init_change_rule_occurrences(self, rule):
-        """Check backwards until timeframe, if defined, or the last 10 minutes to update the rule's occurences variable with the latest compare key value for the key values."""
+        """ Check backwards until timeframe, if defined,
+        or the last 10 minutes to update the rule's occurences
+        variable with the latest compare key value for the key values. """
+
         try:
 
             query_key = rule.get("query_key")
@@ -875,7 +878,9 @@ class ElastAlerter():
             index_query = self.get_index(rule, timeframe, ts_now())
             filters = rule['filter']
             self.current_es = elasticsearch_client(rule)
-            query_rule = self.get_query(filters, starttime=timeframe, endtime=ts_now(), timestamp_field=timestamp, to_ts_func=rule['dt_to_ts'], desc=True, five=rule['five'])
+            query_rule = self.get_query(filters, starttime=timeframe, endtime=ts_now(),
+                                        timestamp_field=timestamp, to_ts_func=rule['dt_to_ts'],
+                                        desc=True, five=rule['five'])
 
             query_rule['size'] = 1
 
@@ -883,7 +888,6 @@ class ElastAlerter():
                        timestamp]
             for v in compare_key.split(","):
                 include.append(v)
-
 
             query_rule['aggs'] = {
                 query_key: {
@@ -919,6 +923,7 @@ class ElastAlerter():
                 )
 
         except ElasticsearchException as e:
+            elastalert_logger.debug(e)
             return False
 
         self.total_hits = int(res['hits']['total'])
@@ -982,7 +987,8 @@ class ElastAlerter():
                 continue
             new_rule[prop] = rule[prop]
 
-        #If the rule has a parameter to check time backwards until timeframe for events.
+        # If the rule has a parameter to check time backwards until timeframe for events.
+        # Usefull for the ChangeRule rule.
         if "check_last_occurrences" in new_rule and new_rule.get("check_last_occurrences", False):
             self.init_change_rule_occurrences(new_rule)
 

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -122,7 +122,9 @@ class CompareRule(RuleType):
                 self.add_match(event)
 
     def init_occurrences(self, es_res):
-        """ If rule has the parameter 'check_last_occurrences', this method will be used to let elastalert know the last compare keys value for each query key """
+        """ If rule has the parameter 'check_last_occurrences', 
+        this method will be used to let elastalert know the last
+        compare keys value for each query key """
         raise NotImplementedError()
 
     def add_occurrence(self, key, values, timeframe=None):
@@ -223,7 +225,7 @@ class ChangeRule(CompareRule):
             sources = event['top_hit']['hits']['hits'][0]['_source']
             event_values = []
             for val in self.rules['compound_compare_key']:
-                #if compare key was valid (i.e. exists on elasticsearch)
+                # if compare key was valid (i.e. exists on elasticsearch)
                 if val in sources:
                     event_values.append(sources[val])
                 else:
@@ -239,6 +241,7 @@ class ChangeRule(CompareRule):
         self.occurrences[key] = values
         if event_timeframe is not None:
             self.occurrence_time[key] = event_timeframe
+
 
 class FrequencyRule(RuleType):
     """ A rule that matches if num_events number of events occur within a timeframe """

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -122,7 +122,7 @@ class CompareRule(RuleType):
                 self.add_match(event)
 
     def init_occurrences(self, es_res):
-        """ If rule has the parameter 'check_last_occurrences', 
+        """ If rule has the parameter 'check_last_occurrences',
         this method will be used to let elastalert know the last
         compare keys value for each query key """
         raise NotImplementedError()

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -120,13 +120,13 @@ class CompareRule(RuleType):
         for event in data:
             if self.compare(event):
                 self.add_match(event)
-				
-	def init_occurrences(self, es_res):
-	    """ If rule has the parameter 'check_last_occurrences', this method will be used to let elastalert know the last compare keys value for each query key """
+
+    def init_occurrences(self, es_res):
+        """ If rule has the parameter 'check_last_occurrences', this method will be used to let elastalert know the last compare keys value for each query key """
         raise NotImplementedError()
 
     def add_occurrence(self, key, values, timeframe=None):
-	    """ Update the occurrences variable with the query key and compare keys value """
+        """ Update the occurrences variable with the query key and compare keys value """
         raise NotImplementedError()
 
 
@@ -228,7 +228,7 @@ class ChangeRule(CompareRule):
                     event_values.append(sources[val])
                 else:
                     event_values.append(None)
-                    key_msg = "None" if event_key == None else event_key
+                    key_msg = "None" if event_key is None else event_key
                     elastalert_logger.info("Compare key '" + val + "' not existing for last document with query key '" + key_msg + "'.")
             event_timeframe = None
             if 'timeframe' in self.rules:
@@ -237,7 +237,7 @@ class ChangeRule(CompareRule):
 
     def add_occurrence(self, key, values, event_timeframe=None):
         self.occurrences[key] = values
-        if event_timeframe != None:
+        if event_timeframe is not None:
             self.occurrence_time[key] = event_timeframe
 
 class FrequencyRule(RuleType):


### PR DESCRIPTION
If i have a ChangeRule type, and elastalert goes down for some time, the events that occurred during the time that elastalert was down will not be considered and there will be no alerts regarding those. And, for example, if a key had a certain value during that time, when elastalert starts again, the value is changed and it will not alert because it has no history of the values for that key.
Now, if the rule has the parameter "check_last_occurrences" and elastalert is started or the rule is modified, elastalert will fill in the occurrences variable with the last values from “timeframe” ago until now, so the next time a document with the query key appears, and the compare key is changed, an alert will be sent.

This also fixes issue #1480 .