### PR TITLE
Configure ElasticSearch URL prefix using environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ build/
 
 my_rules
 *.swp
+*~

--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -125,7 +125,7 @@ The environment variable ``ES_USE_SSL`` will override this field.
 
 ``es_password``: Optional; basic-auth password for connecting to ``es_host``. The environment variable ``ES_PASSWORD`` will override this field.
 
-``es_url_prefix``: Optional; URL prefix for the Elasticsearch endpoint.
+``es_url_prefix``: Optional; URL prefix for the Elasticsearch endpoint.  The environment variable ``ES_URL_PREFIX`` will override this field.
 
 ``es_send_get_body_as``: Optional; Method for querying Elasticsearch - ``GET``, ``POST`` or ``source``. The default is ``GET``
 

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -37,7 +37,8 @@ env_settings = {'ES_USE_SSL': 'use_ssl',
                 'ES_PASSWORD': 'es_password',
                 'ES_USERNAME': 'es_username',
                 'ES_HOST': 'es_host',
-                'ES_PORT': 'es_port'}
+                'ES_PORT': 'es_port',
+                'ES_URL_PREFIX': 'es_url_prefix'}
 
 env = Env(ES_USE_SSL=bool)
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -233,6 +233,22 @@ def test_load_ssl_env_true():
                 assert rules['use_ssl'] is True
 
 
+def test_load_url_prefix_env():
+    test_rule_copy = copy.deepcopy(test_rule)
+    test_rule_copy.pop('es_host')
+    test_rule_copy.pop('es_port')
+    test_config_copy = copy.deepcopy(test_config)
+    with mock.patch('elastalert.config.yaml_loader') as mock_open:
+        mock_open.side_effect = [test_config_copy, test_rule_copy]
+
+        with mock.patch('os.listdir') as mock_ls:
+            with mock.patch.dict(os.environ, {'ES_URL_PREFIX': 'es/'}):
+                mock_ls.return_value = ['testrule.yaml']
+                rules = load_rules(test_args)
+
+                assert rules['es_url_prefix'] == 'es/'
+
+
 def test_load_disabled_rules():
     test_rule_copy = copy.deepcopy(test_rule)
     test_rule_copy['is_enabled'] = False


### PR DESCRIPTION
I run `elastalert` inside a container against multiple environments and the value I need to put in `es_url_prefix` changes depending on the environment.

Currently, I need to write a new `config.yaml` file for each environment and bind-mount it into the container, which is pretty tedious.  I can already configure `es_host`, `es_port` and `use_ssl` using environment variables, so I though doing the same for `es_url_prefix` would be neat.

Let me know what you think :-)