### PR TITLE
Using SSL with stomp alerts

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -364,8 +364,9 @@ class StompAlerter(Alerter):
         self.stomp_password = self.rule.get('stomp_password', 'admin')
         self.stomp_destination = self.rule.get(
             'stomp_destination', '/queue/ALERT')
+        self.stomp_ssl = self.rule.get('stomp_ssl', False)
 
-        conn = stomp.Connection([(self.stomp_hostname, self.stomp_hostport)])
+        conn = stomp.Connection([(self.stomp_hostname, self.stomp_hostport)],use_ssl=self.stomp_ssl)
 
         conn.start()
         conn.connect(self.stomp_login, self.stomp_password)

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -366,7 +366,7 @@ class StompAlerter(Alerter):
             'stomp_destination', '/queue/ALERT')
         self.stomp_ssl = self.rule.get('stomp_ssl', False)
 
-        conn = stomp.Connection([(self.stomp_hostname, self.stomp_hostport)],use_ssl=self.stomp_ssl)
+        conn = stomp.Connection([(self.stomp_hostname, self.stomp_hostport)], use_ssl=self.stomp_ssl)
 
         conn.start()
         conn.connect(self.stomp_login, self.stomp_password)


### PR DESCRIPTION
Default value of stomp_ssl will be "False"
The format will be like
alert:
- stomp:
       stomp_hostname: ....
       stomp_hostport: ....
       stomp_login:  ....
       stomp_password:  ....
       stomp_destination:  ....
       stomp_ssl: True
