### PR TITLE
Added support for alerts for Alerta. Taken from Pull Request #848

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1702,6 +1702,80 @@ Optional:
 
 The stomp_destination field depends on the broker, the /queue/ALERT example is the nomenclature used by ActiveMQ. Each broker has its own logic.
 
+Alerta
+~~~~~~
+
+Alerta alerter will post an alert in the Alerta server instance through the alert API endpoint. 
+The default values will work with a local Alerta server installation with authorization disabled.
+See http://alerta.readthedocs.io/en/latest/api/alert.html for more details on the Alerta alert json format.
+
+Required:
+
+``alerta_api_url``: API server URL. 
+
+Optional:
+
+``alerta_api_key``: This is the api key for alerta server if required. Default behaviour is that no Authorization header sent with the request.
+
+``alerta_resource``: The resource name of the generated alert. Defaults to "elastalert". Can be a reference to a part of the match.
+
+``alerta_service``: A list of service tags for the generated alert. Defaults to "elastalert".  Can be a reference to a part of the match.
+
+``alerta_severity``: The severity level of the alert. Defaults to "warning". 
+
+``alerta_origin``: The origin field for the generated alert. Defaults to "elastalert".  Can be a reference to a part of the match.
+
+``alerta_environment``: The environment field for the generated alert. Defaults to "Production".  Can be a reference to a part of the match.
+
+``alerta_group``: The group field for the generated alert. No Default. Can be a reference to a part of the match.
+
+``alerta_timeout``: The time in seconds before this alert will expire (in Alerta). Default 84600 (1 Day).
+
+``alerta_correlate``: A list of alerta events that this one correlates with. Default is an empty list. Can make reference to a part of the match to build the event name.
+
+``alerta_tags``: A list of alerta tags. Default is an empty list.  Can be a reference to a part of the match.
+
+``alerta_use_qk_as_resource``: If true and query_key is present this will override alerta_resource field with the query key value (Can be useful if query_key is a hostname).
+
+``alerta_use_match_timestamp``: If true will use the timestamp of the first match as the createTime of the alert, otherwise the current time is used. Default False. 
+
+``alerta_ssl``: If true alerts will be sent over https to the alerta server api.
+
+``alerta_event``: Can make reference to parts of the match to build the event name. Defaults to "elastalert".
+
+``alerta_customer``: No Default.
+
+``alerta_text``: Python-style string can be used to make reference to parts of the match. Defaults to "elastalert".
+
+``alerta_type``: Defaults to "elastalert".
+
+``alerta_value``: Can be a reference to a part of the match. No Default.
+
+``alerta_attributes_keys``: List of key names for the Alerta Attributes dictionary
+
+``alerta_attributes_values``: List of values for the Alerta Attributes dictionary, corresponding in order to the described keys. Can be a reference to a part of the match.
+
+``alerta_new_style_string_format``: If True, the optional values that make reference to fields in the match are expected on the new-style format ``{match[<field>]}``.
+
+.. info::
+
+    The optional values use Python-like string syntax ``{match[<field>]}`` or ``%(<field>)s`` to access parts of the match, similar to the CommandAlerter. Ie: "Alert for {match[clientip]}"
+    If the referenced value is not found in the match, it is replaced by ``<MISSING VALUE>`` or the text indicated by the rule in ``alert_missing_value``.
+
+Example usage using old-style format::
+
+    alert:
+      - alerta
+    alerta_api_url: "http://youralertahost/api/alert"
+    alerta_attributes_keys:   ["hostname",   "TimestampEvent",  "senderIP" ]
+    alerta_attributes_values: ["%(key)s",    "%(logdate)s",     "%(sender_ip)s"  ]
+    alerta_correlate: ["ProbeUP","ProbeDOWN"]
+    alerta_event: "ProbeUP"
+    alerta_text:  "Probe %(hostname)s is UP at %(logdate)s GMT"
+    alerta_value: "UP"
+    
+    
+    
 HTTP POST
 ~~~~~~~~~
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -33,7 +33,8 @@ from util import elastalert_logger
 from util import lookup_es_key
 from util import pretty_ts
 from util import ts_now
-from util import ts_to_dt 
+from util import ts_to_dt
+
 
 class DateTimeEncoder(json.JSONEncoder):
     def default(self, obj):
