### PR TITLE
Re-indent index definitions

### DIFF
--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -135,23 +135,86 @@ def main():
 
     print("Mapping used for string:"+str(mapping))
 
-    silence_mapping = {'silence': {'properties': {'rule_name': mapping,
-                                                  'until': {'type': 'date', 'format': 'dateOptionalTime'},
-                                                  '@timestamp': {'format': 'dateOptionalTime', 'type': 'date'}}}}
-    ess_mapping = {'elastalert_status': {'properties': {'rule_name': mapping,
-                                                        '@timestamp': {'format': 'dateOptionalTime', 'type': 'date'}}}}
-    es_mapping = {'elastalert': {'properties': {'rule_name': mapping,
-                                                '@timestamp': {'format': 'dateOptionalTime', 'type': 'date'},
-                                                'alert_time': {'format': 'dateOptionalTime', 'type': 'date'},
-                                                'match_time': {'format': 'dateOptionalTime', 'type': 'date'},
-                                                'match_body': {'enabled': False, 'type': 'object'},
-                                                'aggregate_id': mapping}}}
-    past_mapping = {'past_elastalert': {'properties': {'rule_name': mapping,
-                                                       'match_body': {'enabled': False, 'type': 'object'},
-                                                       '@timestamp': {'format': 'dateOptionalTime', 'type': 'date'},
-                                                       'aggregate_id': mapping}}}
-    error_mapping = {'elastalert_error': {'properties': {'data': {'type': 'object', 'enabled': False},
-                                                         '@timestamp': {'format': 'dateOptionalTime', 'type': 'date'}}}}
+    silence_mapping = {
+        'silence': {
+            'properties': {
+                'rule_name': mapping,
+                'until': {
+                    'type': 'date',
+                    'format': 'dateOptionalTime',
+                },
+                '@timestamp': {
+                    'type': 'date',
+                    'format': 'dateOptionalTime',
+                },
+            },
+        },
+    }
+    ess_mapping = {
+        'elastalert_status': {
+            'properties': {
+                'rule_name': mapping,
+                '@timestamp': {
+                    'type': 'date',
+                    'format': 'dateOptionalTime',
+                },
+            },
+        },
+    }
+    es_mapping = {
+        'elastalert': {
+            'properties': {
+                'rule_name': mapping,
+                '@timestamp': {
+                    'type': 'date',
+                    'format': 'dateOptionalTime',
+                },
+                'alert_time': {
+                    'type': 'date',
+                    'format': 'dateOptionalTime',
+                },
+                'match_time': {
+                    'type': 'date',
+                    'format': 'dateOptionalTime',
+                },
+                'match_body': {
+                    'type': 'object',
+                    'enabled': False,
+                },
+                'aggregate_id': mapping,
+            },
+        },
+    }
+    past_mapping = {
+        'past_elastalert': {
+            'properties': {
+                'rule_name': mapping,
+                'match_body': {
+                    'type': 'object',
+                    'enabled': False,
+                },
+                '@timestamp': {
+                    'type': 'date',
+                    'format': 'dateOptionalTime',
+                },
+                'aggregate_id': mapping,
+            },
+        },
+    }
+    error_mapping = {
+        'elastalert_error': {
+            'properties': {
+                'data': {
+                    'type': 'object',
+                    'enabled': False,
+                },
+                '@timestamp': {
+                    'type': 'date',
+                    'format': 'dateOptionalTime',
+                },
+            },
+        },
+    }
 
     es_index = IndicesClient(es)
     if es_index.exists(index):


### PR DESCRIPTION
I'm working on a few upcoming changes to the index definitions and
it will be much easier to review changes when indentation is reduced
and number of affected lines is lower.

Examples of changes for which I intend to submit pull requests:

- add `data.rule` in `elastalert_error` documents;
- add `time_taken` in `elastalert_status` documents;
- remove `format: dateOptionalTime` on date fields in ES 5+.