### PR TITLE
Fix num_hits in match dict

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -865,7 +865,7 @@ class ElastAlerter():
         num_matches = len(rule['type'].matches)
         while rule['type'].matches:
             match = rule['type'].matches.pop(0)
-            match['num_hits'] = self.num_hits
+            match['num_hits'] = self.cumulative_hits
             match['num_matches'] = num_matches
 
             # If realert is set, silence the rule for that duration


### PR DESCRIPTION
When I changed num_hits to cumulative_hits in a few places, I didn't change where it gets added to the match dict. This would mean that num_hits could sometimes be zero even though a match was generated. This would occur when the query got split up into segments and the last segment had 0 hits.