@@ -45,7 +46,6 @@ class DateTimeEncoder(json.JSONEncoder):
 
 class BasicMatchString(object):
     """ Creates a string containing fields in match for the given rule. """
-
     def __init__(self, rule, match):
         self.rule = rule
         self.match = match
@@ -855,7 +855,7 @@ class CommandAlerter(Alerter):
             self.new_style_string_format = True
 
     def alert(self, matches):
-         # Format the command and arguments
+        # Format the command and arguments
         try:
             if self.new_style_string_format:
                 command = [command_arg.format(match=matches[0]) for command_arg in self.rule['command']]
@@ -864,7 +864,7 @@ class CommandAlerter(Alerter):
             self.last_command = command
         except KeyError as e:
             raise EAException("Error formatting command: %s" % (e))
-        
+
         # Run command and pipe data
         try:
             subp = subprocess.Popen(command, stdin=subprocess.PIPE, shell=self.shell)
@@ -1438,7 +1438,7 @@ class AlertaAlerter(Alerter):
 
         self.url = self.rule.get('alerta_api_url', None)
 
-        #Fill up default values
+        # Fill up default values
         self.api_key = self.rule.get('alerta_api_key', None)
         self.severity = self.rule.get('alerta_severity', 'warning')
         self.resource = self.rule.get('alerta_resource', 'elastalert')
@@ -1448,17 +1448,17 @@ class AlertaAlerter(Alerter):
         self.timeout = self.rule.get('alerta_timeout', 86400)
         self.use_match_timestamp = self.rule.get('alerta_use_match_timestamp', False)
         self.use_qk_as_resource = self.rule.get('alerta_use_qk_as_resource', False)
-        self.text= self.rule.get('alerta_text', 'elastalert')
-        self.type= self.rule.get('alerta_type', 'elastalert')
-        self.event=  self.rule.get('alerta_event', 'elastalert')
+        self.text = self.rule.get('alerta_text', 'elastalert')
+        self.type = self.rule.get('alerta_type', 'elastalert')
+        self.event = self.rule.get('alerta_event', 'elastalert')
         self.correlate = self.rule.get('alerta_correlate', [])
         self.tags = self.rule.get('alerta_tags', [])
-        self.group = self.rule.get('alerta_group','')
-        self.customer = self.rule.get('alerta_customer','')
+        self.group = self.rule.get('alerta_group', '')
+        self.customer = self.rule.get('alerta_customer', '')
         self.attributes_keys = self.rule.get('alerta_attributes_keys', [])
         self.attributes_values = self.rule.get('alerta_attributes_values', [])
         self.value = self.rule.get('alerta_value', '')
-        self.use_new_string_format = self.rule.get('alerta_new_style_string_format',False)
+        self.use_new_string_format = self.rule.get('alerta_new_style_string_format', False)
 
     def alert(self, matches):
 
@@ -1467,10 +1467,9 @@ class AlertaAlerter(Alerter):
         else:
             createTime = ts_to_dt(lookup_es_key(matches[0], self.rule['timestamp_field'])).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
-        
         self.resolve_match_fields(matches[0])
 
-        #Override the resource if requested
+        # Override the resource if requested
         if self.use_qk_as_resource and 'query_key' in self.rule and self.rule['query_key'] in matches[0]:
             self.resource = lookup_es_key(matches[0], self.rule['query_key'])
 
@@ -1481,10 +1480,9 @@ class AlertaAlerter(Alerter):
             headers['Authorization'] = 'Key %s' % (self.rule['alerta_api_key'])
 
         if self.text == '':
-            self.text =  self.rule['type'].get_match_str(matches[0])
+            self.text = self.rule['type'].get_match_str(matches[0])
         if self.event == '':
             self.event = self.create_default_title(matches)
-
 
         # set https proxy, if it was provided
         payload = {
@@ -1494,7 +1492,6 @@ class AlertaAlerter(Alerter):
             'severity': self.severity,
             'text': self.text,
             'environment': self.environment,
-            'severity': self.severity,
             'group': self.group,
             'service': self.service,
             'timeout': self.timeout,
@@ -1502,16 +1499,14 @@ class AlertaAlerter(Alerter):
             'correlate': self.correlate,
             'tags': self.tags,
             'customer': self.customer,
-            'type' : self.type,
-            'value' : self.value,
+            'type': self.type,
+            'value': self.value,
             'attributes': dict(zip(self.attributes_keys, self.attributes_values)),
             'rawData': self.create_alert_body(matches),
         }
 
         try:
