### PR TITLE
Fix num_hits for aggregation queries

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -865,6 +865,7 @@ class ElastAlerter():
         if rule.get('aggregation_query_element'):
             if endtime - tmp_endtime == segment_size:
                 self.run_query(rule, tmp_endtime, endtime)
+                self.cumulative_hits += self.num_hits
             elif total_seconds(rule['original_starttime'] - tmp_endtime) == 0:
                 rule['starttime'] = rule['original_starttime']
                 return 0
@@ -873,6 +874,7 @@ class ElastAlerter():
         else:
             if not self.run_query(rule, rule['starttime'], endtime):
                 return 0
+            self.cumulative_hits += self.num_hits
             rule['type'].garbage_collect(endtime)
 
         # Process any new matches


### PR DESCRIPTION
When I added cumulative_hits, I forgot to count these two locations. run_query is what affects self.num_hits and cumulative_hits needs to count it after every invocation.