### PR TITLE
add support of compound query keies for function get_hits_terms

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -460,26 +460,27 @@ class ElastAlerter():
 
     def get_hits_terms(self, rule, starttime, endtime, index, key, qk=None, size=None):
         rule_filter = copy.copy(rule['filter'])
-        qk_list = qk.split(", ")
-        end = None
-        if rule['five']:
-            end = '.keyword'
-        else:
-            end = '.raw'
+        if qk:
+            qk_list = qk.split(", ")
+            end = None
+            if rule['five']:
+                end = '.keyword'
+            else:
+                end = '.raw'
 
-        if len(qk_list) == 1:
-            qk = qk_list[0]
-            filter_key = rule['query_key']
-            if rule.get('raw_count_keys', True) and not rule['query_key'].endswith(end):
-                filter_key = add_raw_postfix(filter_key, rule['five'])
-            rule_filter.extend([{'term': {filter_key: qk}}])
-        else:
-            filter_keys = rule['compound_query_key']
-            for i in range(len(filter_keys)):
-                key_with_postfix = filter_keys[i]
-                if rule.get('raw_count_keys', True) and not key.endswith(end):
-                    key_with_postfix = add_raw_postfix(key_with_postfix, rule['five'])
-                rule_filter.extend([{'term': {key_with_postfix: qk_list[i]}}])
+            if len(qk_list) == 1:
+                qk = qk_list[0]
+                filter_key = rule['query_key']
+                if rule.get('raw_count_keys', True) and not rule['query_key'].endswith(end):
+                    filter_key = add_raw_postfix(filter_key, rule['five'])
+                rule_filter.extend([{'term': {filter_key: qk}}])
+            else:
+                filter_keys = rule['compound_query_key']
+                for i in range(len(filter_keys)):
+                    key_with_postfix = filter_keys[i]
+                    if rule.get('raw_count_keys', True) and not key.endswith(end):
+                        key_with_postfix = add_raw_postfix(key_with_postfix, rule['five'])
+                    rule_filter.extend([{'term': {key_with_postfix: qk_list[i]}}])
 
         base_query = self.get_query(
             rule_filter,

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -460,15 +460,27 @@ class ElastAlerter():
 
     def get_hits_terms(self, rule, starttime, endtime, index, key, qk=None, size=None):
         rule_filter = copy.copy(rule['filter'])
-        if qk:
+        qk_list = qk.split(", ")
+        end = None
+        if rule['five']:
+            end = '.keyword'
+        else:
+            end = '.raw'
+
+        if len(qk_list) == 1:
+            qk = qk_list[0]
             filter_key = rule['query_key']
-            if rule['five']:
-                end = '.keyword'
-            else:
-                end = '.raw'
             if rule.get('raw_count_keys', True) and not rule['query_key'].endswith(end):
                 filter_key = add_raw_postfix(filter_key, rule['five'])
             rule_filter.extend([{'term': {filter_key: qk}}])
+        else:
+            filter_keys = rule['compound_query_key']
+            for i in range(len(filter_keys)):
+                key_with_postfix = filter_keys[i]
+                if rule.get('raw_count_keys', True) and not key.endswith(end):
+                    key_with_postfix = add_raw_postfix(key_with_postfix, rule['five'])
+                rule_filter.extend([{'term': {key_with_postfix: qk_list[i]}}])
+
         base_query = self.get_query(
             rule_filter,
             starttime,


### PR DESCRIPTION
Tested this with the rule：
```
name: xxxx-test-rule
type: frequency
num_events: 5
timeframe:
  hours: 1
alert:
  - debug
top_count_keys: ['apple']
index: pfang-test
query_key:
  - host
  - port
raw_count_keys: false
```