### PR TITLE
Improve http_alerter (add headers, ignore ssl, basic auth)

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1702,6 +1702,14 @@ Required:
 
 Optional:
 
+``http_post_username``: Username for HTTP basic authentication
+
+``http_post_password``: Password for HTTP basic authentication
+
+``http_post_headers``: List of keys:values to be included as HTTP Headers
+
+``http_post_ignore_ssl_errors``: if set to True -- SSL validation errors will be ignored. by default False.
+
 ``http_post_payload``: List of keys:values to use as the content of the POST. Example - ip:clientip will map the value from the clientip index of Elasticsearch to JSON key named ip. If not defined, all the Elasticsearch keys will be sent.
 
 ``http_post_static_payload``: Key:value pairs of static parameters to be sent, along with the Elasticsearch results. Put your authentication or other information here.
@@ -1714,6 +1722,9 @@ Example usage::
 
     alert: post
     http_post_url: "http://example.com/api"
+    http_post_headers:
+      Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
+    http_post_ignore_ssl_errors: True
     http_post_payload:
       ip: clientip
     http_post_static_payload:

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -1072,9 +1072,11 @@ def test_http_alerter_with_payload():
     }
     mock_post_request.assert_called_once_with(
         rule['http_post_url'],
+        auth=None,
         data=mock.ANY,
         headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
-        proxies=None
+        proxies=None,
+        verify=True
     )
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
@@ -1105,9 +1107,11 @@ def test_http_alerter_with_payload_all_values():
     }
     mock_post_request.assert_called_once_with(
         rule['http_post_url'],
+        auth=None,
         data=mock.ANY,
         headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
-        proxies=None
+        proxies=None,
+        verify=True
     )
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
@@ -1135,9 +1139,11 @@ def test_http_alerter_without_payload():
     }
     mock_post_request.assert_called_once_with(
         rule['http_post_url'],
+        auth=None,
         data=mock.ANY,
         headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
-        proxies=None
+        proxies=None,
+        verify=True
     )
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 


### PR DESCRIPTION
add support for:
- http_post_username/http_post_password for basic auth
- add http_post_ignore_ssl_errors support 
- add http_post_headers 