### PR TITLE
fix username,name for responders in opsgenie alert v2 api

### DIFF
--- a/elastalert/opsgenie.py
+++ b/elastalert/opsgenie.py
@@ -29,9 +29,6 @@ class OpsGenieAlerter(Alerter):
         self.opsgenie_proxy = self.rule.get('opsgenie_proxy', None)
         self.priority = self.rule.get('opsgenie_priority')
 
-    def _fill_responders(self, responders, type_):
-        return [{'id': r, 'type': type_} for r in responders]
-
     def alert(self, matches):
         body = ''
         for match in matches:
@@ -50,9 +47,9 @@ class OpsGenieAlerter(Alerter):
         if self.account:
             post['user'] = self.account
         if self.recipients:
-            post['responders'] = self._fill_responders(self.recipients, 'user')
+            post['responders'] = [{'username': r, 'type': 'user'} for r in self.recipients]
         if self.teams:
-            post['teams'] = self._fill_responders(self.teams, 'team')
+            post['teams'] = [{'name': r, 'type': 'team'} for r in self.teams]
         post['description'] = body
         post['source'] = 'ElastAlert'
         post['tags'] = self.tags

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -389,7 +389,7 @@ def test_opsgenie_basic():
 
         assert mcal[0][1]['headers']['Authorization'] == 'GenieKey ogkey'
         assert mcal[0][1]['json']['source'] == 'ElastAlert'
-        assert mcal[0][1]['json']['responders'] == [{'id': 'lytics', 'type': 'user'}]
+        assert mcal[0][1]['json']['responders'] == [{'username': 'lytics', 'type': 'user'}]
         assert mcal[0][1]['json']['source'] == 'ElastAlert'
 
 
@@ -415,7 +415,7 @@ def test_opsgenie_frequency():
 
         assert mcal[0][1]['headers']['Authorization'] == 'GenieKey ogkey'
         assert mcal[0][1]['json']['source'] == 'ElastAlert'
-        assert mcal[0][1]['json']['responders'] == [{'id': 'lytics', 'type': 'user'}]
+        assert mcal[0][1]['json']['responders'] == [{'username': 'lytics', 'type': 'user'}]
         assert mcal[0][1]['json']['source'] == 'ElastAlert'
         assert mcal[0][1]['json']['source'] == 'ElastAlert'
 


### PR DESCRIPTION
### Problem
- OpsGenie does not accept user or team responders from ElastAlert OpsGenie Integration with Alerts API v2 anymore. APIv2 introduced a generic responders list where teams, users or schedules can be referenced by UUID or teamname/username, but there needs to be different keys: https://docs.opsgenie.com/docs/alert-api#section-create-alert 
- ElastAlert documentation shows opsgenie_team and opsgenie_user config with their real names and not uuid: https://github.com/Yelp/elastalert/blob/master/example_rules/example_opsgenie_frequency.yaml
- However the code does not differentiate between UUID key and real name keys. Only when using UUIDs OpsGenie successfully adds the field values when using real names fields are never set.

### Solution
Instead of sending UUID ElastAlert sends teamname/username with this change as its the more natural and also documented behavior.