### PR TITLE
Avoid writing slack_webhook_url in elastalert_status index

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1198,8 +1198,7 @@ class SlackAlerter(Alerter):
 
     def get_info(self):
         return {'type': 'slack',
-                'slack_username_override': self.slack_username_override,
-                'slack_webhook_url': self.slack_webhook_url}
+                'slack_username_override': self.slack_username_override}
 
 
 class MattermostAlerter(Alerter):


### PR DESCRIPTION
## Description of the change
- Remove slack_webhook_url from elastalert_status index because is visible as plain text

```
{
    "_index": "elastalert_status",
    "_type": "elastalert",
    "_source": {
      "alert_info": {
        "slack_username_override": "ElastAlert",
        "type": "slack",
        "slack_webhook_url": [
          "https://hooks.slack.com/services/xxxxxxxxxxx"
        ]
      }
    }
  }
```