### PR TITLE
Relax requirement on `doc_type` option in `metric_aggregation` rules

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -949,7 +949,7 @@ class BaseAggregationRule(RuleType):
 
 class MetricAggregationRule(BaseAggregationRule):
     """ A rule that matches when there is a low number of events given a timeframe. """
-    required_options = frozenset(['metric_agg_key', 'metric_agg_type', 'doc_type'])
+    required_options = frozenset(['metric_agg_key', 'metric_agg_type'])
     allowed_aggregations = frozenset(['min', 'max', 'avg', 'sum', 'cardinality', 'value_count'])
 
     def __init__(self, *args):


### PR DESCRIPTION
Presence of the `doc_type` option in metric aggregation rules is enforced, but the code doesn't seem to use it and metric aggregation rules work fine in practice when you remove this requirement.

See issues #1557 and #1622.