### PR TITLE
Comply `elastalert-test-rule` with docs

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -76,7 +76,7 @@ class ElastAlerter():
         parser.add_argument('--rule', dest='rule', help='Run only a specific rule (by filename, must still be in rules folder)')
         parser.add_argument('--silence', dest='silence', help='Silence rule for a time period. Must be used with --rule. Usage: '
                                                               '--silence <units>=<number>, eg. --silence hours=2')
-        parser.add_argument('--start', dest='start', help='YYYY-MM-DDTHH:MM:SS Start querying from this timestamp.'
+        parser.add_argument('--start', dest='start', help='YYYY-MM-DDTHH:MM:SS Start querying from this timestamp. '
                                                           'Use "NOW" to start from current time. (Default: present)')
         parser.add_argument('--end', dest='end', help='YYYY-MM-DDTHH:MM:SS Query to this timestamp. (Default: present)')
         parser.add_argument('--verbose', action='store_true', dest='verbose', help='Increase verbosity without suppressing alerts. '


### PR DESCRIPTION
The [documentation](http://elastalert.readthedocs.io/en/latest/ruletypes.html#testing) states that one can use `elastalert-test-rule` with `--start` and `--end` arguments. This change makes it support them.

Thanks!

p.s.: I've created multiple pull requests in order to allow you to pick ones you'd like to accept