### PR TITLE
Added Google Chat alerter

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Currently, we have built-in support for the following alert types:
 - MS Teams
 - Slack
 - Telegram
+- GoogleChat
 - AWS SNS
 - VictorOps
 - PagerDuty

--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -39,6 +39,7 @@ Currently, we have support built in for these alert types:
 - HipChat
 - Slack
 - Telegram
+- GoogleChat
 - Debug
 - Stomp
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1635,6 +1635,27 @@ Optional:
 
 ``telegram_proxy``: By default ElastAlert will not use a network proxy to send notifications to Telegram. Set this option using ``hostname:port`` if you need to use a proxy.
 
+GoogleChat
+~~~~~~~~~~
+GoogleChat alerter will send a notification to a predefined GoogleChat channel. The body of the notification is formatted the same as with other alerters.
+
+The alerter requires the following options:
+
+``googlechat_webhook_url``: The webhook URL that includes the channel (room) you want to post to. Go to the Google Chat website https://chat.google.com and choose the channel in which you wish to receive the notifications. Select 'Configure Webhooks' to create a new webhook or to copy the URL from an existing one. You can use a list of URLs to send to multiple channels.
+
+Optional:
+
+``googlechat_format``: Formatting for the notification. Can be either 'card' or 'basic' (default).
+
+``googlechat_header_title``: Sets the text for the card header title. (Only used if format=card)
+
+``googlechat_header_subtitle``: Sets the text for the card header subtitle. (Only used if format=card)
+
+``googlechat_header_image``: URL for the card header icon. (Only used if format=card)
+
+``googlechat_footer_kibanalink``: URL to Kibana to include in the card footer. (Only used if format=card)
+
+
 PagerDuty
 ~~~~~~~~~
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1443,6 +1443,96 @@ class TelegramAlerter(Alerter):
                 'telegram_room_id': self.telegram_room_id}
 
 
+class GoogleChatAlerter(Alerter):
+    """ Send a notification via Google Chat webhooks """
+    required_options = frozenset(['googlechat_webhook_url'])
+
+    def __init__(self, rule):
+        super(GoogleChatAlerter, self).__init__(rule)
+        self.googlechat_webhook_url = self.rule['googlechat_webhook_url']
+        if isinstance(self.googlechat_webhook_url, basestring):
+            self.googlechat_webhook_url = [self.googlechat_webhook_url]
+        self.googlechat_format = self.rule.get('googlechat_format', 'basic')
+        self.googlechat_header_title =  self.rule.get('googlechat_header_title', None)
+        self.googlechat_header_subtitle = self.rule.get('googlechat_header_subtitle', None)
+        self.googlechat_header_image = self.rule.get('googlechat_header_image', None)
+        self.googlechat_footer_kibanalink = self.rule.get('googlechat_footer_kibanalink', None)
+
+    def create_header(self):
+        header = None
+        if self.googlechat_header_title:
+            header = {
+                        "title": self.googlechat_header_title,
+                        "subtitle": self.googlechat_header_subtitle,
+                        "imageUrl": self.googlechat_header_image
+                     }
+        return header
+
+    def create_footer(self):
+        footer = None
+        if self.googlechat_footer_kibanalink:
+            footer = {"widgets": [{
+                        "buttons": [{
+                            "textButton": {
+                                "text": "VISIT KIBANA",
+                                "onClick": {
+                                    "openLink": {
+                                        "url": self.googlechat_footer_kibanalink
+                                    }
+                                }
+                            }
+                          }]
+                        }]
+                    }
+        return footer
+
+    def create_card(self, matches):
+        card = {"cards": [{
+                    "sections": [{
+                        "widgets": [
+                            {"textParagraph": {"text": self.create_alert_body(matches).encode('UTF-8')}}
+                        ]}
+                    ]}
+                ]}
+
+        # Add the optional header
+        header = self.create_header()
+        if header:
+            card['cards'][0]['header'] = header
+
+        # Add the optional footer
+        footer = self.create_footer()
+        if footer:
+            card['cards'][0]['sections'].append(footer)
+        return card
+
+    def create_basic(self, matches):
+        body = self.create_alert_body(matches)
+        body = body.encode('UTF-8')
+        return {'text': body}
+
+    def alert(self, matches):
+        # Format message
+        if self.googlechat_format == 'card':
+            message = self.create_card(matches)
+        else:
+            message = self.create_basic(matches)
+
+        # Post to webhook
+        headers = {'content-type': 'application/json'}
+        for url in self.googlechat_webhook_url:
+            try:
+                response = requests.post(url, data=json.dumps(message), headers=headers)
+                response.raise_for_status()
+            except RequestException as e:
+                raise EAException("Error posting to google chat: {}".format(e))
+        elastalert_logger.info("Alert sent to Google Chat!")
+
+    def get_info(self):
+        return {'type': 'googlechat',
+                'googlechat_webhook_url': self.googlechat_webhook_url}
+
+
 class GitterAlerter(Alerter):
     """ Creates a Gitter activity message for each alert """
     required_options = frozenset(['gitter_webhook_url'])

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1453,7 +1453,7 @@ class GoogleChatAlerter(Alerter):
         if isinstance(self.googlechat_webhook_url, basestring):
             self.googlechat_webhook_url = [self.googlechat_webhook_url]
         self.googlechat_format = self.rule.get('googlechat_format', 'basic')
-        self.googlechat_header_title =  self.rule.get('googlechat_header_title', None)
+        self.googlechat_header_title = self.rule.get('googlechat_header_title', None)
         self.googlechat_header_subtitle = self.rule.get('googlechat_header_subtitle', None)
         self.googlechat_header_image = self.rule.get('googlechat_header_image', None)
         self.googlechat_footer_kibanalink = self.rule.get('googlechat_footer_kibanalink', None)
@@ -1472,18 +1472,18 @@ class GoogleChatAlerter(Alerter):
         footer = None
         if self.googlechat_footer_kibanalink:
             footer = {"widgets": [{
-                        "buttons": [{
-                            "textButton": {
-                                "text": "VISIT KIBANA",
-                                "onClick": {
-                                    "openLink": {
-                                        "url": self.googlechat_footer_kibanalink
-                                    }
+                "buttons": [{
+                    "textButton": {
+                        "text": "VISIT KIBANA",
+                        "onClick": {
+                            "openLink": {
+                                "url": self.googlechat_footer_kibanalink
                                 }
                             }
-                          }]
-                        }]
-                    }
+                        }
+                    }]
+                }]
+                }
         return footer
 
     def create_card(self, matches):

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -78,6 +78,7 @@ alerts_mapping = {
     'twilio': alerts.TwilioAlerter,
     'victorops': alerts.VictorOpsAlerter,
     'telegram': alerts.TelegramAlerter,
+    'googlechat': alerts.GoogleChatAlerter,
     'gitter': alerts.GitterAlerter,
     'servicenow': alerts.ServiceNowAlerter,
     'alerta': alerts.AlertaAlerter,


### PR DESCRIPTION
Added support for Google Chat webhooks. Both plaintext and cards format are supported. [Ref](https://developers.google.com/hangouts/chat/reference/message-formats/)