### PR TITLE
Fixed a bug causing buffer_time to sometimes be ignored

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -689,7 +689,6 @@ class ElastAlerter():
 
     def set_starttime(self, rule, endtime):
         """ Given a rule and an endtime, sets the appropriate starttime for it. """
-
         # This means we are starting fresh
         if 'starttime' not in rule:
             if not rule.get('scan_entire_timeframe'):
@@ -715,12 +714,9 @@ class ElastAlerter():
             if 'minimum_starttime' in rule and rule['minimum_starttime'] > buffer_delta:
                 rule['starttime'] = rule['minimum_starttime']
             # If buffer_time doesn't bring us past the previous endtime, use that instead
-            elif 'previous_endtime' in rule:
-                if rule['previous_endtime'] < buffer_delta:
-                    rule['starttime'] = rule['previous_endtime']
-                    self.adjust_start_time_for_overlapping_agg_query(rule)
-                elif rule.get('allow_buffer_time_overlap'):
-                    rule['starttime'] = buffer_delta
+            elif 'previous_endtime' in rule and rule['previous_endtime'] < buffer_delta:
+                rule['starttime'] = rule['previous_endtime']
+                self.adjust_start_time_for_overlapping_agg_query(rule)
             else:
                 rule['starttime'] = buffer_delta
 
@@ -843,7 +839,6 @@ class ElastAlerter():
         :return: The number of matches that the rule produced.
         """
         run_start = time.time()
-
         self.current_es = elasticsearch_client(rule)
         self.current_es_addr = (rule['es_host'], rule['es_port'])
 

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -856,6 +856,12 @@ def test_set_starttime(ea):
     ea.set_starttime(ea.rules[0], end)
     assert ea.rules[0]['starttime'] == ea.rules[0]['previous_endtime']
 
+    # Make sure starttime is updated if previous_endtime isn't used
+    ea.rules[0]['previous_endtime'] = end - ea.buffer_time / 2
+    ea.rules[0]['starttime'] = ts_to_dt('2014-10-09T00:00:01')
+    ea.set_starttime(ea.rules[0], end)
+    assert ea.rules[0]['starttime'] == end - ea.buffer_time
+
     # scan_entire_timeframe
     ea.rules[0].pop('previous_endtime')
     ea.rules[0].pop('starttime')


### PR DESCRIPTION
Fixes the issue reported in #1363

While running in normal (not use_count/terms_query or metric agg) mode, will sometimes start ignoring the buffer_time when making queries and prevent any overlap. This occurs when there is a slight delay and elastalert splits a segment into two pieces, on the subsequent run, it will use the starttime of the 2nd query.

For example, if the buffer_time is set to 45 minutes, and run 0 took an extra 1 minute to run
```
Run 1 - at 12:46  
 - Query 1a 12:00 to 12:45
 - Query 1b 12:45 to 12:46
Run 2 - at 12:47
 - Query 1a 12:45 - 12:47
```

This is because there's a code path in `set_starttime` where it's never set at all, and the previous run is used.

This was introduced all the way back in 2017 by in #846

```
-            elif 'previous_endtime' in rule and rule['previous_endtime'] < buffer_delta:
-                rule['starttime'] = rule['previous_endtime']
+            elif 'previous_endtime' in rule:
+                if rule['previous_endtime'] < buffer_delta:
+                    rule['starttime'] = rule['previous_endtime']
+                self.adjust_start_time_for_overlapping_agg_query(rule)
            else:
                rule['starttime'] = buffer_delta
```

This also removes the `allow_buffer_time_overlap` "feature" which was added when someone noticed this bug but probably thought it was intentional and I didn't realize it was actually a bug fix either.