### PR TITLE
Add option "--formatted-output" to make stdout print JSON formatted test results

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -687,6 +687,8 @@ guaranteed to have the exact same results as with Elasticsearch. For example, an
 
 ``--alert``: Trigger real alerts instead of the debug (logging text) alert.
 
+``--formatted-output``: Output results in formatted JSON.
+
 .. note::
    Results from running this script may not always be the same as if an actual ElastAlert instance was running. Some rule types, such as spike
    and flatline require a minimum elapsed time before they begin alerting, based on their timeframe. In addition, use_count_query and

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -43,6 +43,7 @@ def print_terms(terms, parent):
 class MockElastAlerter(object):
     def __init__(self):
         self.data = []
+        self.formatted_output = {}
 
     def test_file(self, conf, args):
         """ Loads a rule config file, performs a query over the last day (args.days), lists available keys
@@ -111,9 +112,15 @@ class MockElastAlerter(object):
             return None
 
         num_hits = res['count']
-        print("Got %s hits from the last %s day%s" % (num_hits, args.days, 's' if args.days > 1 else ''))
-        print("\nAvailable terms in first hit:")
-        print_terms(terms, '')
+
+        if args.formatted_output:
+            self.formatted_output['hits'] = num_hits
+            self.formatted_output['days'] = args.days
+            self.formatted_output['terms'] = terms
+        else:
+            print("Got %s hits from the last %s day%s" % (num_hits, args.days, 's' if args.days > 1 else ''))
+            print("\nAvailable terms in first hit:")
+            print_terms(terms, '')
 
         # Check for missing keys
         pk = conf.get('primary_key')
@@ -133,7 +140,9 @@ class MockElastAlerter(object):
             # If the index starts with 'logstash', fields with .raw will be available but won't in _source
             if term not in terms and not (term.endswith('.raw') and term[:-4] in terms and index.startswith('logstash')):
                 print("top_count_key %s may be missing" % (term), file=sys.stderr)
-        print('')  # Newline
+        
+        if not args.formatted_output:
+            print('')  # Newline
 
         # Download up to max_query_size (defaults to 10,000) documents to save
         if args.save and not args.count:
@@ -146,7 +155,12 @@ class MockElastAlerter(object):
                     exit(1)
                 return None
             num_hits = len(res['hits']['hits'])
-            print("Downloaded %s documents to save" % (num_hits))
+
+            if args.formatted_output:
+                self.formatted_output['download_hits'] = num_hits
+            else:
+                print("Downloaded %s documents to save" % (num_hits))
+                
             return res['hits']['hits']
 
     def mock_count(self, rule, start, end, index):
@@ -291,10 +305,19 @@ class MockElastAlerter(object):
             client.run_rule(rule, endtime, starttime)
 
             if mock_writeback.call_count:
-                print("\nWould have written the following documents to writeback index (default is elastalert_status):\n")
+
+                if args.formatted_output:
+                    self.formatted_output['writeback'] = {}
+                else:
+                    print("\nWould have written the following documents to writeback index (default is elastalert_status):\n")
+
                 errors = False
                 for call in mock_writeback.call_args_list:
-                    print("%s - %s\n" % (call[0][0], call[0][1]))
+                    if args.formatted_output:
+                        self.formatted_output['writeback'][call[0][0]] = json.loads(json.dumps(call[0][1], default=str))
+                    else:
+                        print("%s - %s\n" % (call[0][0], call[0][1]))
+
                     if call[0][0] == 'elastalert_error':
                         errors = True
                 if errors and args.stop_error:
@@ -340,7 +363,12 @@ class MockElastAlerter(object):
                 conf[key] = conf_default[key]
         elastalert.config.base_config = copy.deepcopy(conf)
         load_options(rules, conf, args.file)
-        print("Successfully loaded %s\n" % (rules['name']))
+
+        if args.formatted_output:
+            self.formatted_output['success'] = True
+            self.formatted_output['name'] = rules['name']
+        else:
+            print("Successfully loaded %s\n" % (rules['name']))
 
         return conf
 
@@ -356,6 +384,7 @@ class MockElastAlerter(object):
         parser.add_argument('--end', dest='end', help='YYYY-MM-DDTHH:MM:SS Query to this timestamp. (Default: present) '
                                                       'Use "NOW" to start from current time. (Default: present)')
         parser.add_argument('--stop-error', action='store_true', help='Stop the entire test right after the first error')
+        parser.add_argument('--formatted-output', action='store_true', help='Output results in formatted JSON')
         parser.add_argument(
             '--data',
             type=str,
@@ -416,6 +445,9 @@ class MockElastAlerter(object):
 
         if not args.schema_only and not args.count:
             self.run_elastalert(rule_yaml, conf, args)
+
+        if args.formatted_output:
+            print(json.dumps(self.formatted_output))
 
 
 def main():

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -140,7 +140,6 @@ class MockElastAlerter(object):
             # If the index starts with 'logstash', fields with .raw will be available but won't in _source
             if term not in terms and not (term.endswith('.raw') and term[:-4] in terms and index.startswith('logstash')):
                 print("top_count_key %s may be missing" % (term), file=sys.stderr)
-        
         if not args.formatted_output:
             print('')  # Newline
 
@@ -160,7 +159,6 @@ class MockElastAlerter(object):
                 self.formatted_output['download_hits'] = num_hits
             else:
                 print("Downloaded %s documents to save" % (num_hits))
-                
             return res['hits']['hits']
 
     def mock_count(self, rule, start, end, index):


### PR DESCRIPTION
Hello, we are writing a GUI to create alerts, built on top of bitsensor's api. 

When testing a rule, the output that comes back isn't structured, so can't be parsed easily by a client. 

This change adds a new option `--formatted-output` for elastalert.test_rule that outputs JSON results.

If this gets merged, a companion PR will get submitted to bitsensor's fork to take advantage of it.

Here is an example output for full run:
```javascript
{
  "writeback": {
    "elastalert_status": {
      "hits": 11,
      "matches": 11,
      "@timestamp": "2018-09-11 16:55:07.546522+00:00",
      "rule_name": "test321",
      "starttime": "2018-09-10 16:55:03.854197+00:00",
      "endtime": "2018-09-11 16:55:03.854197+00:00",
      "time_taken": 3.6562910079956055
    }
  },
  "hits": 11,
  "terms": {
    "syslog_severity_code": 6,
    "service": "Vpxa",
    "tags": [],
    "syslog_severity": "informational",
    "@timestamp": "2018-09-10T18:16:23.461Z",
    "syslog_facility": "user-level",
    "host": "c5014-cesx121.ms",
    "@version": "1",
    "dept_id": "ms",
    "message": "- - [Originator@68762018-09-10T18:16:23.450Z Vpxa: verbose vpxa[FFC9AAE0] [Originator@6876[VpxaHalCnxHostagent::ProcessUpdate] Applying updates from 11843011 to 11843012 (at 11843011)",
    "syslog_pri": "14",
    "type": "syslog",
    "syslog_facility_code": 1
  },
  "name": "test321",
  "success": true,
  "days": 1
}
```

Here is an example output for countOnly:
```javascript
{
  "hits": 11,
  "terms": {
    "syslog_severity_code": 6,
    "service": "Vpxa",
    "tags": [],
    "syslog_severity": "informational",
    "@timestamp": "2018-09-10T18:16:23.461Z",
    "syslog_facility": "user-level",
    "host": "c5014-cesx121.ms",
    "@version": "1",
    "dept_id": "ms",
    "message": "- - [Originator@68762018-09-10T18:16:23.450Z Vpxa: verbose vpxa[FFC9AAE0] [Originator@6876[VpxaHalCnxHostagent::ProcessUpdate] Applying updates from 11843011 to 11843012 (at 11843011)",
    "syslog_pri": "14",
    "type": "syslog",
    "syslog_facility_code": 1
  },
  "name": "test321",
  "success": true,
  "days": 1
}
```

Here is an example output for schemaOnly:
```javascript
{
  "name": "test321",
  "success": true
}
```
