### PR TITLE
Adding Custom HTTP headers support to HTTPPostAlerter

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1647,6 +1647,7 @@ class HTTPPostAlerter(Alerter):
         self.post_payload = self.rule.get('http_post_payload', {})
         self.post_static_payload = self.rule.get('http_post_static_payload', {})
         self.post_all_values = self.rule.get('http_post_all_values', not self.post_payload)
+        self.post_http_headers = self.rule.get('http_post_headers', {})
 
     def alert(self, matches):
         """ Each match will trigger a POST to the specified endpoint(s). """
@@ -1659,6 +1660,7 @@ class HTTPPostAlerter(Alerter):
                 "Content-Type": "application/json",
                 "Accept": "application/json;charset=utf-8"
             }
+            headers.update(self.post_http_headers)
             proxies = {'https': self.post_proxy} if self.post_proxy else None
             for url in self.post_url:
                 try:


### PR DESCRIPTION
will add custom HTTP headers to request
Exemple of rule content
http_post_headers:
 cache-control: no-cache
 x-my-id: "12345678"
 x-my-key: a9CmTogOPdDEsHupmmm4z1gOGlRnOvKBM9pa2Eja9g