### PR TITLE
Adding Slack fields support

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1520,6 +1520,9 @@ Provide absolute address of the pciture, for example: http://some.address.com/im
 
 ``slack_proxy``: By default ElastAlert will not use a network proxy to send notifications to Slack. Set this option using ``hostname:port`` if you need to use a proxy.
 
+``slack_alert_fields``: You can add additional fields to your slack alerts using this field. Specify the title using `title` and a value for the field using `value`. Additionally you can specify whether or not this field should be a `short` field using `short: true`.
+
+
 Telegram
 ~~~~~~~~
 Telegram alerter will send a notification to a predefined Telegram username or channel. The body of the notification is formatted the same as with other alerters.


### PR DESCRIPTION
This addresses https://github.com/Yelp/elastalert/issues/1053 and makes incoming alerts a bit easier on the eyes. Please let me know if I can improve this patch at all. The `title` is the name of the Field and then the value is the elasticsearch key you'd like to populate as the value.

Given this config:
```
slack_alert_fields:
- title: First Field
  value: columns.address
  short: true
- title: Second Field
  value: decorations.username
  short: true
```

and this patch, here is the output:

<img width="435" alt="test" src="https://user-images.githubusercontent.com/1205898/36113683-41341844-0ff3-11e8-99ff-82103f09976e.png">



Cheers,