### PR TITLE
Added scan_entire_timeframe feature

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -84,6 +84,8 @@ Rule Configuration Cheat Sheet
 +--------------------------------------------------------------+           |
 | ``priority`` (int, default 2)                                |           |
 +--------------------------------------------------------------+           |
+| ``scan_entire_timeframe`` (bool, default False)              |           |
++--------------------------------------------------------------+           |
 | ``import`` (string)                                          |           |
 |                                                              |           |
 | IGNORED IF ``use_count_query`` or ``use_terms_query`` is true|           |
@@ -576,7 +578,9 @@ scan_entire_timeframe
 
 ``scan_entire_timeframe``: If true, when ElastAlert starts, it will always start querying at the current time minus the timeframe.
 ``timeframe`` must exist in the rule. This may be useful, for example, if you are using a flatline rule type with a large timeframe,
-and you want to be sure that if ElastAlert restarts, you can still get alerts. This may cause duplicate alerts for some rule types.
+and you want to be sure that if ElastAlert restarts, you can still get alerts. This may cause duplicate alerts for some rule types,
+for example, Frequency can alert multiple times in a single timeframe, and if ElastAlert were to restart with this setting, it may
+scan the same range again, triggering duplicate alerts.
 
 Some rules and alerts require additional options, which also go in the top level of the rule configuration file.
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -571,6 +571,13 @@ ElastAlert will use ``fields`` to retrieve stored fields. Both of these are repr
 See https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-fields.html for more details. The fields used come from ``include``,
 see above for more details. (Optional, boolean, default True)
 
+scan_entire_timeframe
+^^^^^^^^^^^^^^^^^^^^^
+
+``scan_entire_timeframe``: If true, when ElastAlert starts, it will always start querying at the current time minus the timeframe.
+``timeframe`` must exist in the rule. This may be useful, for example, if you are using a flatline rule type with a large timeframe,
+and you want to be sure that if ElastAlert restarts, you can still get alerts. This may cause duplicate alerts for some rule types.
+
 Some rules and alerts require additional options, which also go in the top level of the rule configuration file.
 
 

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -319,6 +319,9 @@ def load_options(rule, conf, filename, args=None):
                                 'The index will be formatted like %s' % (token,
                                                                          datetime.datetime.now().strftime(rule.get('index'))))
 
+    if rule.get('scan_entire_timeframe') and not rule.get('timeframe'):
+        raise EAException('scan_entire_timeframe can only be used if there is a timeframe specified')
+
 
 def load_modules(rule, args=None):
     """ Loads things that could be modules. Enhancements, alerts and rule type. """

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -174,6 +174,7 @@ properties:
   match_enhancements: {type: array, items: {type: string}}
   query_key: *arrayOfString
   replace_dots_in_field_names: {type: boolean}
+  scan_entire_timeframe: {type: boolean}
 
   # Alert Content
   alert_text: {type: string} # Python format string

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -851,6 +851,16 @@ def test_set_starttime(ea):
     ea.set_starttime(ea.rules[0], end)
     assert ea.rules[0]['starttime'] == ea.rules[0]['previous_endtime']
 
+    # scan_entire_timeframe
+    ea.rules[0].pop('previous_endtime')
+    ea.rules[0].pop('starttime')
+    ea.rules[0]['timeframe'] = datetime.timedelta(days=3)
+    ea.rules[0]['scan_entire_timeframe'] = True
+    with mock.patch.object(ea, 'get_starttime') as mock_gs:
+        mock_gs.return_value = None
+        ea.set_starttime(ea.rules[0], end)
+    assert ea.rules[0]['starttime'] == end - datetime.timedelta(days=3)
+
 
 def test_kibana_dashboard(ea):
     match = {'@timestamp': '2014-10-11T00:00:00'}


### PR DESCRIPTION
Allow you to ignore the previous endtime and instead the entire timeframe. This is useful when using flatline type if you need a long timeframe and are worried that the service restarting will prevent the full timeframe from ever elapsing.