### PR TITLE
Fixed is_enabled on rule change

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -980,6 +980,9 @@ class ElastAlerter():
                 try:
                     new_rule = load_configuration(rule_file, self.conf)
                     if 'is_enabled' in new_rule and not new_rule['is_enabled']:
+                        elastalert_logger.info('Rule file %s is now disabled.' % (rule_file))
+                        # Remove this rule if it's been disabled
+                        self.rules = [rule for rule in self.rules if rule['rule_file'] != rule_file]
                         continue
                 except EAException as e:
                     message = 'Could not load rule %s: %s' % (rule_file, e)


### PR DESCRIPTION
Fixes ``is_enabled: false`` not disabling a running rule. #1677 

Tested this manually.