### PR TITLE
Fixed a TypeError that occurs for old versions of Elasticsearch

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -393,9 +393,13 @@ class ElastAlerter():
                 self.total_hits = int(res['hits']['total'])
 
             if len(res.get('_shards', {}).get('failures', [])) > 0:
-                errs = [e['reason']['reason'] for e in res['_shards']['failures'] if 'Failed to parse' in e['reason']['reason']]
-                if len(errs):
-                    raise ElasticsearchException(errs)
+                try:
+                    errs = [e['reason']['reason'] for e in res['_shards']['failures'] if 'Failed to parse' in e['reason']['reason']]
+                    if len(errs):
+                        raise ElasticsearchException(errs)
+                except (TypeError, KeyError):
+                    # Different versions of ES have this formatted in different ways. Fallback to str-ing the whole thing
+                    raise ElasticsearchException(str(res['_shards']['failures']))
 
             logging.debug(str(res))
         except ElasticsearchException as e:


### PR DESCRIPTION
The error message from some versions doesn't have ['reason']['reason'] in it. In those cases, let's just stringify the whole failure blob, so as to always work. I don't actually know what all the possibilities are for formatting of this error message.