### PR TITLE
Added forget_keys feature

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -940,6 +940,9 @@ default 50, unique terms.
 ``query_key``: With flatline rule, ``query_key`` means that an alert will be triggered if any value of ``query_key`` has been seen at least once
 and then falls below the threshold.
 
+``forget_keys``: Only valid when used with ``query_key``. If this is set to true, ElastAlert will "forget" about the ``query_key`` value that
+triggers an alert, therefore preventing any more alerts for it until it's seen again.
+
 New Term
 ~~~~~~~~
 


### PR DESCRIPTION
This adds a new feature, ``forget_keys``, which tells flatline rule to forget about any ``query_key`` values and not realert on them. This reproduces the original (2015-2016) behavior of flatline alert where you won't get another alert unless you see the document again.

This is very useful for a situation where an abnormal piece of data triggers a flatline if it appears just once. If you don't expect it to return, you don't want to continue alerting on it.