### PR TITLE
fix/cumulative_hits

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -141,6 +141,7 @@ class ElastAlerter():
         self.smtp_host = self.conf.get('smtp_host', 'localhost')
         self.max_aggregation = self.conf.get('max_aggregation', 10000)
         self.alerts_sent = 0
+        self.cumulative_hits = 0
         self.num_hits = 0
         self.num_dupes = 0
         self.current_es = None


### PR DESCRIPTION
In some rare cases of time unsync, we can reach this:
```
INFO:elastalert:Starting up
WARNING:root:Attempted to use query start time in the future (None), sleeping instead
Traceback (most recent call last):
  File "/opt/hosting/run/elastalert/elastalert.py", line 1924, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/opt/hosting/run/elastalert/elastalert.py", line 1920, in main
    client.start()
  File "/opt/hosting/run/elastalert/elastalert.py", line 1107, in start
    self.run_all_rules()
  File "/opt/hosting/run/elastalert/elastalert.py", line 1181, in run_all_rules
    total_hits = max(self.num_hits, self.cumulative_hits)
AttributeError: ElastAlerter instance has no attribute 'cumulative_hits'
```