### PR TITLE
min_denominator feature

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1124,6 +1124,8 @@ evaluated separately against the threshold(s).
 For example, "%.2f" will round it to 2 decimal places.
 See: https://docs.python.org/3.4/library/string.html#format-specification-mini-language
 
+``min_denominator``: Minimum number of documents on which percentage calculation will apply. Default is 0.
+
 .. _alerts:
 
 Alerts

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -1109,6 +1109,7 @@ class PercentageMatchRule(BaseAggregationRule):
         if 'max_percentage' not in self.rules and 'min_percentage' not in self.rules:
             raise EAException("PercentageMatchRule must have at least one of either min_percentage or max_percentage")
 
+        self.min_denominator = self.rules.get('min_denominator', 0)
         self.match_bucket_filter = self.rules['match_bucket_filter']
         self.rules['aggregation_query_element'] = self.generate_aggregation_query()
 
@@ -1146,7 +1147,7 @@ class PercentageMatchRule(BaseAggregationRule):
             return
         else:
             total_count = other_bucket_count + match_bucket_count
-            if total_count == 0:
+            if total_count == 0 or total_count < self.min_denominator:
                 return
             else:
                 match_percentage = (match_bucket_count * 1.0) / (total_count * 1.0) * 100


### PR DESCRIPTION
PercentageMatchRule is often interesting when enough samples to calculate on.

``min_denominator`` option is the minimal number of required samples to calculate percentage.