### PR TITLE
Add option to gracefully fail loading of configs.

### DIFF
--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -190,6 +190,8 @@ The default value is ``False``. Elasticsearch 2.0 - 2.3 does not support dots in
 ``string_multi_field_name``: If set, the suffix to use for the subfield for string multi-fields in Elasticsearch.
 The default value is ``.raw`` for Elasticsearch 2 and ``.keyword`` for Elasticsearch 5.
 
+``skip_invalid``: If ``True``, skip invalid files instead of exiting.
+
 .. _runningelastalert:
 
 Running ElastAlert

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -119,7 +119,7 @@ def load_configuration(filename, conf, args=None):
     try:
         rule = load_rule_yaml(filename)
     except Exception as e:
-        if (conf.get('skip_invalid') == True):
+        if (conf.get('skip_invalid')):
             return False
         else:
             raise e
@@ -490,7 +490,7 @@ def load_rules(args):
         try:
             rule = load_configuration(rule_file, conf, args)
             # A rule failed to load, don't try to process it
-            if (rule == False):
+            if (not rule):
                 logging.error('Invalid rule file skipped: %s' % rule_file)
                 continue
             # By setting "is_enabled: False" in rule file, a rule is easily disabled

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -116,7 +116,13 @@ def load_configuration(filename, conf, args=None):
     :param conf: The global configuration dictionary, used for populating defaults.
     :return: The rule configuration, a dictionary.
     """
-    rule = load_rule_yaml(filename)
+    try:
+        rule = load_rule_yaml(filename)
+    except Exception as e:
+        if (conf.get('skip_invalid') == True):
+            return False
+        else:
+            raise e
     load_options(rule, conf, filename, args)
     load_modules(rule, args)
     return rule
@@ -483,6 +489,10 @@ def load_rules(args):
     for rule_file in rule_files:
         try:
             rule = load_configuration(rule_file, conf, args)
+            # A rule failed to load, don't try to process it
+            if (rule == False):
+                logging.error('Invalid rule file skipped: %s' % rule_file)
+                continue
             # By setting "is_enabled: False" in rule file, a rule is easily disabled
             if 'is_enabled' in rule and not rule['is_enabled']:
                 continue

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -120,6 +120,7 @@ def load_configuration(filename, conf, args=None):
         rule = load_rule_yaml(filename)
     except Exception as e:
         if (conf.get('skip_invalid')):
+            logging.error(e)
             return False
         else:
             raise e

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1042,6 +1042,9 @@ class ElastAlerter():
                 # Rule file was changed, reload rule
                 try:
                     new_rule = load_configuration(rule_file, self.conf)
+                    if (new_rule == False):
+                        logging.error('Invalid rule file skipped: %s' % rule_file)
+                        continue
                     if 'is_enabled' in new_rule and not new_rule['is_enabled']:
                         elastalert_logger.info('Rule file %s is now disabled.' % (rule_file))
                         # Remove this rule if it's been disabled
@@ -1080,6 +1083,9 @@ class ElastAlerter():
             for rule_file in set(new_rule_hashes.keys()) - set(self.rule_hashes.keys()):
                 try:
                     new_rule = load_configuration(rule_file, self.conf)
+                    if (new_rule == False):
+                        logging.error('Invalid rule file skipped: %s' % rule_file)
+                        continue
                     if 'is_enabled' in new_rule and not new_rule['is_enabled']:
                         continue
                     if new_rule['name'] in [rule['name'] for rule in self.rules]:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1042,7 +1042,7 @@ class ElastAlerter():
                 # Rule file was changed, reload rule
                 try:
                     new_rule = load_configuration(rule_file, self.conf)
-                    if (new_rule == False):
+                    if (not new_rule):
                         logging.error('Invalid rule file skipped: %s' % rule_file)
                         continue
                     if 'is_enabled' in new_rule and not new_rule['is_enabled']:
@@ -1083,7 +1083,7 @@ class ElastAlerter():
             for rule_file in set(new_rule_hashes.keys()) - set(self.rule_hashes.keys()):
                 try:
                     new_rule = load_configuration(rule_file, self.conf)
-                    if (new_rule == False):
+                    if (not new_rule):
                         logging.error('Invalid rule file skipped: %s' % rule_file)
                         continue
                     if 'is_enabled' in new_rule and not new_rule['is_enabled']:


### PR DESCRIPTION
We've had a few situations where invalid rules will sneak in and bring down the server. I added this option so that we can fail more gracefully if this happens - just printing an error to console. I made this an option but it might be worth considering making this the default behavior. 

Thanks!