### PR TITLE
check import rule hash

### DIFF
--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -14,7 +14,7 @@ from elastalert.config import load_modules
 from elastalert.config import load_options
 from elastalert.config import load_rules
 from elastalert.util import EAException
-
+from elastalert.config import import_rules
 
 test_config = {'rules_folder': 'test_folder',
                'run_every': {'minutes': 10},
@@ -92,6 +92,9 @@ def test_import_import():
         assert rules['es_host'] == 'imported_host'
         assert rules['email'] == ['test@test.test']
         assert rules['filter'] == import_rule['filter']
+
+        # check global import_rule dependency
+        assert import_rules == {'blah.yaml': ['importme.ymlt']}
 
 
 def test_import_absolute_import():


### PR DESCRIPTION
## Motivation
close #1517

## How to change?

1. add import dependency into global  `import_rules`
1. check rule file hash using `import_rules`

## Check
check working on local, following loggings show `import_rules`, `rule_mod_times` and reload log.

```
WARNING:root:{'rules/error_realtime.yaml': ['rules/../common_rules/common.yaml']}
WARNING:root:{'rules/error_realtime.yaml': '\x9e\xb3\x8b\x01v\x8c\x94\xb7\r\xb0\xad"\x07\x1bq-\xba\xc2\xbb\xaaF@\x9f\xa5d\xe4\x90\x8fc\xc7V\n\xc9\xbc\x92ND;O\x0c'}
INFO:elastalert:Reloading configuration for rule rules/error_realtime.yaml
```