### PR TITLE
Alerts: create_custom_title can respect a configurable max length

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -226,6 +226,7 @@ class Alerter(object):
 
     def create_custom_title(self, matches):
         alert_subject = unicode(self.rule['alert_subject'])
+        alert_subject_max_len = int(self.rule.get('alert_subject_max_len', 2048))
 
         if 'alert_subject_args' in self.rule:
             alert_subject_args = self.rule['alert_subject_args']
@@ -242,7 +243,10 @@ class Alerter(object):
 
             missing = self.rule.get('alert_missing_value', '<MISSING VALUE>')
             alert_subject_values = [missing if val is None else val for val in alert_subject_values]
-            return alert_subject.format(*alert_subject_values)
+            alert_subject = alert_subject.format(*alert_subject_values)
+
+        if len(alert_subject) > alert_subject_max_len:
+            alert_subject = alert_subject[:alert_subject_max_len]
 
         return alert_subject
 

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -2118,3 +2118,32 @@ def test_alerta_new_style(ea):
     )
     assert expected_data == json.loads(
         mock_post_request.call_args_list[0][1]['data'])
+
+
+def test_alert_subject_size_limit_no_args(ea):
+    rule = {
+        'name': 'test_rule',
+        'type': mock_rule(),
+        'owner': 'the_owner',
+        'priority': 2,
+        'alert_subject': 'A very long subject',
+        'alert_subject_max_len': 5
+    }
+    alert = Alerter(rule)
+    alertSubject = alert.create_custom_title([{'test_term': 'test_value', '@timestamp': '2014-10-31T00:00:00'}])
+    assert 5 == len(alertSubject)
+
+
+def test_alert_subject_size_limit_with_args(ea):
+    rule = {
+        'name': 'test_rule',
+        'type': mock_rule(),
+        'owner': 'the_owner',
+        'priority': 2,
+        'alert_subject': 'Test alert for {0} {1}',
+        'alert_subject_args': ['test_term', 'test.term'],
+        'alert_subject_max_len': 6
+    }
+    alert = Alerter(rule)
+    alertSubject = alert.create_custom_title([{'test_term': 'test_value', '@timestamp': '2014-10-31T00:00:00'}])
+    assert 6 == len(alertSubject)


### PR DESCRIPTION
Hi there,

I've never written python before. I also have no IDE and was not able to execute any code but I assume it should work. So please forgive me if something does not work.

The implemented feature is:

For example in Jira a subject is limited to 255 chars. When generating
a subject with arguments it sometimes exceeds 255 characters.

This feature adds the new configuration parameter "alert_subject_max_len"
to limit the length of the custom alert subject to the desired length.

Default length is at 2048 chars.