### PR TITLE
added search_extra_index

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -108,6 +108,8 @@ Rule Configuration Cheat Sheet
 +--------------------------------------------------------------+           |
 | ``is_enabled`` (boolean, default True)                       |           |
 +--------------------------------------------------------------+-----------+
+| ``search_extra_index`` (boolean, default False)              |           |
++--------------------------------------------------------------+-----------+
 
 |
 
@@ -285,6 +287,13 @@ If a query spans multiple days, the formatted indexes will be concatenated with 
 as narrowing the number of indexes searched, compared to using a wildcard, may be significantly faster. For example, if ``index`` is
 ``logstash-%Y.%m.%d``, the query url will be similar to ``elasticsearch.example.com/logstash-2015.02.03/...`` or
 ``elasticsearch.example.com/logstash-2015.02.03,logstash-2015.02.04/...``.
+
+search_extra_index
+^^^^^^^^^^^^^^^^^^
+
+``search_extra_index``: If this is true, ElastAlert will add an extra index on the early side onto each search. For example, if it's querying
+completely within 2018-06-28, it will actually use 2018-06-27,2018-06-28. This can be useful if your timestamp_field is not what's being used
+to generate the index names. If that's the case, sometimes a query would not have been using the right index.
 
 aggregation
 ^^^^^^^^^^^

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -188,9 +188,10 @@ class ElastAlerter():
         is set but starttime and endtime are not provided, it will replace all format
         tokens with a wildcard. """
         index = rule['index']
+        add_extra = rule.get('search_extra_index', False)
         if rule.get('use_strftime_index'):
             if starttime and endtime:
-                return format_index(index, starttime, endtime)
+                return format_index(index, starttime, endtime, add_extra)
             else:
                 # Replace the substring containing format characters with a *
                 format_start = index.find('%')

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -192,19 +192,19 @@ def format_index(index, start, end, add_extra=False):
     start -= start.utcoffset()
     end -= end.utcoffset()
     original_start = start
-    indexes = set()
+    indices = set()
     while start.date() <= end.date():
-        indexes.add(start.strftime(index))
+        indices.add(start.strftime(index))
         start += datetime.timedelta(days=1)
-    num = len(indexes)
+    num = len(indices)
     if add_extra:
-        while len(indexes) == num:
+        while len(indices) == num:
             original_start -= datetime.timedelta(days=1)
             new_index = original_start.strftime(index)
             assert new_index != index, "You cannot use a static index with search_extra_index"
-            indexes.add(new_index)
+            indices.add(new_index)
 
-    return ','.join(indexes)
+    return ','.join(indices)
 
 
 class EAException(Exception):

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -200,7 +200,9 @@ def format_index(index, start, end, add_extra=False):
     if add_extra:
         while len(indexes) == num:
             original_start -= datetime.timedelta(days=1)
-            indexes.add(original_start.strftime(index))
+            new_index = original_start.strftime(index)
+            assert new_index != index, "You cannot use a static index with search_extra_index"
+            indexes.add(new_index)
 
     return ','.join(indexes)
 

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -185,17 +185,22 @@ def hashable(obj):
     return obj
 
 
-def format_index(index, start, end):
+def format_index(index, start, end, add_extra=False):
     """ Takes an index, specified using strftime format, start and end time timestamps,
     and outputs a wildcard based index string to match all possible timestamps. """
     # Convert to UTC
     start -= start.utcoffset()
     end -= end.utcoffset()
-
-    indexes = []
+    original_start = start
+    indexes = set()
     while start.date() <= end.date():
-        indexes.append(start.strftime(index))
+        indexes.add(start.strftime(index))
         start += datetime.timedelta(days=1)
+    num = len(indexes)
+    if add_extra:
+        while len(indexes) == num:
+            original_start -= datetime.timedelta(days=1)
+            indexes.add(original_start.strftime(index))
 
     return ','.join(indexes)
 

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -987,7 +987,7 @@ def test_strf_index(ea):
     end = ts_to_dt('2015-01-02T16:15:14Z')
     assert ea.get_index(ea.rules[0], start, end) == 'logstash-2015.01.02'
     end = ts_to_dt('2015-01-03T01:02:03Z')
-    assert ea.get_index(ea.rules[0], start, end) == 'logstash-2015.01.02,logstash-2015.01.03'
+    assert set(ea.get_index(ea.rules[0], start, end).split(',')) == set(['logstash-2015.01.02', 'logstash-2015.01.03'])
 
     # Test formatting for wildcard
     assert ea.get_index(ea.rules[0]) == 'logstash-*'

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -180,6 +180,7 @@ def test_resolve_string(ea):
 
 def test_format_index():
     pattern = 'logstash-%Y.%m.%d'
+    pattern2 = 'logstash-%Y.%W'
     date = dt('2018-06-25T12:00:00Z')
     date2 = dt('2018-06-26T12:00:00Z')
     assert sorted(format_index(pattern, date, date).split(',')) == ['logstash-2018.06.25']
@@ -187,3 +188,4 @@ def test_format_index():
     assert sorted(format_index(pattern, date, date2, True).split(',')) == ['logstash-2018.06.24',
                                                                            'logstash-2018.06.25',
                                                                            'logstash-2018.06.26']
+    assert sorted(format_index(pattern2, date, date2, True).split(',')) == ['logstash-2018.25', 'logstash-2018.26']

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -7,6 +7,7 @@ import pytest
 from dateutil.parser import parse as dt
 
 from elastalert.util import add_raw_postfix
+from elastalert.util import format_index
 from elastalert.util import lookup_es_key
 from elastalert.util import parse_deadline
 from elastalert.util import parse_duration
@@ -175,3 +176,14 @@ def test_resolve_string(ea):
     assert resolve_string(new_style_strings[0], match) == expected_outputs[0]
     assert resolve_string(new_style_strings[1], match) == expected_outputs[1]
     assert resolve_string(new_style_strings[2], match) == expected_outputs[2]
+
+
+def test_format_index():
+    pattern = 'logstash-%Y.%m.%d'
+    date = dt('2018-06-25T12:00:00Z')
+    date2 = dt('2018-06-26T12:00:00Z')
+    assert sorted(format_index(pattern, date, date).split(',')) == ['logstash-2018.06.25']
+    assert sorted(format_index(pattern, date, date2).split(',')) == ['logstash-2018.06.25', 'logstash-2018.06.26']
+    assert sorted(format_index(pattern, date, date2, True).split(',')) == ['logstash-2018.06.24',
+                                                                           'logstash-2018.06.25',
+                                                                           'logstash-2018.06.26']


### PR DESCRIPTION
Adds a new feature to add a extra index to the previous end of each query. This is useful in the case where timestamp_field more recent than the timestamp used to generate index names.

This is a bit limited right now since it's only 1 and only on the previous end, but it should cover the most common use case.