### PR TITLE
Allow regex in blacklists/whitelist filter enhancements

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -820,7 +820,6 @@ class ElastAlerter():
             else:
                 # These are regular expressions and won't work if they are quoted
                 additional_terms.append(rule['compare_key'] + ':' + term)
-        additional_terms = [(rule['compare_key'] + ':"' + term + '"') for term in rule[listname]]
         if listname == 'whitelist':
             query = "NOT " + " AND NOT ".join(additional_terms)
         else:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -813,6 +813,13 @@ class ElastAlerter():
             return
 
         filters = rule['filter']
+        additional_terms = []
+        for term in rule[listname]:
+            if not term.startswith('/') or not term.endswith('/'):
+                additional_terms.append(rule['compare_key'] + ':"' + term + '"')
+            else:
+                # These are regular expressions and won't work if they are quoted
+                additional_terms.append(rule['compare_key'] + ':' + term)
         additional_terms = [(rule['compare_key'] + ':"' + term + '"') for term in rule[listname]]
         if listname == 'whitelist':
             query = "NOT " + " AND NOT ".join(additional_terms)


### PR DESCRIPTION
The blacklist/whitelist filter enhancements was hardcoded to add quotes around each item. However, if you want to use regex, you would have had to do it in filters. You wouldn't use regex with `type: blacklist`, but you might want to use this with `type: any`.

As some context, query_strings are interpreted as regex is the start and end with `/`.