### PR TITLE
When getting count only and using formatted output, include single result

### DIFF
--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -117,6 +117,7 @@ class MockElastAlerter(object):
             self.formatted_output['hits'] = num_hits
             self.formatted_output['days'] = args.days
             self.formatted_output['terms'] = terms.keys()
+            self.formatted_output['result'] = terms
         else:
             print("Got %s hits from the last %s day%s" % (num_hits, args.days, 's' if args.days > 1 else ''))
             print("\nAvailable terms in first hit:")


### PR DESCRIPTION
This will allow you to see a preview of a single result when getting count with formatted output