### PR TITLE
Fix Docs: Writing Filters, add ES version info

### DIFF
--- a/docs/source/recipes/writing_filters.rst
+++ b/docs/source/recipes/writing_filters.rst
@@ -97,7 +97,7 @@ For ranges on fields::
 Negation, and, or
 *****************
 
-Any of the filters can be embedded in ``not``, ``and``, and ``or``::
+For Elasticsearch 2.X, any of the filters can be embedded in ``not``, ``and``, and ``or``::
 
     filter:
     - or:
@@ -113,6 +113,13 @@ Any of the filters can be embedded in ``not``, ``and``, and ``or``::
                 term:
                   _type: "something"
 
+For Elasticsearch 5.x, this will not work and to implement boolean logic use query strings::
+
+    filter:
+     - query:
+          query_string:
+            query: "somefield: somevalue OR foo: bar"
+            
 
 Loading Filters Directly From Kibana 3
 --------------------------------------


### PR DESCRIPTION
Implementing boolean logic in filters is quite different for Elasticsearch versions, mainly 2.x and 5.x. The examples given in the documentation are of Elasticsearch 2.x ( which is quite outdated ). It should be specified in documentation which version of Elasticsearch do these queries support. Users have already faced issues and confusion regarding this #912, #930