-            response = requests.post(self.url, data = json.dumps(payload, cls=DateTimeEncoder), headers=headers)
-
-            #print(json.dumps(payload, cls=DateTimeEncoder))
+            response = requests.post(self.url, data=json.dumps(payload, cls=DateTimeEncoder), headers=headers)
 
             response.raise_for_status()
         except RequestException as e:
@@ -1533,13 +1528,13 @@ class AlertaAlerter(Alerter):
         return {'type': 'alerta',
                 'alerta_url': self.url}
 
-    def resolve_match_fields(self,match):
+    def resolve_match_fields(self, match):
         """
             For the values that could have references to fields on the match, resolve those references
         """
-        
+
         self.match_dictionary = match
-        
+
         self.resource = self.replace_string_from_match(self.resource)
         self.environment = self.replace_string_from_match(self.environment)
         self.origin = self.replace_string_from_match(self.origin)
@@ -1547,48 +1542,52 @@ class AlertaAlerter(Alerter):
         self.event = self.replace_string_from_match(self.event)
         self.text = self.replace_string_from_match(self.text)
         self.value = self.replace_string_from_match(self.value)
-        alerta_service =  [ self.replace_string_from_match(a_service) for a_service in self.service ]
+        alerta_service = [self.replace_string_from_match(a_service) for a_service in self.service]
         self.service = alerta_service
-        alerta_tags = [ self.replace_string_from_match(a_tag) for a_tag in self.tags ]
+        alerta_tags = [self.replace_string_from_match(a_tag) for a_tag in self.tags]
         self.tags = alerta_tags
-        alerta_correlate = [ self.replace_string_from_match(an_event) for an_event in self.correlate ]
+        alerta_correlate = [self.replace_string_from_match(an_event) for an_event in self.correlate]
         self.correlate = alerta_correlate
-        alerta_attributes_values = [ self.replace_string_from_match(a_value) for a_value in self.attributes_values ]
+        alerta_attributes_values = [self.replace_string_from_match(a_value) for a_value in self.attributes_values]
         self.attributes_values = alerta_attributes_values
-        
-    def replace_string_from_match(self, string ):
+
+    def replace_string_from_match(self, string):
         """
-            Given a python string that may contain references to fields on the match dictionary, the string is completed using the corresponding values.
-            However, if the referenced field is not found on the dictionary, it is replaced by a default string.
-            Strings can be formatted using the old-style format ('%(field)s') or the new-style format ('{match[field]}'), according to 'use_new_string_format'
+            Given a python string that may contain references to fields on the match dictionary,
+                the strings are replaced using the corresponding values.
+            However, if the referenced field is not found on the dictionary,
+                it is replaced by a default string.
+            Strings can be formatted using the old-style format ('%(field)s') or
+                the new-style format ('{match[field]}'), according to 'use_new_string_format'.
 
             :param python_string: A string that may contain references to values of the 'match' dictionary.
             :param match_dictio: A dictionary with the values to replace where referenced by keys in the string.
             :param use_new_string_format: If True, the string is expected to use the new-style format '{match[field]}'
-            
-            The text used when the reference field is not used is determined by the rule's argument 'alert_missing_value', or '<MISSING VALUE>' by default
+
+            The text used when the reference field is not used is determined
+                by the rule's argument 'alert_missing_value', or '<MISSING VALUE>' by default.
         """
         missing_text = self.rule.get('alert_missing_value', '<MISSING VALUE>')
-        
+
         if self.use_new_string_format:
             match_field_regex = re.compile('.*({match\[(\w+)\]}).*')
             match_field_definition_regex = re.compile('{match\[(\w+)\]}')
         else:
             match_field_regex = re.compile('.*(%\(\w+\)s).*')
             match_field_definition_regex = re.compile('%\((\w+)\)s')
-        
+
         while True:
             regex_match = match_field_regex.search(string)
             if regex_match is not None:
-                match_field =   regex_match.group(1)
+                match_field = regex_match.group(1)
                 regex_match = match_field_definition_regex.search(match_field)
                 if regex_match is not None:
                     match_field_key = regex_match.group(1)
