### PR TITLE
Add mattermost alerter

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1617,6 +1617,36 @@ Provide absolute address of the pciture, for example: http://some.address.com/im
 ``slack_alert_fields``: You can add additional fields to your slack alerts using this field. Specify the title using `title` and a value for the field using `value`. Additionally you can specify whether or not this field should be a `short` field using `short: true`.
 
 
+Mattermost
+~~~~~
+
+Mattermost alerter will send a notification to a predefined Mattermost channel. The body of the notification is formatted the same as with other alerters.
+
+The alerter requires the following option:
+
+``mattermost_webhook_url``: The webhook URL. Follow the instructions on https://docs.mattermost.com/developer/webhooks-incoming.html to create an incoming webhook on your Mattermost installation.
+
+Optional:
+
+``mattermost_proxy``: By default ElastAlert will not use a network proxy to send notifications to Mattermost. Set this option using ``hostname:port`` if you need to use a proxy.
+
+``mattermost_ignore_ssl_errors``: By default ElastAlert will verify SSL certificate. Set this option to ``False`` if you want to ignore SSL errors.
+
+``mattermost_username_override``: By default Mattermost will use your username when posting to the channel. Use this option to change it (free text).
+
+``mattermost_channel_override``: Incoming webhooks have a default channel, but it can be overridden. A public channel can be specified "#other-channel", and a Direct Message with "@username".
+
+``mattermost_icon_url_override``: By default ElastAlert will use the default webhook icon when posting to the channel. You can provide icon_url to use custom image.
+Provide absolute address of the picture (for example: http://some.address.com/image.jpg) or Base64 data url.
+
+``mattermost_msg_pretext``: You can set the message attachment pretext using this option.
+
+``mattermost_msg_color``: By default the alert will be posted with the 'danger' color. You can also use 'good', 'warning', or hex color code.
+
+``mattermost_msg_fields``: You can add fields to your Mattermost alerts using this option. You can specify the title using `title` and the text value using `value`. Additionally you can specify whether this field should be a `short` field using `short: true`. If you set `args` and `value` is a formattable string, ElastAlert will format the incident key based on the provided array of fields from the rule or match.
+See https://docs.mattermost.com/developer/message-attachments.html#fields for more information.
+
+
 Telegram
 ~~~~~~~~
 Telegram alerter will send a notification to a predefined Telegram username or channel. The body of the notification is formatted the same as with other alerters.

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1188,6 +1188,115 @@ class SlackAlerter(Alerter):
                 'slack_webhook_url': self.slack_webhook_url}
 
 
