### PR TITLE
Some fixes

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1358,7 +1358,7 @@ Example usage::
 
     jira_bump_in_statuses:
       - Open
-      
+
 ``jira_bump_only``: Only update if a ticket is found to bump.  This skips ticket creation for rules where you only want to affect existing tickets.
 
 Example usage::
@@ -1722,7 +1722,7 @@ The stomp_destination field depends on the broker, the /queue/ALERT example is t
 Alerta
 ~~~~~~
 
-Alerta alerter will post an alert in the Alerta server instance through the alert API endpoint. 
+Alerta alerter will post an alert in the Alerta server instance through the alert API endpoint.
 The default values will work with a local Alerta server installation with authorization disabled.
 See http://alerta.readthedocs.io/en/latest/api/alert.html for more details on the Alerta alert json format.
 
@@ -1730,7 +1730,7 @@ For Alerta 5.0
 
 Required:
 
-``alerta_api_url``: API server URL. 
+``alerta_api_url``: API server URL.
 
 Optional:
 
@@ -1740,7 +1740,7 @@ Optional:
 
 ``alerta_service``: A list of service tags for the generated alert. Defaults to "elastalert".  Can be a reference to a part of the match.
 
-``alerta_severity``: The severity level of the alert. Defaults to "warning". 
+``alerta_severity``: The severity level of the alert. Defaults to "warning".
 
 ``alerta_origin``: The origin field for the generated alert. Defaults to "elastalert".  Can be a reference to a part of the match.
 
@@ -1756,7 +1756,7 @@ Optional:
 
 ``alerta_use_qk_as_resource``: If true and query_key is present this will override alerta_resource field with the query key value (Can be useful if query_key is a hostname).
 
-``alerta_use_match_timestamp``: If true will use the timestamp of the first match as the createTime of the alert, otherwise the current time is used. Default False. 
+``alerta_use_match_timestamp``: If true will use the timestamp of the first match as the createTime of the alert, otherwise the current time is used. Default False.
 
 ``alerta_event``: Can make reference to parts of the match to build the event name. Defaults to "elastalert".
 
@@ -1770,11 +1770,9 @@ Optional:
 
 ``alerta_attributes_values``: List of values for the Alerta Attributes dictionary, corresponding in order to the described keys. Can be a reference to a part of the match.
 
-``alerta_new_style_string_format``: If True, the optional values that make reference to fields in the match are expected on the new-style format ``{match[<field>]}``.
-
 .. info::
 
-    The optional values use Python-like string syntax ``{match[<field>]}`` or ``%(<field>)s`` to access parts of the match, similar to the CommandAlerter. Ie: "Alert for {match[clientip]}"
+    The optional values use Python-like string syntax ``{<field>}`` or ``%(<field>)s`` to access parts of the match, similar to the CommandAlerter. Ie: "Alert for {clientip}"
     If the referenced value is not found in the match, it is replaced by ``<MISSING VALUE>`` or the text indicated by the rule in ``alert_missing_value``.
 
 Example usage using old-style format::
@@ -1788,9 +1786,9 @@ Example usage using old-style format::
     alerta_event: "ProbeUP"
     alerta_text:  "Probe %(hostname)s is UP at %(logdate)s GMT"
     alerta_value: "UP"
-    
-    
-    
+
+
+
 HTTP POST
 ~~~~~~~~~
 

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -366,3 +366,13 @@ def parse_deadline(value):
     """Convert ``unit=num`` spec into a ``datetime`` object."""
     duration = parse_duration(value)
     return ts_now() + duration
+
+
+def flatten_dict(dct, delim='.', prefix=''):
+    ret = {}
+    for key, val in dct.items():
+        if type(val) == dict:
+            ret.update(flatten_dict(val, prefix=prefix + key + delim))
+        else:
+            ret[prefix + key] = val
+    return ret

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -1790,7 +1790,6 @@ def test_alerta_resolve_string(ea):
     assert alert.resolve_string(old_style_strings[1], match) == expected_outputs[1]
     assert alert.resolve_string(old_style_strings[2], match) == expected_outputs[2]
 
