### PR TITLE
Fixes FrequencyRule.add_data to run check_for_match on all keys seen

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -244,6 +244,7 @@ class FrequencyRule(RuleType):
         else:
             qk = None
 
+        keys = set()
         for event in data:
             if qk:
                 key = hashable(lookup_es_key(event, qk))
@@ -252,13 +253,15 @@ class FrequencyRule(RuleType):
                 key = 'all'
 
             # Store the timestamps of recent occurrences, per key
+            keys.add(key)
             self.occurrences.setdefault(key, EventWindow(self.rules['timeframe'], getTimestamp=self.get_ts)).append((event, 1))
             self.check_for_match(key, end=False)
 
         # We call this multiple times with the 'end' parameter because subclasses
         # may or may not want to check while only partial data has been added
-        if key in self.occurrences:  # could have been emptied by previous check
-            self.check_for_match(key, end=True)
+        for key in keys:
+            if key in self.occurrences:  # could have been emptied by previous check
+                self.check_for_match(key, end=True)
 
     def check_for_match(self, key, end=False):
         # Match if, after removing old events, we hit num_events.


### PR DESCRIPTION
`FrequencyRule.add_data` runs a final `self.check_for_match(key, end=True)` after it has added all the data provided.

There are subclasses such as `FlatlineRule` that only checks for matches when `end=True`. Currently this means that if more than one key was found in the given data that only the last key found would actually be checked.

This fix stores a set of keys found in `data` and runs `self.check_for_match(key, end=True)` on all found keys not just the last key found.