+class MattermostAlerter(Alerter):
+    """ Creates a Mattermsot post for each alert """
+    required_options = frozenset(['mattermost_webhook_url'])
+
+    def __init__(self, rule):
+        super(MattermostAlerter, self).__init__(rule)
+
+        # HTTP config
+        self.mattermost_webhook_url = self.rule['mattermost_webhook_url']
+        if isinstance(self.mattermost_webhook_url, basestring):
+            self.mattermost_webhook_url = [self.mattermost_webhook_url]
+        self.mattermost_proxy = self.rule.get('mattermost_proxy', None)
+        self.mattermost_ignore_ssl_errors = self.rule.get('mattermost_ignore_ssl_errors', False)
+
+        # Override webhook config
+        self.mattermost_username_override = self.rule.get('mattermost_username_override', 'elastalert')
+        self.mattermost_channel_override = self.rule.get('mattermost_channel_override', '')
+        self.mattermost_icon_url_override = self.rule.get('mattermost_icon_url_override', '')
+
+        # Message properties
+        self.mattermost_msg_pretext = self.rule.get('mattermost_msg_pretext', '')
+        self.mattermost_msg_color = self.rule.get('mattermost_msg_color', 'danger')
+        self.mattermost_msg_fields = self.rule.get('mattermost_msg_fields', '')
+
+    def get_aggregation_summary_text__maximum_width(self):
+        width = super(MattermostAlerter, self).get_aggregation_summary_text__maximum_width()
+        # Reduced maximum width for prettier Mattermost display.
+        return min(width, 75)
+
+    def get_aggregation_summary_text(self, matches):
+        text = super(MattermostAlerter, self).get_aggregation_summary_text(matches)
+        if text:
+            text = u'```\n{0}```\n'.format(text)
+        return text
+
+    def populate_fields(self, matches):
+        alert_fields = []
+        missing = self.rule.get('alert_missing_value', '<MISSING VALUE>')
+        for field in self.mattermost_msg_fields:
+            field = copy.copy(field)
+            if 'args' in field:
+                args_values = [lookup_es_key(matches[0], arg) or missing for arg in field['args']]
+                if 'value' in field:
+                    field['value'] = field['value'].format(*args_values)
+                else:
+                    field['value'] = "\n".join(str(arg) for arg in args_values)
+                del(field['args'])
+            alert_fields.append(field)
+        return alert_fields
+
+    def alert(self, matches):
+        body = self.create_alert_body(matches)
+        title = self.create_title(matches)
+
+        # post to mattermost
+        headers = {'content-type': 'application/json'}
+        # set https proxy, if it was provided
+        proxies = {'https': self.mattermost_proxy} if self.mattermost_proxy else None
+        payload = {
+            'attachments': [
+                {
+                    'fallback': "{0}: {1}".format(title, self.mattermost_msg_pretext),
+                    'color': self.mattermost_msg_color,
+                    'title': title,
+                    'pretext': self.mattermost_msg_pretext,
+                    'fields': []
+                }
+            ]
+        }
+
+        if self.rule.get('alert_text_type') == 'alert_text_only':
+            payload['attachments'][0]['text'] = body
+        else:            
+            payload['text'] = body
+
+        if self.mattermost_msg_fields != '':
+            payload['attachments'][0]['fields'] = self.populate_fields(matches)
+
+        if self.mattermost_icon_url_override != '':
+            payload['icon_url'] = self.mattermost_icon_url_override
+
+        if self.mattermost_username_override != '':
+            payload['username'] = self.mattermost_username_override
+
+        if self.mattermost_channel_override != '':
+            payload['channel'] = self.mattermost_channel_override
+
+        for url in self.mattermost_webhook_url:
+            try:
+                if self.mattermost_ignore_ssl_errors:
+                    requests.urllib3.disable_warnings()
+
+                response = requests.post(
+                    url, data=json.dumps(payload, cls=DateTimeEncoder),
+                    headers=headers, verify=not self.mattermost_ignore_ssl_errors,
+                    proxies=proxies)
+
+                warnings.resetwarnings()
+                response.raise_for_status()
+            except RequestException as e:
+                raise EAException("Error posting to Mattermost: %s" % e)
+        elastalert_logger.info("Alert sent to Mattermost")
+
+    def get_info(self):
+        return {'type': 'mattermost',
+                'mattermost_username_override': self.mattermost_username_override,
+                'mattermost_webhook_url': self.mattermost_webhook_url}
+
+
 class PagerDutyAlerter(Alerter):
     """ Create an incident on PagerDuty for each alert """
     required_options = frozenset(['pagerduty_service_key', 'pagerduty_client_name'])

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1260,7 +1260,7 @@ class MattermostAlerter(Alerter):
 
         if self.rule.get('alert_text_type') == 'alert_text_only':
             payload['attachments'][0]['text'] = body
-        else:            
+        else:
             payload['text'] = body
 
         if self.mattermost_msg_fields != '':

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -73,6 +73,7 @@ alerts_mapping = {
     'stride': alerts.StrideAlerter,
     'ms_teams': alerts.MsTeamsAlerter,
     'slack': alerts.SlackAlerter,
+    'mattermost': alerts.MattermostAlerter,
     'pagerduty': alerts.PagerDutyAlerter,
     'exotel': alerts.ExotelAlerter,
     'twilio': alerts.TwilioAlerter,

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -25,6 +25,15 @@ definitions:
 
   filter: &filter {}
 
+  mattermostField: &mattermostField
+    type: object
+    additionalProperties: false
+    properties:
+      title: {type: string}
+      value: {type: string}
+      args: *arrayOfString
+      short: {type: boolean}
+
 required: [type, index, alert]
 type: object
 
@@ -238,6 +247,17 @@ properties:
   slack_parse_override: {enum: [none, full]}
   slack_text_string: {type: string}
   slack_ignore_ssl_errors: {type: boolean}
+
+  ### Mattermost
+  mattermost_webhook_url: *arrayOfString
+  mattermost_proxy: {type: string}
+  mattermost_ignore_ssl_errors: {type: boolean}
+  mattermost_username_override: {type: string}
+  mattermost_icon_url_override: {type: string}
+  mattermost_channel_override: {type: string}
+  mattermost_msg_color: {enum: [good, warning, danger]}
+  mattermost_msg_pretext: {type: string}
+  mattermost_msg_fields: *mattermostField
 
   ### PagerDuty
   pagerduty_service_key: {type: string}


### PR DESCRIPTION
This contribution adds a new alerter to publish events on Mattermsot.
from [Mattermost](mattermost.org) website:
> As an alternative to proprietary SaaS messaging,  brings all your team communication into one place,  making it searchable and accessible anywhere. 
