### PR TITLE
OpsGenie alert routing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,21 @@
 # Change Log
 
+# v0.1.34
+
+### Added
+- Added prefix/suffix support for summary table
+- Added support for ignoring SSL validation in Slack
+- More visible exceptions during query parse failures
+
+### Fixed
+- Fixed top_count_keys when using compound query_key
+- Fixed num_hits sometimes being reported too low
+- Fixed an issue with setting ES_USERNAME via env
+- Fixed an issue when using test script with custom timestamps
+- Fixed a unicode error when using Telegram
+- Fixed an issue with jsonschema version conflict
+- Fixed an issue with nested timestamps in cardinality type
+
 # v0.1.33
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# v0.1.35
+
+### Fixed
+- Fixed an issue preventing new term rule from working with terms query
+
 # v0.1.34
 
 ### Added

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1478,8 +1478,10 @@ Optional:
 ``opsgenie_account``: The OpsGenie account to integrate with.
 
 ``opsgenie_recipients``: A list OpsGenie recipients who will be notified by the alert.
+``opsgenie_recipients_args``: Map of arguments used to format opsgenie_recipients.
 
 ``opsgenie_teams``: A list of OpsGenie teams to notify (useful for schedules with escalation).
+``opsgenie_teams_args``: Map of arguments used to format opsgenie_teams (useful for assigning the alerts to teams based on some data)
 
 ``opsgenie_tags``: A list of tags for this alert.
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1479,10 +1479,10 @@ Optional:
 
 ``opsgenie_recipients``: A list OpsGenie recipients who will be notified by the alert.
 ``opsgenie_recipients_args``: Map of arguments used to format opsgenie_recipients.
-
+``opsgenie_default_recipients``: List of default recipients to notify when the formatting of opsgenie_recipients is unsuccesful. 
 ``opsgenie_teams``: A list of OpsGenie teams to notify (useful for schedules with escalation).
 ``opsgenie_teams_args``: Map of arguments used to format opsgenie_teams (useful for assigning the alerts to teams based on some data)
-
+``opsgenie_default_teams``: List of default teams to notify when the formatting of opsgenie_teams is unsuccesful. 
 ``opsgenie_tags``: A list of tags for this alert.
 
 ``opsgenie_message``: Set the OpsGenie message to something other than the rule name. The message can be formatted with fields from the first match e.g. "Error occurred for {app_name} at {timestamp}.".

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -391,8 +391,8 @@ class ElastAlerter():
                 )
                 self.total_hits = int(res['hits']['total'])
 
-            if len(res['_shards']['failures']) > 0:
-                errs = [ e['reason']['reason'] for e in res['_shards']['failures'] if 'Failed to parse' in e['reason']['reason']]
+            if len(res.get('_shards', {}).get('failures', [])) > 0:
+                errs = [e['reason']['reason'] for e in res['_shards']['failures'] if 'Failed to parse' in e['reason']['reason']]
                 if len(errs):
                     raise ElasticsearchException(errs)
 

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -639,7 +639,7 @@ class NewTermsRule(RuleType):
                 (len(self.fields) != 1 or (len(self.fields) == 1 and type(self.fields[0]) == list)):
             raise EAException("use_terms_query can only be used with a single non-composite field")
         if self.rules.get('use_terms_query'):
-            if self.rules.get('query_key') != self.fields:
+            if [self.rules['query_key']] != self.fields:
                 raise EAException('If use_terms_query is specified, you cannot specify different query_key and fields')
             if not self.rules.get('query_key').endswith('.keyword') and not self.rules.get('query_key').endswith('.raw'):
                 if self.rules.get('use_keyword_postfix', True):

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -94,7 +94,7 @@ oneOf:
       doc_type: {type: string}
 
   - title: New Term
-    required: [fields]
+    required: []
     properties:
       type: {enum: [new_term]}
       fields: *arrayOfStringsOrOtherArray

--- a/example_rules/example_opsgenie_frequency.yaml
+++ b/example_rules/example_opsgenie_frequency.yaml
@@ -25,7 +25,7 @@ opsgenie_key: ogkey
 # OpsGenie recipients with args
 # opsgenie_recipients:
 #   - {recipient} 
-# opsgenie_teams_args:
+# opsgenie_recipients_args:
 #     team_prefix:'user.email'
 
 # (Optional)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 base_dir = os.path.dirname(__file__)
 setup(
     name='elastalert',
-    version='0.1.33',
+    version='0.1.34',
     description='Runs custom filters on Elasticsearch and alerts on matches',
     author='Quentin Long',
     author_email='qlo@yelp.com',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 base_dir = os.path.dirname(__file__)
 setup(
     name='elastalert',
-    version='0.1.34',
+    version='0.1.35',
     description='Runs custom filters on Elasticsearch and alerts on matches',
     author='Quentin Long',
     author_email='qlo@yelp.com',


### PR DESCRIPTION
Currently we are making extensive use of elastalert to alert responsible teams on certain events. One thing that this PR provides is to route alert to teams and recipients based on a some data in matches. 

Example  Use Case:

We have some ECS clusters and are streaming ecs events to elastic search. When we certain service fails we want to be able to automatically assign the alert to the correct team or recipient based on the tag on the service. This removes the hassle of having one alert rule per team.

Usage Example:
```
opsgenie_key: xxxxx
opsgenie_subject: "Some count {0} for {1}"
opsgenie_subject_args:
  - host.raw
  - key
opsgenie_teams:
  - {team_prefix}-Team 
  - Team2
  - {team_prefix}-Team-{team_postfix}
opsgenie_teams_args:
    team_prefix:'team'
    team_postfix:'team_postfix'
opsgenie_tags:
  - num_hits
```

PS: this also has a fix for Dockerfile. Since setuptools does not ship with easy_install. https://launchpad.net/ubuntu/+source/python-setuptools/39.0.1-2