### PR TITLE
Fixed resolve_string and documentation

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1223,14 +1223,12 @@ This alert requires one option:
 string, the command is executed through the shell.
 
 Strings can be formatted using the old-style format (``%``) or the new-style format (``.format()``). When the old-style format is used, fields are accessed
-using ``%(field_name)s``. When the new-style format is used, fields are accessed using ``{match[field_name]}``. New-style formatting allows accessing nested
-fields (e.g., ``{match[field_1_name][field_2_name]}``).
+using ``%(field_name)s``, or ``%(field.subfield)s``. When the new-style format is used, fields are accessed using ``{field_name}``. New-style formatting allows accessing nested
+fields (e.g., ``{field_1[subfield]}``).
 
 In an aggregated alert, these fields come from the first match.
 
 Optional:
-
-``new_style_string_format``: If True, arguments are formatted using ``.format()`` rather than ``%``. The default is False.
 
 ``pipe_match_json``: If true, the match will be converted to JSON and passed to stdin of the command. Note that this will cause ElastAlert to block
 until the command exits or sends an EOF to stdout.

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -398,12 +398,13 @@ def resolve_string(string, match, missing_text='<MISSING VALUE>'):
         :param missing_text: The default text to replace a formatter with if the field doesnt exist.
     """
     flat_match = flatten_dict(match)
+    flat_match.update(match)
     dd_match = collections.defaultdict(lambda: missing_text, flat_match)
     dd_match['_missing_value'] = missing_text
     while True:
         try:
-            string = string.format(**dd_match)
             string = string % dd_match
+            string = string.format(**dd_match)
             break
         except KeyError as e:
             if '{%s}' % e.message not in string:

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -152,30 +152,36 @@ def test_resolve_string(ea):
         'name': 'mySystem',
         'temperature': 45,
         'humidity': 80.56,
-        'sensors': ['outsideSensor', 'insideSensor']
+        'sensors': ['outsideSensor', 'insideSensor'],
+        'foo': {'bar': 'baz'}
     }
 
     expected_outputs = [
         "mySystem is online <MISSING VALUE>",
         "Sensors ['outsideSensor', 'insideSensor'] in the <MISSING VALUE> have temp 45 and 80.56 humidity",
-        "Actuator <MISSING VALUE> in the <MISSING VALUE> has temp <MISSING VALUE>"]
+        "Actuator <MISSING VALUE> in the <MISSING VALUE> has temp <MISSING VALUE>",
+        'Something baz']
     old_style_strings = [
         "%(name)s is online %(noKey)s",
         "Sensors %(sensors)s in the %(noPlace)s have temp %(temperature)s and %(humidity)s humidity",
-        "Actuator %(noKey)s in the %(noPlace)s has temp %(noKey)s"]
+        "Actuator %(noKey)s in the %(noPlace)s has temp %(noKey)s",
+        'Something %(foo.bar)s']
 
     assert resolve_string(old_style_strings[0], match) == expected_outputs[0]
     assert resolve_string(old_style_strings[1], match) == expected_outputs[1]
     assert resolve_string(old_style_strings[2], match) == expected_outputs[2]
+    assert resolve_string(old_style_strings[3], match) == expected_outputs[3]
 
     new_style_strings = [
         "{name} is online {noKey}",
         "Sensors {sensors} in the {noPlace} have temp {temperature} and {humidity} humidity",
-        "Actuator {noKey} in the {noPlace} has temp {noKey}"]
+        "Actuator {noKey} in the {noPlace} has temp {noKey}",
+        "Something {foo[bar]}"]
 
     assert resolve_string(new_style_strings[0], match) == expected_outputs[0]
     assert resolve_string(new_style_strings[1], match) == expected_outputs[1]
     assert resolve_string(new_style_strings[2], match) == expected_outputs[2]
+    assert resolve_string(new_style_strings[3], match) == expected_outputs[3]
 
 
 def test_format_index():


### PR DESCRIPTION
Fixes a recently introduced bug where nested fields were not accessible using the {} formatter. I had incorrectly assumed that a flattened dictionary would work for both cases

```
>>> '%(foo.bar)s' % {'foo.bar': 'baz'}
'baz'
>>> '{foo.bar}'.format(**{'foo.bar': 'baz'})
KeyError: 'foo'
>>> '{foo.bar}'.format(**{'foo': {'bar': 'baz'}})
AttributeError: 'dict' object has no attribute 'bar'
```

To fix these, update the flattened dict with the original match so that '{foo[bar]}' format still works.
