### PR TITLE
Fixing json.dumps indent

### DIFF
--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -403,7 +403,7 @@ class MockElastAlerter(object):
                 with open(args.save, 'wb') as data_file:
                     # Add _id to _source for dump
                     [doc['_source'].update({'_id': doc['_id']}) for doc in hits]
-                    data_file.write(json.dumps([doc['_source'] for doc in hits], indent=1))
+                    data_file.write(json.dumps([doc['_source'] for doc in hits], indent=4))
             if args.use_downloaded:
                 if hits:
                     args.json = args.save

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -403,7 +403,7 @@ class MockElastAlerter(object):
                 with open(args.save, 'wb') as data_file:
                     # Add _id to _source for dump
                     [doc['_source'].update({'_id': doc['_id']}) for doc in hits]
-                    data_file.write(json.dumps([doc['_source'] for doc in hits], indent='    '))
+                    data_file.write(json.dumps([doc['_source'] for doc in hits], indent=1))
             if args.use_downloaded:
                 if hits:
                     args.json = args.save


### PR DESCRIPTION
The json.dumps indent parameter is a number.  When switched from simplejson, the same arguments were passed, even though a different API.