### PR TITLE
Sentry integration

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ pytest<3.3.0
 setuptools
 sphinx_rtd_theme
 tox<2.0
+raven>=6.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ PyStaticConfiguration>=0.10.3
 python-dateutil>=2.6.0,<2.7.0
 PyYAML>=3.12
 requests>=2.0.0
+raven>=6.4.0
 stomp.py>=4.1.17
 texttable>=0.8.8
 twilio==6.0.0


### PR DESCRIPTION
Added error reporting to [Sentry](https://sentry.io), when ENV variable `SENTRY_DSN` is defined.

Any Python exception or logger message with severity at least `WARNING` will be reported to Sentry (if configured).