-    alert.use_new_string_format = True
     new_style_strings = [
         "{match[name]} is online {match[noKey]}",
         "Sensors {match[sensors]} in the {match[noPlace]} have temp {match[temperature]} and {match[humidity]} humidity",
@@ -1902,13 +1901,13 @@ def test_alerta_new_style(ea):
         'timeframe': datetime.timedelta(hours=1),
         'timestamp_field': '@timestamp',
         'alerta_attributes_keys': ["hostname", "TimestampEvent", "senderIP"],
-        'alerta_attributes_values': ["{match[hostname]}", "{match[logdate]}", "{match[sender_ip]}"],
+        'alerta_attributes_values': ["{hostname}", "{logdate}", "{sender_ip}"],
         'alerta_correlate': ["ProbeUP", "ProbeDOWN"],
         'alerta_event': "ProbeUP",
         'alerta_group': "Health",
         'alerta_origin': "Elastalert",
         'alerta_severity': "debug",
-        'alerta_text': "Probe {match[hostname]} is UP at {match[logdate]} GMT",
+        'alerta_text': "Probe {hostname} is UP at {logdate} GMT",
         'alerta_value': "UP",
         'alerta_new_style_string_format': True,
         'type': 'any',

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -1763,43 +1763,6 @@ def test_hipchat_body_size_limit_html():
     assert len(body) <= 10000
 
 
-def test_alerta_resolve_string(ea):
-    match = {
-        'name': 'mySystem',
-        'temperature': 45,
-        'humidity': 80.56,
-        'sensors': ['outsideSensor', 'insideSensor']
-    }
-    rule = {
-        'name': 'Test Alerta rule!',
-        'alerta_api_url': 'http://elastalerthost:8080/api/alert'
-    }
-
-    alert = AlertaAlerter(rule)
-
-    expected_outputs = [
-        "mySystem is online <MISSING VALUE>",
-        "Sensors ['outsideSensor', 'insideSensor'] in the <MISSING VALUE> have temp 45 and 80.56 humidity",
-        "Actuator <MISSING VALUE> in the <MISSING VALUE> has temp <MISSING VALUE>"]
-    old_style_strings = [
-        "%(name)s is online %(noKey)s",
-        "Sensors %(sensors)s in the %(noPlace)s have temp %(temperature)s and %(humidity)s humidity",
-        "Actuator %(noKey)s in the %(noPlace)s has temp %(noKey)s"]
-
-    assert alert.resolve_string(old_style_strings[0], match) == expected_outputs[0]
-    assert alert.resolve_string(old_style_strings[1], match) == expected_outputs[1]
-    assert alert.resolve_string(old_style_strings[2], match) == expected_outputs[2]
-
-    new_style_strings = [
-        "{match[name]} is online {match[noKey]}",
-        "Sensors {match[sensors]} in the {match[noPlace]} have temp {match[temperature]} and {match[humidity]} humidity",
-        "Actuator {match[noKey]} in the {match[noPlace]} has temp {match[noKey]}"]
-
-    assert alert.resolve_string(new_style_strings[0], match) == expected_outputs[0]
-    assert alert.resolve_string(new_style_strings[1], match) == expected_outputs[1]
-    assert alert.resolve_string(new_style_strings[2], match) == expected_outputs[2]
-
-
 def test_alerta_no_auth(ea):
     rule = {
         'name': 'Test Alerta rule!',


### PR DESCRIPTION
- Pep8 changes

- Change resolve_string
    - Move to util as we should be reusing this function
    - Switch it from regex to actually using % and .format
    - Flatten dict for accessing nested fields via dot notation
    - Don't require an argument specifying which format, either work

- Make command alerter use resolve_string 

@JoseIgnacioTamayo please note a slight change in that ``{match[field]}`` will become just ``{field}``