### PR TITLE
add aggregation_summary_only alert_text_type

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1167,6 +1167,12 @@ With ``alert_text_type: exclude_fields``::
 
                           {top_counts}
 
+With ``alert_text_type: aggregation_summary_only``::
+
+    body                = rule_name
+
+                          aggregation_summary
++
 ruletype_text is the string returned by RuleType.get_match_str.
 
 field_values will contain every key value pair included in the results from Elasticsearch. These fields include "@timestamp" (or the value of ``timestamp_field``),

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -241,11 +241,12 @@ class Alerter(object):
 
     def create_alert_body(self, matches):
         body = self.get_aggregation_summary_text(matches)
-        for match in matches:
-            body += unicode(BasicMatchString(self.rule, match))
-            # Separate text of aggregated alerts with dashes
-            if len(matches) > 1:
-                body += '\n----------------------------------------\n'
+        if self.rule.get('alert_text_type') != 'aggregation_summary_only':
+            for match in matches:
+                body += unicode(BasicMatchString(self.rule, match))
+                # Separate text of aggregated alerts with dashes
+                if len(matches) > 1:
+                    body += '\n----------------------------------------\n'
         return body
 
     def get_aggregation_summary_text__maximum_width(self):
@@ -797,10 +798,11 @@ class JiraAlerter(Alerter):
     def create_alert_body(self, matches):
         body = self.description + '\n'
         body += self.get_aggregation_summary_text(matches)
-        for match in matches:
-            body += unicode(JiraFormattedMatchString(self.rule, match))
-            if len(matches) > 1:
-                body += '\n----------------------------------------\n'
+        if self.rule.get('alert_text_type') != 'aggregation_summary_only':
+            for match in matches:
+                body += unicode(JiraFormattedMatchString(self.rule, match))
+                if len(matches) > 1:
+                    body += '\n----------------------------------------\n'
         return body
 
     def get_aggregation_summary_text(self, matches):

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -179,7 +179,7 @@ properties:
   alert_text: {type: string} # Python format string
   alert_text_args: {type: array, items: {type: string}}
   alert_text_kw: {type: object}
-  alert_text_type: {enum: [alert_text_only, exclude_fields]}
+  alert_text_type: {enum: [alert_text_only, exclude_fields, aggregation_summary_only]}
   alert_missing_value: {type: string}
   timestamp_field: {type: string}
   field: {}


### PR DESCRIPTION
## Motivation

When I use aggregation, I just want to see aggregation summary only.

![slack](https://user-images.githubusercontent.com/915731/35311110-25317f06-00f8-11e8-9bb9-404c6416ab92.png)

## How to change

add `aggregation_summary_only` option to `alert_text_type`. (is this make sense?)