### PR TITLE
add: custom timeframe testing support

### DIFF
--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -274,7 +274,16 @@ class MockElastAlerter(object):
                     self.handle_error("%s is not a valid ISO8601 timestamp (YYYY-MM-DDTHH:MM:SS+XX:00)" % (args.start))
                     exit(1)
             else:
-                starttime = endtime - datetime.timedelta(days=args.days)
+                # if days given as command line argument
+                if args.days > 0:
+                    starttime = endtime - datetime.timedelta(days=args.days)
+                else:
+                    # if timeframe is given in rule
+                    if 'timeframe' in rule:
+                        starttime = endtime - datetime.timedelta(seconds=rule['timeframe'].total_seconds() * 1.01)
+                    # default is 1 days / 24 hours
+                    else:
+                        starttime = endtime - datetime.timedelta(days=1)
 
         # Set run_every to cover the entire time range unless count query, terms query or agg query used
         # This is to prevent query segmenting which unnecessarily slows down tests
@@ -376,7 +385,7 @@ class MockElastAlerter(object):
         parser = argparse.ArgumentParser(description='Validate a rule configuration')
         parser.add_argument('file', metavar='rule', type=str, help='rule configuration filename')
         parser.add_argument('--schema-only', action='store_true', help='Show only schema errors; do not run query')
-        parser.add_argument('--days', type=int, default=1, action='store', help='Query the previous N days with this rule')
+        parser.add_argument('--days', type=int, default=0, action='store', help='Query the previous N days with this rule')
         parser.add_argument('--start', dest='start', help='YYYY-MM-DDTHH:MM:SS Start querying from this timestamp.')
         parser.add_argument('--end', dest='end', help='YYYY-MM-DDTHH:MM:SS Query to this timestamp. (Default: present) '
                                                       'Use "NOW" to start from current time. (Default: present)')


### PR DESCRIPTION
Fixes #1978 
Currently, for testing any rule the elastalert-test-rule script runs ElastAlert over the last 24 hours and prints out any alerts that would have occurred.
see [Testing Your Rule](https://elastalert.readthedocs.io/en/latest/ruletypes.html#testing-your-rule) 
This PR fixes this. The timeframe given in the rule is read and test is run for only that period. If days is given as command line argument, it overrides the timreframe given in rule. If no timeframe is given in the rule and no command line argument of days is given, it defaults to 24 hours.
Also, default value of days(command line arg) is set to 0 instead of 1
