### PR TITLE
Pull down all fields for frequency use_terms_query action.

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -231,8 +231,9 @@ class FrequencyRule(RuleType):
     def add_terms_data(self, terms):
         for timestamp, buckets in terms.iteritems():
             for bucket in buckets:
-                event = ({self.ts_field: timestamp,
-                          self.rules['query_key']: bucket['key']}, bucket['doc_count'])
+                event_fields = bucket['hits'][0]['_source']
+                event_fields.update({self.ts_field: timestamp})
+                event = (event_fields, bucket['doc_count'])
                 self.occurrences.setdefault(bucket['key'], EventWindow(self.rules['timeframe'], getTimestamp=self.get_ts)).append(event)
                 self.check_for_match(bucket['key'])
 
@@ -639,7 +640,7 @@ class NewTermsRule(RuleType):
                 (len(self.fields) != 1 or (len(self.fields) == 1 and type(self.fields[0]) == list)):
             raise EAException("use_terms_query can only be used with a single non-composite field")
         if self.rules.get('use_terms_query'):
-            if [self.rules['query_key']] != self.fields:
+            if self.rules.get('query_key') != self.fields:
                 raise EAException('If use_terms_query is specified, you cannot specify different query_key and fields')
             if not self.rules.get('query_key').endswith('.keyword') and not self.rules.get('query_key').endswith('.raw'):
                 if self.rules.get('use_keyword_postfix', True):


### PR DESCRIPTION
Frequency rule use_terms_query doesn't pull down all the fields even though "include" was used. I've modified the code so that it'll pull down all the fields. Please review and see if this can be merged and put into v0.1.35. Thanks.