### PR TITLE
Adding additional parameters to the ServiceNow Alert

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1669,6 +1669,20 @@ Optional:
 
 ``servicenow_proxy``: By default ElastAlert will not use a network proxy to send notifications to ServiceNow. Set this option using ``hostname:port`` if you need to use a proxy.
 
+``caller_id``: Used to log the ticket under another name than user making request.
+
+``impact``: Used to specify the impact of the incident created.
+
+``urgency``: Used to specify the urgency of the incident created.
+
+``u_originating_group``: The originating group the incident is for.
+
+``u_division``: The Division the incident is specified for.
+
+``contact_type``: The preferred contact method.
+
+``opened_by``: Specifies the user that opened it.
+
 
 Debug
 ~~~~~

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1409,7 +1409,13 @@ class ServiceNowAlerter(Alerter):
             "category": self.rule['category'],
             "subcategory": self.rule['subcategory'],
             "cmdb_ci": self.rule['cmdb_ci'],
-            "caller_id": self.rule["caller_id"]
+            "caller_id": self.rule["caller_id"],
+            "impact": self.rule["impact"],
+            "urgency": self.rule["urgency"],
+            "u_originating_group": self.rule["u_originating_group"],
+            "u_division": self.rule["u_division"],
+            "contact_type": self.rule["contact_type"],
+            "opened_by": self.rule["opened_by"]
         }
         try:
             response = requests.post(

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -237,6 +237,14 @@ properties:
   slack_parse_override: {enum: [none, full]}
   slack_text_string: {type: string}
 
+  ### ServiceNow
+  impact: {type: [string, integer]}
+  urgency: {type: [string, integer]}
+  u_originating_group: {type: string}
+  u_division: {type: string}
+  contact_type: {type: string}
+  opened_by: {type: string}
+
   ### PagerDuty
   pagerduty_service_key: {type: string}
   pagerduty_client_name: {type: string}


### PR DESCRIPTION
Hey y'all,

I needed to add some additional parameters to the Service Now alert so I can alter the urgency/impact of incidents being created to Service Now.

I'm not 100% sure if some of these fields are specific to my needs only, or could be used in general. Please let me know if there is anything else that I should add, or remove.

Thanks!