### PR TITLE
Fixed bug where long queries sometimes terminate early

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -805,6 +805,7 @@ class ElastAlerter():
         # Run the rule. If querying over a large time period, split it up into segments
         self.num_hits = 0
         self.num_dupes = 0
+        self.cumulative_hits = 0
         segment_size = self.get_segment_size(rule)
 
         tmp_endtime = rule['starttime']
@@ -813,6 +814,8 @@ class ElastAlerter():
             tmp_endtime = tmp_endtime + segment_size
             if not self.run_query(rule, rule['starttime'], tmp_endtime):
                 return 0
+            self.cumulative_hits += self.num_hits
+            self.num_hits = 0
             rule['starttime'] = tmp_endtime
             rule['type'].garbage_collect(tmp_endtime)
 
@@ -879,7 +882,7 @@ class ElastAlerter():
                 'endtime': endtime,
                 'starttime': rule['original_starttime'],
                 'matches': num_matches,
-                'hits': self.num_hits,
+                'hits': max(self.num_hits, self.cumulative_hits),
                 '@timestamp': ts_now(),
                 'time_taken': time_taken}
         self.writeback('elastalert_status', body)
@@ -1122,9 +1125,10 @@ class ElastAlerter():
                 self.handle_uncaught_exception(e, rule)
             else:
                 old_starttime = pretty_ts(rule.get('original_starttime'), rule.get('use_local_time'))
+                total_hits = max(self.num_hits, self.cumulative_hits)
                 elastalert_logger.info("Ran %s from %s to %s: %s query hits (%s already seen), %s matches,"
                                        " %s alerts sent" % (rule['name'], old_starttime, pretty_ts(endtime, rule.get('use_local_time')),
-                                                            self.num_hits, self.num_dupes, num_matches, self.alerts_sent))
+                                                            total_hits, self.num_dupes, num_matches, self.alerts_sent))
                 self.alerts_sent = 0
 
                 if next_run < datetime.datetime.utcnow():
@@ -1398,6 +1402,8 @@ class ElastAlerter():
             'alert_sent': alert_sent,
             'alert_time': alert_time
         }
+        if 'name' in match:
+            body['name'] = match['name']
 
         match_time = lookup_es_key(match, rule['timestamp_field'])
         if match_time is not None:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1402,8 +1402,6 @@ class ElastAlerter():
             'alert_sent': alert_sent,
             'alert_time': alert_time
         }
-        if 'name' in match:
-            body['name'] = match['name']
 
         match_time = lookup_es_key(match, rule['timestamp_field'])
         if match_time is not None:

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -739,10 +739,7 @@ def test_query_segmenting_reset_num_hits(ea):
 def test_query_segmenting(ea):
     # buffer_time segments with normal queries
     ea.rules[0]['buffer_time'] = datetime.timedelta(minutes=53)
-    mock_es = mock.Mock()
-    mock_es.search.side_effect = _duplicate_hits_generator([START_TIMESTAMP])
-    with mock.patch('elastalert.elastalert.elasticsearch_client') as mock_es_init:
-        mock_es_init.return_value = mock_es
+    with mock.patch('elastalert.elastalert.elasticsearch_client'):
         run_and_assert_segmented_queries(ea, START, END, ea.rules[0]['buffer_time'])
 
     # run_every segments with count queries


### PR DESCRIPTION
Fixes #1723 

When making a multi-segement query, ``self.num_hits`` was never cleared, and would cause the query to terminate early because it thinks the second scroll has already finished.

``num_hits`` needs to be set to 0 before ``run_query`` is called to properly follow through on a scroll.

Testing:
```
INFO:elastalert:Starting up
INFO:elastalert:Queried rule dffgdfgd from 2018-06-01 10:20 PDT to 2018-06-01 10:25 PDT: 15000 / 15000 hits (scrolling..)
INFO:elastalert:Queried rule dffgdfgd from 2018-06-01 10:20 PDT to 2018-06-01 10:25 PDT: 30000 / 15000 hits (scrolling..)
INFO:elastalert:Queried rule dffgdfgd from 2018-06-01 10:20 PDT to 2018-06-01 10:25 PDT: 43520 / 13520 hits (scrolling..)
INFO:elastalert:Queried rule dffgdfgd from 2018-06-01 10:25 PDT to 2018-06-01 10:30 PDT: 15000 / 15000 hits (scrolling..)
*(Query would have stopped here before)*
INFO:elastalert:Queried rule dffgdfgd from 2018-06-01 10:25 PDT to 2018-06-01 10:30 PDT: 30000 / 15000 hits (scrolling..)
INFO:elastalert:Queried rule dffgdfgd from 2018-06-01 10:25 PDT to 2018-06-01 10:30 PDT: 39823 / 9823 hits (scrolling..)
INFO:elastalert:Queried rule dffgdfgd from 2018-06-01 10:30 PDT to 2018-06-01 10:30 PDT: 6818 / 6818 hits
INFO:elastalert:Skipping writing to ES: {'hits': 83343, 'matches': 0, '@timestamp': '2018-06-01T17:31:05.024102Z', 'rule_name': 'dffgdfgd', 'starttime': '2018-06-01T10:20:00-07:00', 'endtime': '2018-06-01T17:30:45.963194Z', 'time_taken': 19.060894012451172}
INFO:elastalert:Ran dffgdfgd from 2018-06-01 10:20 PDT to 2018-06-01 10:30 PDT: 83343 query hits (0 already seen), 0 matches, 0 alerts sent
```

Also added a test case. While doing that I realized there some dead mock code in another test, so I removed that. I don't think it was important, as that test was mainly for segmenting itself, not whether run_query updates num_hits.