### PR TITLE
Raise an exception on parse failure

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -390,6 +390,12 @@ class ElastAlerter():
                     **extra_args
                 )
                 self.total_hits = int(res['hits']['total'])
+
+            if len(res['_shards']['failures']) > 0:
+                errs = [ e['reason']['reason'] for e in res['_shards']['failures'] if 'Failed to parse' in e['reason']['reason']]
+                if len(errs):
+                    raise ElasticsearchException(errs)
+
             logging.debug(str(res))
         except ElasticsearchException as e:
             # Elasticsearch sometimes gives us GIGANTIC error messages


### PR DESCRIPTION
Currently, `elastalert` does not complain if there are failures in the search. Mainly, `parse_exception`, which goes unnoticed.

This change would inspect the result of a search and raise an `ElasticsearchException` if there were any parse errors present.