### PR TITLE
Add match timestamp to pagerduty v2 api

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1374,6 +1374,9 @@ class PagerDutyAlerter(Alerter):
                     },
                 },
             }
+            match_timestamp = lookup_es_key(matches[0], self.rule.get('timestamp_field', '@timestamp'))
+            if match_timestamp:
+                payload['payload']['timestamp'] = match_timestamp
         else:
             payload = {
                 'service_key': self.pagerduty_service_key,
@@ -1910,7 +1913,7 @@ class AlertaAlerter(Alerter):
             'tags': [resolve_string(a_tag, match, self.missing_text) for a_tag in self.tags],
             'correlate': [resolve_string(an_event, match, self.missing_text) for an_event in self.correlate],
             'attributes': dict(zip(self.attributes_keys,
-                               [resolve_string(a_value, match, self.missing_text) for a_value in self.attributes_values])),
+                                   [resolve_string(a_value, match, self.missing_text) for a_value in self.attributes_values])),
             'rawData': self.create_alert_body([match]),
         }
 

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -1364,6 +1364,7 @@ def test_pagerduty_alerter_v2():
             'custom_details': {
                 'information': 'Test PD Rule\n\n@timestamp: 2017-01-01T00:00:00\nsomefield: foobarbaz\n'
             },
+            'timestamp': '2017-01-01T00:00:00'
         },
         'event_action': 'trigger',
         'dedup_key': '',


### PR DESCRIPTION
Fixes #2037

Add the timestamp into the structured pagerduty v2 payload.