### PR TITLE
Added timeout into HTTP Post alerter

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1839,6 +1839,8 @@ Optional:
 
 ``http_post_all_values``: Boolean of whether or not to include every key value pair from the match in addition to those in http_post_payload and http_post_static_payload. Defaults to True if http_post_payload is not specified, otherwise False.
 
+``http_post_timeout``: The timeout value, in seconds, for making the post. The default is 10. If a timeout occurs, the alert will be retried next time elastalert cycles.
+
 Example usage::
 
     alert: post

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1621,6 +1621,7 @@ class HTTPPostAlerter(Alerter):
         self.post_static_payload = self.rule.get('http_post_static_payload', {})
         self.post_all_values = self.rule.get('http_post_all_values', not self.post_payload)
         self.post_http_headers = self.rule.get('http_post_headers', {})
+        self.timeout = self.rule.get('http_post_timeout', 10)
 
     def alert(self, matches):
         """ Each match will trigger a POST to the specified endpoint(s). """
@@ -1638,7 +1639,7 @@ class HTTPPostAlerter(Alerter):
             for url in self.post_url:
                 try:
                     response = requests.post(url, data=json.dumps(payload, cls=DateTimeEncoder),
-                                             headers=headers, proxies=proxies)
+                                             headers=headers, proxies=proxies, timeout=self.timeout)
                     response.raise_for_status()
                 except RequestException as e:
                     raise EAException("Error posting HTTP Post alert: %s" % e)


### PR DESCRIPTION
What the title says. Previously, elastalert could hang if the server didn't respond.