-                    match_field_value = lookup_es_key(self.match_dictionary, match_field_key )
+                    match_field_value = lookup_es_key(self.match_dictionary, match_field_key)
                     match_field_value = missing_text if match_field_value is None else match_field_value
-                    string = string.replace(match_field,match_field_value)
+                    string = string.replace(match_field, match_field_value)
                 else:
-                    string = string.replace(match_field,missing_text)
+                    string = string.replace(match_field, missing_text)
             else:
                 break
         return string

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -79,6 +79,7 @@ alerts_mapping = {
     'telegram': alerts.TelegramAlerter,
     'gitter': alerts.GitterAlerter,
     'servicenow': alerts.ServiceNowAlerter,
+    'alerta': alerts.AlertaAlerter,
     'post': alerts.HTTPPostAlerter
 }
 # A partial ordering of alert types. Relative order will be preserved in the resulting alerts list

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -272,6 +272,28 @@ properties:
   gitter_proxy: {type: string}
   gitter_msg_level: {enum: [info, error]}
 
+  ### Alerta
+  alerta_api_url: {type: string}
+  alerta_api_key: {type: string}
+  alerta_severity: {enum: [unknown, security, debug, informational, ok, normal, cleared, indeterminate, warning, minor, major, critical]}
+  alerta_resource: {type: string}   # Python format string
+  alerta_environment: {type: string}  # Python format string
+  alerta_origin: {type: string}   # Python format string
+  alerta_group: {type: string}  # Python format string
+  alerta_service: {type: array, items: {type: string}}  # Python format string
+  alerta_service: {type: array, items: {type: string}}  # Python format string
+  alerta_correlate: {type: array, items: {type: string}}  # Python format string
+  alerta_tags: {type: array, items: {type: string}}   # Python format string
+  alerta_event: {type: string} # Python format string
+  alerta_customer: {type: string}
+  alerta_text: {type: string} # Python format string
+  alerta_type: {type: string} 
+  alerta_value: {type: string} # Python format string
+  alerta_attributes_keys: {type: array, items: {type: string}}  
+  alerta_attributes_values: {type: array, items: {type: string}}  # Python format string
+  alerta_new_style_string_format: {type: boolean}
+
+
   ### Simple
   simple_webhook_url: *arrayOfString
   simple_proxy: {type: string}

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -46,7 +46,6 @@ def _find_es_dict_by_key(lookup_dict, term):
     """
     if term in lookup_dict:
         return lookup_dict, term
-
     # If the term does not match immediately, perform iterative lookup:
     # 1. Split the search term into tokens
     # 2. Recurrently concatenate these together to traverse deeper into the dictionary,

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -771,7 +771,6 @@ def test_kibana(ea):
     # Included fields active in table
     assert dashboard['rows'][1]['panels'][0]['fields'] == ['@timestamp']
 
-   
 
 def test_command():
     # Test command as list with a formatted arg
@@ -1704,12 +1703,12 @@ def test_stride_html():
     assert expected_data == json.loads(
         mock_post_request.call_args_list[0][1]['data'])
 
-        
+
 def test_alerta_replace_string_from_match(ea):
     match = {
-        'name':'mySystem' , 
-        'temperature':'45', 
-        'sensor':'outsideSensor'
+        'name': 'mySystem',
+        'temperature': '45',
+        'sensor': 'outsideSensor'
         }
     rule = {
             'name': 'Test Alerta rule!',
@@ -1718,26 +1717,40 @@ def test_alerta_replace_string_from_match(ea):
 
     alert = AlertaAlerter(rule)
     alert.match_dictionary = match
-    
-    assert alert.replace_string_from_match("%(name)s is online %(noKey)s" ) == "mySystem is online <MISSING VALUE>"
-    assert alert.replace_string_from_match("Sensor %(sensor)s in the %(noPlace)s has temp %(temperature)s") == 'Sensor outsideSensor in the <MISSING VALUE> has temp 45'
-    assert alert.replace_string_from_match("Actuator %(noKey)s in the %(noPlace)s has temp %(noKey)s" ) == 'Actuator <MISSING VALUE> in the <MISSING VALUE> has temp <MISSING VALUE>'
-    
+
+    expected_outputs = [
+                        "mySystem is online <MISSING VALUE>",
+                        'Sensor outsideSensor in the <MISSING VALUE> has temp 45',
+                        'Actuator <MISSING VALUE> in the <MISSING VALUE> has temp <MISSING VALUE>']
+    old_style_strings = [
+                        "%(name)s is online %(noKey)s",
+                        "Sensor %(sensor)s in the %(noPlace)s has temp %(temperature)s",
+                        "Actuator %(noKey)s in the %(noPlace)s has temp %(noKey)s"]
+
+    assert alert.replace_string_from_match(old_style_strings[0]) == expected_outputs[0]
+    assert alert.replace_string_from_match(old_style_strings[1]) == expected_outputs[1]
+    assert alert.replace_string_from_match(old_style_strings[2]) == expected_outputs[2]
+
     alert.use_new_string_format = True
-    
-    assert alert.replace_string_from_match("{match[name]} is online {match[noKey]}" ) == "mySystem is online <MISSING VALUE>"
-    assert alert.replace_string_from_match("Sensor {match[sensor]} in the {match[noPlace]} has temp {match[temperature]}") == 'Sensor outsideSensor in the <MISSING VALUE> has temp 45'
-    assert alert.replace_string_from_match("Actuator {match[noKey]} in the {match[noPlace]} has temp {match[noKey]}" ) == 'Actuator <MISSING VALUE> in the <MISSING VALUE> has temp <MISSING VALUE>'
- 
+    new_style_strings = [
+                        "{match[name]} is online {match[noKey]}",
+                        "Sensor {match[sensor]} in the {match[noPlace]} has temp {match[temperature]}",
+                        "Actuator {match[noKey]} in the {match[noPlace]} has temp {match[noKey]}"]
+
+    assert alert.replace_string_from_match(new_style_strings[0]) == expected_outputs[0]
+    assert alert.replace_string_from_match(new_style_strings[1]) == expected_outputs[1]
+    assert alert.replace_string_from_match(new_style_strings[2]) == expected_outputs[2]
+
+
 def test_alerta_no_auth(ea):
     rule = {
             'name': 'Test Alerta rule!',
             'alerta_api_url': 'http://elastalerthost:8080/api/alert',
             'timeframe': datetime.timedelta(hours=1),
             'timestamp_field': '@timestamp',
-            'alerta_attributes_keys':   ["hostname",   "TimestampEvent",    "senderIP" ],
-            'alerta_attributes_values': ["%(key)s",    "%(logdate)s",       "%(sender_ip)s"  ],
-            'alerta_correlate': ["ProbeUP","ProbeDOWN"],
+            'alerta_attributes_keys': ["hostname",   "TimestampEvent",    "senderIP"],
+            'alerta_attributes_values': ["%(key)s",    "%(logdate)s",       "%(sender_ip)s"],
+            'alerta_correlate': ["ProbeUP", "ProbeDOWN"],
             'alerta_event': "ProbeUP",
             'alerta_group': "Health",
             'alerta_origin': "Elastalert",
@@ -1749,35 +1762,35 @@ def test_alerta_no_auth(ea):
             }
 
     match = {
-            '@timestamp': '2014-10-10T00:00:00', 
+            '@timestamp': '2014-10-10T00:00:00',
             # 'key': ---- missing field on purpose, to verify that simply the text is left empty
             # 'logdate': ---- missing field on purpose, to verify that simply the text is left empty
             'sender_ip': '1.1.1.1',
             'hostname': 'aProbe'
             }
-        
+
     load_modules(rule)
     alert = AlertaAlerter(rule)
     with mock.patch('requests.post') as mock_post_request:
         alert.alert([match])
 
     expected_data = {
-        "origin": "Elastalert", 
-        "customer": "", 
-        "resource": "elastalert", 
-        "severity": "debug", 
-        "service": ["elastalert"], 
-        "tags": [], 
-        "text": "Probe aProbe is UP at <MISSING VALUE> GMT", 
-        "value": "UP", 
-        "createTime": "2014-10-10T00:00:00.000000Z", 
-        "environment": "Production", 
-        "rawData": "Test Alerta rule!\n\n@timestamp: 2014-10-10T00:00:00\nhostname: aProbe\nsender_ip: 1.1.1.1\n", 
-        "timeout": 86400, 
-        "correlate": ["ProbeUP", "ProbeDOWN"], 
-        "group": "Health", 
-        "attributes": {"senderIP": "1.1.1.1", "hostname": "<MISSING VALUE>", "TimestampEvent": "<MISSING VALUE>"}, 
-        "type": "elastalert", 
+        "origin": "Elastalert",
+        "customer": "",
+        "resource": "elastalert",
+        "severity": "debug",
+        "service": ["elastalert"],
+        "tags": [],
+        "text": "Probe aProbe is UP at <MISSING VALUE> GMT",
+        "value": "UP",
+        "createTime": "2014-10-10T00:00:00.000000Z",
+        "environment": "Production",
+        "rawData": "Test Alerta rule!\n\n@timestamp: 2014-10-10T00:00:00\nhostname: aProbe\nsender_ip: 1.1.1.1\n",
+        "timeout": 86400,
+        "correlate": ["ProbeUP", "ProbeDOWN"],
+        "group": "Health",
+        "attributes": {"senderIP": "1.1.1.1", "hostname": "<MISSING VALUE>", "TimestampEvent": "<MISSING VALUE>"},
+        "type": "elastalert",
         "event": "ProbeUP"
         }
 
@@ -1785,10 +1798,11 @@ def test_alerta_no_auth(ea):
         alert.url,
         data=mock.ANY,
         headers={
-            'content-type': 'application/json' }
+            'content-type': 'application/json'}
     )
     assert expected_data == json.loads(
         mock_post_request.call_args_list[0][1]['data'])
+
 
 def test_alerta_auth(ea):
     rule = {
@@ -1807,16 +1821,15 @@ def test_alerta_auth(ea):
             'sender_ip': '1.1.1.1',
             'hostname': 'aProbe'
             }
-            
+
     load_modules(rule)
     alert = AlertaAlerter(rule)
     with mock.patch('requests.post') as mock_post_request:
         alert.alert([match])
-        
+
     mock_post_request.assert_called_once_with(
         alert.url,
         data=mock.ANY,
         headers={
-            'content-type': 'application/json' ,
+            'content-type': 'application/json',
             'Authorization': 'Key {}'.format(rule['alerta_api_key'])})
-

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -19,8 +19,10 @@ from elastalert.alerts import MsTeamsAlerter
 from elastalert.alerts import PagerDutyAlerter
 from elastalert.alerts import SlackAlerter
 from elastalert.alerts import StrideAlerter
+from elastalert.alerts import AlertaAlerter
 from elastalert.config import load_modules
 from elastalert.opsgenie import OpsGenieAlerter
+
 from elastalert.util import ts_add
 from elastalert.util import ts_now
 
@@ -769,6 +771,7 @@ def test_kibana(ea):
     # Included fields active in table
     assert dashboard['rows'][1]['panels'][0]['fields'] == ['@timestamp']
 
+   
 
 def test_command():
     # Test command as list with a formatted arg
@@ -1700,3 +1703,120 @@ def test_stride_html():
     )
     assert expected_data == json.loads(
         mock_post_request.call_args_list[0][1]['data'])
+
+        
+def test_alerta_replace_string_from_match(ea):
+    match = {
+        'name':'mySystem' , 
+        'temperature':'45', 
+        'sensor':'outsideSensor'
+        }
+    rule = {
+            'name': 'Test Alerta rule!',
+            'alerta_api_url': 'http://elastalerthost:8080/api/alert'
+            }
+
+    alert = AlertaAlerter(rule)
+    alert.match_dictionary = match
+    
+    assert alert.replace_string_from_match("%(name)s is online %(noKey)s" ) == "mySystem is online <MISSING VALUE>"
+    assert alert.replace_string_from_match("Sensor %(sensor)s in the %(noPlace)s has temp %(temperature)s") == 'Sensor outsideSensor in the <MISSING VALUE> has temp 45'
+    assert alert.replace_string_from_match("Actuator %(noKey)s in the %(noPlace)s has temp %(noKey)s" ) == 'Actuator <MISSING VALUE> in the <MISSING VALUE> has temp <MISSING VALUE>'
+    
+    alert.use_new_string_format = True
+    
+    assert alert.replace_string_from_match("{match[name]} is online {match[noKey]}" ) == "mySystem is online <MISSING VALUE>"
+    assert alert.replace_string_from_match("Sensor {match[sensor]} in the {match[noPlace]} has temp {match[temperature]}") == 'Sensor outsideSensor in the <MISSING VALUE> has temp 45'
+    assert alert.replace_string_from_match("Actuator {match[noKey]} in the {match[noPlace]} has temp {match[noKey]}" ) == 'Actuator <MISSING VALUE> in the <MISSING VALUE> has temp <MISSING VALUE>'
+ 
+def test_alerta_no_auth(ea):
+    rule = {
+            'name': 'Test Alerta rule!',
+            'alerta_api_url': 'http://elastalerthost:8080/api/alert',
+            'timeframe': datetime.timedelta(hours=1),
+            'timestamp_field': '@timestamp',
+            'alerta_attributes_keys':   ["hostname",   "TimestampEvent",    "senderIP" ],
+            'alerta_attributes_values': ["%(key)s",    "%(logdate)s",       "%(sender_ip)s"  ],
+            'alerta_correlate': ["ProbeUP","ProbeDOWN"],
+            'alerta_event': "ProbeUP",
+            'alerta_group': "Health",
+            'alerta_origin': "Elastalert",
+            'alerta_severity': "debug",
+            'alerta_text':  "Probe %(hostname)s is UP at %(logdate)s GMT",
+            'alerta_value': "UP",
+            'type': 'any',
+            'alert': 'alerta'
+            }
+
+    match = {
+            '@timestamp': '2014-10-10T00:00:00', 
+            # 'key': ---- missing field on purpose, to verify that simply the text is left empty
+            # 'logdate': ---- missing field on purpose, to verify that simply the text is left empty
+            'sender_ip': '1.1.1.1',
+            'hostname': 'aProbe'
+            }
+        
+    load_modules(rule)
+    alert = AlertaAlerter(rule)
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+
+    expected_data = {
+        "origin": "Elastalert", 
+        "customer": "", 
+        "resource": "elastalert", 
+        "severity": "debug", 
+        "service": ["elastalert"], 
+        "tags": [], 
+        "text": "Probe aProbe is UP at <MISSING VALUE> GMT", 
+        "value": "UP", 
+        "createTime": "2014-10-10T00:00:00.000000Z", 
+        "environment": "Production", 
+        "rawData": "Test Alerta rule!\n\n@timestamp: 2014-10-10T00:00:00\nhostname: aProbe\nsender_ip: 1.1.1.1\n", 
+        "timeout": 86400, 
+        "correlate": ["ProbeUP", "ProbeDOWN"], 
+        "group": "Health", 
+        "attributes": {"senderIP": "1.1.1.1", "hostname": "<MISSING VALUE>", "TimestampEvent": "<MISSING VALUE>"}, 
+        "type": "elastalert", 
+        "event": "ProbeUP"
+        }
+
+    mock_post_request.assert_called_once_with(
+        alert.url,
+        data=mock.ANY,
+        headers={
+            'content-type': 'application/json' }
+    )
+    assert expected_data == json.loads(
+        mock_post_request.call_args_list[0][1]['data'])
+
+def test_alerta_auth(ea):
+    rule = {
+            'name': 'Test Alerta rule!',
+            'alerta_api_url': 'http://elastalerthost:8080/api/alert',
+            'alerta_api_key': '123456789ABCDEF',
+            'timeframe': datetime.timedelta(hours=1),
+            'timestamp_field': '@timestamp',
+            'alerta_severity': "debug",
+            'type': 'any',
+            'alert': 'alerta'
+            }
+
+    match = {
+            '@timestamp': '2014-10-10T00:00:00',
+            'sender_ip': '1.1.1.1',
+            'hostname': 'aProbe'
+            }
+            
+    load_modules(rule)
+    alert = AlertaAlerter(rule)
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+        
+    mock_post_request.assert_called_once_with(
+        alert.url,
+        data=mock.ANY,
+        headers={
+            'content-type': 'application/json' ,
+            'Authorization': 'Key {}'.format(rule['alerta_api_key'])})
+


### PR DESCRIPTION
Added support for alerts for Alerta alerts. 

Taken from Pull Request #848. Original code by mircopolo

Added documentation, AlertaAlerter and corresponding tests

This Alerter allows to directly build and send the JSON payload for the Alerta POST method. The main feature is that any field in the Alerta JSON can be completed by values from the match, in a similar way to CommandAlerter. If the field is missing, it is replaced by a default string.
