### PR TITLE
Put quotes around aggregate_id search

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1599,7 +1599,7 @@ class ElastAlerter():
         """ Removes and returns all matches from writeback_es that have aggregate_id == _id """
 
         # XXX if there are more than self.max_aggregation matches, you have big alerts and we will leave entries in ES.
-        query = {'query': {'query_string': {'query': 'aggregate_id:%s' % (_id)}}, 'sort': {'@timestamp': 'asc'}}
+        query = {'query': {'query_string': {'query': 'aggregate_id:"%s"' % (_id)}}, 'sort': {'@timestamp': 'asc'}}
         matches = []
         try:
             res = self.writeback_es.search(index=self.writeback_index,

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -363,8 +363,8 @@ def test_agg_matchtime(ea):
     call4 = ea.writeback_es.search.call_args_list[10][1]['body']
 
     assert 'alert_time' in call2['filter']['range']
-    assert call3['query']['query_string']['query'] == 'aggregate_id:ABCD'
-    assert call4['query']['query_string']['query'] == 'aggregate_id:CDEF'
+    assert call3['query']['query_string']['query'] == 'aggregate_id:"ABCD"'
+    assert call4['query']['query_string']['query'] == 'aggregate_id:"CDEF"'
     assert ea.writeback_es.search.call_args_list[9][1]['size'] == 1337
 
 
@@ -529,8 +529,8 @@ def test_agg_with_aggregation_key(ea):
     call4 = ea.writeback_es.search.call_args_list[10][1]['body']
 
     assert 'alert_time' in call2['filter']['range']
-    assert call3['query']['query_string']['query'] == 'aggregate_id:ABCD'
-    assert call4['query']['query_string']['query'] == 'aggregate_id:CDEF'
+    assert call3['query']['query_string']['query'] == 'aggregate_id:"ABCD"'
+    assert call4['query']['query_string']['query'] == 'aggregate_id:"CDEF"'
     assert ea.writeback_es.search.call_args_list[9][1]['size'] == 1337
 
 


### PR DESCRIPTION
Add quotes to the aggregate_id search. This prevents it from accidentally picking up incorrect alerts if the _ids share common patterns. Note that this *only* occurs if the mapping is applied incorrectly, as aggregate_id is supposed to be non-analyzed. However, we may as well preemptively prevent these errors because it's as simple as adding quotes.