### PR TITLE
Fix sending telegram cropped message

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1308,7 +1308,7 @@ class TelegramAlerter(Alerter):
             if len(matches) > 1:
                 body += '\n----------------------------------------\n'
         if len(body) > 4095:
-            body = body[0:4000] + "\n⚠ *message was cropped according to telegram limits!* ⚠"
+            body = body[0:4000] + u"\n⚠ *message was cropped according to telegram limits!* ⚠"
         body += u' ```'
 
         headers = {'content-type': 'application/json'}


### PR DESCRIPTION
We need to use unicode string in cropped message.