### PR TITLE
[RFC] writeback_alias added as required global config value

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -57,6 +57,7 @@ es_port: 9200
 # This can be a unmapped index, but it is recommended that you run
 # elastalert-create-index to set a mapping
 writeback_index: elastalert_status
+writeback_alias: elastalert_alerts
 
 # If an alert fails for some reason, ElastAlert will retry
 # sending the alert until this time period has elapsed

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -29,7 +29,8 @@ from util import unixms_to_dt
 rule_schema = jsonschema.Draft4Validator(yaml.load(open(os.path.join(os.path.dirname(__file__), 'schema.yaml'))))
 
 # Required global (config.yaml) and local (rule.yaml)  configuration options
-required_globals = frozenset(['run_every', 'rules_folder', 'es_host', 'es_port', 'writeback_index', 'buffer_time'])
+required_globals = frozenset(['run_every', 'rules_folder', 'es_host', 'es_port', 'writeback_index',
+                              'writeback_alias', 'buffer_time'])
 required_locals = frozenset(['alert', 'type', 'name', 'index'])
 
 # Settings that can be derived from ENV variables

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -32,6 +32,7 @@ def main():
     parser.add_argument('--verify-certs', action='store_true', default=None, help='Verify TLS certificates')
     parser.add_argument('--no-verify-certs', dest='verify_certs', action='store_false', help='Do not verify TLS certificates')
     parser.add_argument('--index', help='Index name to create')
