### PR TITLE
Multi threading

### DIFF
--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -132,6 +132,7 @@ def load_configuration(filename, conf, args=None):
 def load_rule_yaml(filename):
     rule = {
         'rule_file': filename,
+        'running': False,
     }
 
     import_rules.pop(filename, None)  # clear `filename` dependency

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -727,8 +727,8 @@ def run_and_assert_segmented_queries(ea, start, end, segment_size):
 def test_query_segmenting_reset_num_hits(ea):
     # Tests that num_hits gets reset every time run_query is run
     def assert_num_hits_reset():
-        assert ea.num_hits == 0
-        ea.num_hits += 10
+        assert ea.num_hits[ea.rules[0]['name']] == 0
+        ea.num_hits[ea.rules[0]['name']] += 10
     with mock.patch.object(ea, 'run_query') as mock_run_query:
         mock_run_query.side_effect = assert_num_hits_reset()
         ea.run_rule(ea.rules[0], END, START)


### PR DESCRIPTION
Allow rules to be run simultaneously using multi threading. By default ElastAlert will continue to run rules in a sequential basis but adding an additional configuration option `num_threads` will allow multiple threads to process the rules to be run.

The different hits counters are separated out per rule to ensure no collisions.