### PR TITLE
allow list of slack channel overrides additionally to list of webhooks

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1104,6 +1104,8 @@ class SlackAlerter(Alerter):
         self.slack_proxy = self.rule.get('slack_proxy', None)
         self.slack_username_override = self.rule.get('slack_username_override', 'elastalert')
         self.slack_channel_override = self.rule.get('slack_channel_override', '')
+        if isinstance(self.slack_channel_override, basestring):
+            self.slack_channel_override = [self.slack_channel_override]
         self.slack_emoji_override = self.rule.get('slack_emoji_override', ':ghost:')
         self.slack_icon_url_override = self.rule.get('slack_icon_url_override', '')
         self.slack_msg_color = self.rule.get('slack_msg_color', 'danger')
@@ -1145,7 +1147,6 @@ class SlackAlerter(Alerter):
         proxies = {'https': self.slack_proxy} if self.slack_proxy else None
         payload = {
             'username': self.slack_username_override,
-            'channel': self.slack_channel_override,
             'parse': self.slack_parse_override,
             'text': self.slack_text_string,
             'attachments': [
@@ -1169,18 +1170,20 @@ class SlackAlerter(Alerter):
             payload['icon_emoji'] = self.slack_emoji_override
 
         for url in self.slack_webhook_url:
-            try:
-                if self.slack_ignore_ssl_errors:
-                    requests.packages.urllib3.disable_warnings()
-                response = requests.post(
-                    url, data=json.dumps(payload, cls=DateTimeEncoder),
-                    headers=headers, verify=not self.slack_ignore_ssl_errors,
-                    proxies=proxies)
-                warnings.resetwarnings()
-                response.raise_for_status()
-            except RequestException as e:
-                raise EAException("Error posting to slack: %s" % e)
-        elastalert_logger.info("Alert sent to Slack")
+            for channel_override in self.slack_channel_override:
+                try:
+                    if self.slack_ignore_ssl_errors:
+                        requests.packages.urllib3.disable_warnings()
+                    payload['channel'] = channel_override
+                    response = requests.post(
+                        url, data=json.dumps(payload, cls=DateTimeEncoder),
+                        headers=headers, verify=not self.slack_ignore_ssl_errors,
+                        proxies=proxies)
+                    warnings.resetwarnings()
+                    response.raise_for_status()
+                except RequestException as e:
+                    raise EAException("Error posting to slack: %s" % e)
+        elastalert_logger.info("Alert '%s' sent to Slack" % self.rule['name'])
 
     def get_info(self):
         return {'type': 'slack',

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -1058,6 +1058,66 @@ def test_slack_uses_custom_slack_channel():
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
+def test_slack_uses_list_of_custom_slack_channel():
+    rule = {
+        'name': 'Test Rule',
+        'type': 'any',
+        'slack_webhook_url': ['http://please.dontgohere.slack'],
+        'slack_channel_override': ['#test-alert', '#test-alert2'],
+        'alert': []
+    }
+    load_modules(rule)
+    alert = SlackAlerter(rule)
+    match = {
+        '@timestamp': '2016-01-01T00:00:00',
+        'somefield': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+
+    expected_data1 = {
+        'username': 'elastalert',
+        'channel': '#test-alert',
+        'icon_emoji': ':ghost:',
+        'attachments': [
+            {
+                'color': 'danger',
+                'title': rule['name'],
+                'text': BasicMatchString(rule, match).__str__(),
+                'mrkdwn_in': ['text', 'pretext'],
+                'fields': []
+            }
+        ],
+        'text': '',
+        'parse': 'none'
+    }
+    expected_data2 = {
+        'username': 'elastalert',
+        'channel': '#test-alert2',
+        'icon_emoji': ':ghost:',
+        'attachments': [
+            {
+                'color': 'danger',
+                'title': rule['name'],
+                'text': BasicMatchString(rule, match).__str__(),
+                'mrkdwn_in': ['text', 'pretext'],
+                'fields': []
+            }
+        ],
+        'text': '',
+        'parse': 'none'
+    }
+    mock_post_request.assert_called_with(
+        rule['slack_webhook_url'][0],
+        data=mock.ANY,
+        headers={'content-type': 'application/json'},
+        proxies=None,
+        verify=True
+    )
+    assert expected_data1 == json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert expected_data2 == json.loads(mock_post_request.call_args_list[1][1]['data'])
+
+
 def test_http_alerter_with_payload():
     rule = {
         'name': 'Test HTTP Post Alerter With Payload',


### PR DESCRIPTION
### Problem
While ElastAlert currently already allows to send one alert to multiple Slack channel by using different webhook urls it might not always be feasible to create these f.i. in an environment where rules are generated in an automated manner. 

### Solution
The proposed change allows to have a list of channel overrides instead of only one.