+    parser.add_argument('--alias', help='Alias name to create')
     parser.add_argument('--old-index', help='Old index name to copy')
     parser.add_argument('--send_get_body_as', default='GET', help='Method for querying Elasticsearch - POST, GET or source')
     parser.add_argument(
@@ -74,6 +75,7 @@ def main():
         client_cert = data.get('client_cert')
         client_key = data.get('client_key')
         index = args.index if args.index is not None else data.get('writeback_index')
+        alias = args.alias if args.alias is not None else data.get('writeback_alias')
         old_index = args.old_index if args.old_index is not None else None
     else:
         username = args.username if args.username else None
@@ -100,6 +102,9 @@ def main():
         index = args.index if args.index is not None else raw_input('New index name? (Default elastalert_status) ')
         if not index:
             index = 'elastalert_status'
+        alias = args.alias if args.alias is not None else raw_input('New alias name? (Default elastalert_alerts) ')
+        if not alias:
+            alias = 'elastalert_alias'
         old_index = (args.old_index if args.old_index is not None
                      else raw_input('Name of existing index to copy? (Default None) '))
 
@@ -128,7 +133,7 @@ def main():
     print("Elastic Version:" + esversion.split(".")[0])
     elasticversion = int(esversion.split(".")[0])
 
-    if(elasticversion > 5):
+    if elasticversion > 5:
         mapping = {'type': 'keyword'}
     else:
         mapping = {'index': 'not_analyzed', 'type': 'string'}
@@ -158,7 +163,7 @@ def main():
         print('Index ' + index + ' already exists. Skipping index creation.')
         return None
 
-    if (elasticversion > 5):
+    if elasticversion > 5:
         es.indices.create(index)
         es.indices.create(index+'_status')
         es.indices.create(index+'_silence')
@@ -170,12 +175,15 @@ def main():
     # To avoid a race condition. TODO: replace this with a real check
     time.sleep(2)
 
-    if(elasticversion > 5):
+    if elasticversion > 5:
         es.indices.put_mapping(index=index, doc_type='elastalert', body=es_mapping)
         es.indices.put_mapping(index=index+'_status', doc_type='elastalert_status', body=ess_mapping)
         es.indices.put_mapping(index=index+'_silence', doc_type='silence', body=silence_mapping)
         es.indices.put_mapping(index=index+'_error', doc_type='elastalert_error', body=error_mapping)
         es.indices.put_mapping(index=index+'_past', doc_type='past_elastalert', body=past_mapping)
+        es.indices.put_alias(index=index, name=alias)
+        es.indices.put_template(name='elastalert', body={'index_patterns': ['elastalert_*'],
+                                                         'aliases': {alias: {}}, 'mappings': es_mapping})
         print('New index %s created' % index)
     else:
         es.indices.put_mapping(index=index, doc_type='elastalert', body=es_mapping)
@@ -183,6 +191,9 @@ def main():
         es.indices.put_mapping(index=index, doc_type='silence', body=silence_mapping)
         es.indices.put_mapping(index=index, doc_type='elastalert_error', body=error_mapping)
         es.indices.put_mapping(index=index, doc_type='past_elastalert', body=past_mapping)
+        es.indices.put_alias(index=index, name=alias, body={'filter': {'term': {'_type': 'elastalert'}}})
+        es.indices.put_template(name='elastalert', body={'template': 'elastalert_*',
+                                                         'aliases': {alias: {}}, 'mappings': es_mapping})
         print('New index %s created' % index)
 
     if old_index:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -132,6 +132,7 @@ class ElastAlerter():
         self.scroll_keepalive = self.conf['scroll_keepalive']
         self.rules = self.conf['rules']
         self.writeback_index = self.conf['writeback_index']
+        self.writeback_alias = self.conf['writeback_alias']
         self.run_every = self.conf['run_every']
         self.alert_time_limit = self.conf['alert_time_limit']
         self.old_query_limit = self.conf['old_query_limit']
@@ -199,19 +200,27 @@ class ElastAlerter():
         else:
             return index
 
-    def get_six_index(self, doc_type):
-        """ In ES6, you cannot have multiple _types per index,
-        therefore we use self.writeback_index as the prefix for the actual
-        index name, based on doc_type. """
+    def get_writeback_index(self, doc_type, rule=None):
         writeback_index = self.writeback_index
-        if doc_type == 'silence':
-            writeback_index += '_silence'
-        elif doc_type == 'past_elastalert':
-            writeback_index += '_past'
-        elif doc_type == 'elastalert_status':
-            writeback_index += '_status'
-        elif doc_type == 'elastalert_error':
-            writeback_index += '_error'
+        if rule is None or 'writeback_suffix' not in rule:
+            if self.is_atleastsix():
+                if doc_type == 'silence':
+                    writeback_index += '_silence'
+                elif doc_type == 'past_elastalert':
+                    writeback_index += '_past'
+                elif doc_type == 'elastalert_status':
+                    writeback_index += '_status'
+                elif doc_type == 'elastalert_error':
+                    writeback_index += '_error'
+        else:
+            suffix = rule['writeback_suffix']
+            if '%' in rule['writeback_suffix']:
+                format_start = suffix.find('%')
+                format_end = suffix.rfind('%') + 2
+                ts = datetime.datetime.utcnow().strftime(suffix[format_start:format_end])
+                suffix = suffix[:format_start] + ts + suffix[format_end:]
+            writeback_index += '_' + suffix
+
         return writeback_index
 
     @staticmethod
@@ -644,13 +653,9 @@ class ElastAlerter():
         query.update(sort)
 
         try:
-            if self.is_atleastsix():
-                index = self.get_six_index('elastalert_status')
-                res = self.writeback_es.search(index=index, doc_type='elastalert_status',
-                                               size=1, body=query, _source_include=['endtime', 'rule_name'])
-            else:
-                res = self.writeback_es.search(index=self.writeback_index, doc_type='elastalert_status',
-                                               size=1, body=query, _source_include=['endtime', 'rule_name'])
+            index = self.get_writeback_index('elastalert_status')
+            res = self.writeback_es.search(index=index, doc_type='elastalert_status',
+                                           size=1, body=query, _source_include=['endtime', 'rule_name'])
             if res['hits']['hits']:
                 endtime = ts_to_dt(res['hits']['hits'][0]['_source']['endtime'])
 
@@ -1068,7 +1073,7 @@ class ElastAlerter():
         ref = clock()
         while (clock() - ref) < timeout:
             try:
-                if self.writeback_es.indices.exists(self.writeback_index):
+                if self.writeback_es.indices.exists(self.writeback_alias):
                     return
             except ConnectionError:
                 pass
@@ -1076,8 +1081,8 @@ class ElastAlerter():
 
         if self.writeback_es.ping():
             logging.error(
-                'Writeback index "%s" does not exist, did you run `elastalert-create-index`?',
-                self.writeback_index,
+                'Writeback alias "%s" does not exist, did you run `elastalert-create-index`?',
+                self.writeback_alias,
             )
         else:
             logging.error(
@@ -1375,7 +1380,7 @@ class ElastAlerter():
             # Set all matches to aggregate together
             if agg_id:
                 alert_body['aggregate_id'] = agg_id
-            res = self.writeback('elastalert', alert_body)
+            res = self.writeback('elastalert', alert_body, rule)
             if res and not agg_id:
                 agg_id = res['_id']
 
@@ -1399,10 +1404,8 @@ class ElastAlerter():
             body['alert_exception'] = alert_exception
         return body
 
-    def writeback(self, doc_type, body):
-        writeback_index = self.writeback_index
-        if(self.is_atleastsix()):
-            writeback_index = self.get_six_index(doc_type)
+    def writeback(self, doc_type, body, rule=None):
+        writeback_index = self.get_writeback_index(doc_type, rule)
 
         # ES 2.0 - 2.3 does not support dots in field names.
         if self.replace_dots_in_field_names:
@@ -1447,7 +1450,7 @@ class ElastAlerter():
             query = {'query': inner_query, 'filter': time_filter}
         query.update(sort)
         try:
-            res = self.writeback_es.search(index=self.writeback_index,
+            res = self.writeback_es.search(index=self.writeback_alias,
                                            doc_type='elastalert',
                                            body=query,
                                            size=1000)
@@ -1461,6 +1464,7 @@ class ElastAlerter():
         pending_alerts = self.find_recent_pending_alerts(self.alert_time_limit)
         for alert in pending_alerts:
             _id = alert['_id']
+            _index = alert['_index']
             alert = alert['_source']
             try:
                 rule_name = alert.pop('rule_name')
@@ -1503,7 +1507,7 @@ class ElastAlerter():
 
                 # Delete it from the index
                 try:
-                    self.writeback_es.delete(index=self.writeback_index,
+                    self.writeback_es.delete(index=_index,
                                              doc_type='elastalert',
                                              id=_id)
                 except ElasticsearchException:  # TODO: Give this a more relevant exception, try:except: is evil.
@@ -1535,13 +1539,13 @@ class ElastAlerter():
         query = {'query': {'query_string': {'query': 'aggregate_id:%s' % (_id)}}, 'sort': {'@timestamp': 'asc'}}
         matches = []
         try:
-            res = self.writeback_es.search(index=self.writeback_index,
+            res = self.writeback_es.search(index=self.writeback_alias,
                                            doc_type='elastalert',
                                            body=query,
                                            size=self.max_aggregation)
             for match in res['hits']['hits']:
                 matches.append(match['_source'])
-                self.writeback_es.delete(index=self.writeback_index,
+                self.writeback_es.delete(index=match['_index'],
                                          doc_type='elastalert',
                                          id=match['_id'])
         except (KeyError, ElasticsearchException) as e:
@@ -1559,7 +1563,7 @@ class ElastAlerter():
             query = {'query': {'bool': query}}
         query['sort'] = {'alert_time': {'order': 'desc'}}
         try:
-            res = self.writeback_es.search(index=self.writeback_index,
+            res = self.writeback_es.search(index=self.writeback_alias,
                                            doc_type='elastalert',
                                            body=query,
                                            size=1)
@@ -1636,7 +1640,7 @@ class ElastAlerter():
             alert_body['aggregate_id'] = agg_id
         if aggregation_key_value:
             alert_body['aggregation_key'] = aggregation_key_value
-        res = self.writeback('elastalert', alert_body)
+        res = self.writeback('elastalert', alert_body, rule)
 
         # If new aggregation, save _id
         if res and not agg_id:
@@ -1701,13 +1705,9 @@ class ElastAlerter():
         query.update(sort)
 
         try:
-            if(self.is_atleastsix()):
-                index = self.get_six_index('silence')
-                res = self.writeback_es.search(index=index, doc_type='silence',
-                                               size=1, body=query, _source_include=['until', 'exponent'])
-            else:
-                res = self.writeback_es.search(index=self.writeback_index, doc_type='silence',
-                                               size=1, body=query, _source_include=['until', 'exponent'])
+            index = self.get_writeback_index('silence')
+            res = self.writeback_es.search(index=index, doc_type='silence',
+                                           size=1, body=query, _source_include=['until', 'exponent'])
         except ElasticsearchException as e:
             self.handle_error("Error while querying for alert silence status: %s" % (e), {'rule': rule_name})
 

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -304,6 +304,7 @@ class MockElastAlerter(object):
             'es_host': 'localhost',
             'es_port': 14900,
             'writeback_index': 'wb',
+            'writeback_alias': 'wb_a',
             'max_query_size': 10000,
             'alert_time_limit': datetime.timedelta(hours=24),
             'old_query_limit': datetime.timedelta(weeks=1),

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -21,7 +21,8 @@ test_config = {'rules_folder': 'test_folder',
                'buffer_time': {'minutes': 10},
                'es_host': 'elasticsearch.test',
                'es_port': 12345,
-               'writeback_index': 'test_index'}
+               'writeback_index': 'test_index',
+               'writeback_alias': 'test_alias'}
 
 test_rule = {'es_host': 'test_host',
              'es_port': 12345,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,7 @@ def ea():
             'es_host': 'es',
             'es_port': 14900,
             'writeback_index': 'wb',
+            'writeback_alias': 'wb_a',
             'rules': rules,
             'max_query_size': 10000,
             'old_query_limit': datetime.timedelta(weeks=1),


### PR DESCRIPTION
I've been wanting to separate out my alerts into different indexes, for example by date.
This is working attempt of this but doesn't have the necessary documentation updates.

I've added a new `writeback_alias` as a required value in `required_globals`. An alias to the `elastalert` index (defaults for `elastalert_alerts`) and a template for `elastalert_*` indices that can be generated on the fly. Elastalert then uses the alias when searching for alerts.

Rules have a new optional value of `writeback_suffix`. This can include a timestamp. For example:
`writeback_suffix: %Y.%d` would mean that your alerts would be put into an index like `elastalert_2018.03`.

I would love feedback/comments on this! Where this could be improved. I've tried to ensure it is backwards compatible but I have not tested in ES2 (or ES6)