### PR TITLE
setup: Exclude jsonschema 3 alpha

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'envparse>=0.2.0',
         'exotel>=0.1.3',
         'jira>=1.0.10,<1.0.15',
-        'jsonschema>=2.6.0',
+        'jsonschema>=2.6.0,<3.0.0',
         'mock>=2.0.0',
         'PyStaticConfiguration>=0.10.3',
         'python-dateutil>=2.6.0,<2.7.0',


### PR DESCRIPTION
jsonschema recently released 3.0.0 alphas: https://github.com/Julian/jsonschema/releases

Those break the installation, so limit the range to <3.0.0

This is from a build running `python setup.py install`:
```
Searching for jsonschema>=2.6.0
Reading https://pypi.python.org/simple/jsonschema/
Downloading https://files.pythonhosted.org/packages/99/5f/bfa0e2647efff46bc8b5def9dceacc810b31056eaf011feca3053ae85159/jsonschema-3.0.0a2.tar.gz#sha256=aef58a18d83e4c5ea117d7ae1ba4238a6a84654fee6d0f32fd335ded63a1626e
Best match: jsonschema 3.0.0a2
Processing jsonschema-3.0.0a2.tar.gz
Writing /tmp/easy_install-FKdc6q/jsonschema-3.0.0a2/setup.cfg
Running jsonschema-3.0.0a2/setup.py -q bdist_egg --dist-dir /tmp/easy_install-FKdc6q/jsonschema-3.0.0a2/egg-dist-tmp-XTwF9b
[91m/usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'use_scm_version'
  warnings.warn(msg)
[0m[91mzip_safe flag not set; analyzing archive contents...
[0m[91mjsonschema.tests._suite: module references file
[0m[91mjsonschema.tests.test_validators: module references file
[0m[91mjsonschema.benchmarks.issue232: module references file
[0mcreating /usr/lib/python2.7/site-packages/jsonschema-0.0.0-py2.7.egg
Extracting jsonschema-0.0.0-py2.7.egg to /usr/lib/python2.7/site-packages
Adding jsonschema 0.0.0 to easy-install.pth file
Installing jsonschema script to /usr/bin

Installed /usr/lib/python2.7/site-packages/jsonschema-0.0.0-py2.7.egg
[91merror: The 'jsonschema>=2.6.0' distribution was not found and is required by elastalert
```

If this patch makes sense and is correct, the same change probably needs to go into `requirements.txt`. Unfortunately I'm not familar enough with python installs and pip to make a better contribution.