### PR TITLE
Fixes create_index.py to make it possible to overwrite the config

### DIFF
--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -53,9 +53,7 @@ def main():
     parser.add_argument('--recreate', type=bool, default=False, help='Force re-creation of the index (this will cause data loss).')
     args = parser.parse_args()
 
-    if os.path.isfile('config.yaml'):
-        filename = 'config.yaml'
-    elif os.path.isfile(args.config):
+    if os.path.isfile(args.config):
         filename = args.config
     else:
         filename = ''


### PR DESCRIPTION
Fixes create_index.py to make it possible to overwrite the config file with the --config flag.

fixes #2097 create_index config attribute ignored if config.yaml is present