### PR TITLE
Add slack_title option

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1629,7 +1629,9 @@ Provide absolute address of the pciture, for example: http://some.address.com/im
 
 ``slack_alert_fields``: You can add additional fields to your slack alerts using this field. Specify the title using `title` and a value for the field using `value`. Additionally you can specify whether or not this field should be a `short` field using `short: true`.
 
-``slack_title_link``: You can add a link in your Slack notification by setting this to a valid URL.
+``slack_title``: Sets a title for the message, this shows up as a blue text at the start of the message
+
+``slack_title_link``: You can add a link in your Slack notification by setting this to a valid URL. Requires slack_title to be set.
 
 ``slack_timeout``: You can specify a timeout value, in seconds, for making communicating with Slac. The default is 10. If a timeout occurs, the alert will be retried next time elastalert cycles.
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1112,6 +1112,7 @@ class SlackAlerter(Alerter):
         if isinstance(self.slack_channel_override, basestring):
             self.slack_channel_override = [self.slack_channel_override]
         self.slack_title_link = self.rule.get('slack_title_link', '')
+        self.slack_title = self.rule.get('slack_title', '')
         self.slack_emoji_override = self.rule.get('slack_emoji_override', ':ghost:')
         self.slack_icon_url_override = self.rule.get('slack_icon_url_override', '')
         self.slack_msg_color = self.rule.get('slack_msg_color', 'danger')

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1177,6 +1177,9 @@ class SlackAlerter(Alerter):
         else:
             payload['icon_emoji'] = self.slack_emoji_override
 
+        if self.slack_title != '':
+            payload['attachments'][0]['title'] = self.slack_title
+
         if self.slack_title_link != '':
             payload['attachments'][0]['title_link'] = self.slack_title_link
 


### PR DESCRIPTION
As far as I can tell, slack_title_link doesn't actually work without a slack_title set.

This PR adds the ability to pass in a slack_title so that feature works.