### PR TITLE
Add slack_title_link options

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1620,6 +1620,7 @@ Provide absolute address of the pciture, for example: http://some.address.com/im
 
 ``slack_alert_fields``: You can add additional fields to your slack alerts using this field. Specify the title using `title` and a value for the field using `value`. Additionally you can specify whether or not this field should be a `short` field using `short: true`.
 
+``slack_title_link``: You can add a link in your Slack notification by setting this to a valid URL.
 
 Mattermost
 ~~~~~

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1111,6 +1111,7 @@ class SlackAlerter(Alerter):
         self.slack_channel_override = self.rule.get('slack_channel_override', '')
         if isinstance(self.slack_channel_override, basestring):
             self.slack_channel_override = [self.slack_channel_override]
+        self.slack_title_link = self.rule.get('slack_title_link', '')
         self.slack_emoji_override = self.rule.get('slack_emoji_override', ':ghost:')
         self.slack_icon_url_override = self.rule.get('slack_icon_url_override', '')
         self.slack_msg_color = self.rule.get('slack_msg_color', 'danger')
@@ -1173,6 +1174,9 @@ class SlackAlerter(Alerter):
             payload['icon_url'] = self.slack_icon_url_override
         else:
             payload['icon_emoji'] = self.slack_emoji_override
+
+        if self.slack_title_link != '':
+            payload['attachments'][0]['title_link'] = self.slack_title_link
 
         for url in self.slack_webhook_url:
             for channel_override in self.slack_channel_override:


### PR DESCRIPTION
This allows for setting a link in a slack notification