### PR TITLE
Factor out simplejson and just use json

### DIFF
--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 
 import copy
 import datetime
+import json
 import logging
 import os
 import random
@@ -14,7 +15,6 @@ import sys
 
 import argparse
 import mock
-import simplejson
 import yaml
 
 import elastalert.config
@@ -360,14 +360,14 @@ class MockElastAlerter(object):
 
         if args.json:
             with open(args.json, 'r') as data_file:
-                self.data = simplejson.loads(data_file.read())
+                self.data = json.loads(data_file.read())
         else:
             hits = self.test_file(copy.deepcopy(rule_yaml), args)
             if hits and args.save:
                 with open(args.save, 'wb') as data_file:
                     # Add _id to _source for dump
                     [doc['_source'].update({'_id': doc['_id']}) for doc in hits]
-                    data_file.write(simplejson.dumps([doc['_source'] for doc in hits], indent='    '))
+                    data_file.write(json.dumps([doc['_source'] for doc in hits], indent='    '))
 
         if not args.schema_only and not args.count:
             self.run_elastalert(rule_yaml, conf, args)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ PyStaticConfiguration>=0.10.3
 python-dateutil>=2.6.0,<2.7.0
 PyYAML>=3.12
 requests>=2.0.0
-simplejson>=3.10.0
 stomp.py>=4.1.17
 texttable>=0.8.8
 twilio==6.0.0

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
         'python-dateutil>=2.6.0,<2.7.0',
         'PyYAML>=3.12',
         'requests>=2.10.0',
-        'simplejson>=3.10.0',
         'stomp.py>=4.1.17',
         'texttable>=0.8.8',
         'twilio>=6.0.0,<6.1',


### PR DESCRIPTION
json is stdlib and since elastalert doesn't support python2.6 it doesn't
provide any speed benefits.  It also looks like (?) it was only being used in
a test?