### PR TITLE
Correctly set `realert`, `aggregation`, `query_delay` from the config

### DIFF
--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -212,6 +212,10 @@ def load_options(rule, conf, filename, args=None):
         raise EAException('Invalid time format used: %s' % (e))
 
     # Set defaults, copy defaults from config.yaml
+    td_fields = ['realert', 'aggregation', 'query_delay']
+    for td_field in td_fields:
+        if td_field in base_config:
+            rule.setdefault(td_field, datetime.timedelta(**base_config[td_field]))
     for key, val in base_config.items():
         rule.setdefault(key, val)
     rule.setdefault('name', os.path.splitext(filename)[0])

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -212,7 +212,7 @@ def load_options(rule, conf, filename, args=None):
         raise EAException('Invalid time format used: %s' % (e))
 
     # Set defaults, copy defaults from config.yaml
-    td_fields = ['realert', 'aggregation', 'query_delay']
+    td_fields = ['realert', 'exponential_realert', 'aggregation', 'query_delay']
     for td_field in td_fields:
         if td_field in base_config:
             rule.setdefault(td_field, datetime.timedelta(**base_config[td_field]))


### PR DESCRIPTION
Hi! It seems that the `query_delay` field isn't correctly inherited from the config file. Trying to set `query_delay: {'minutes': 1}` in `elasticsearch.yml` results in the following exception:
```
Traceback (most recent call last):
  File "/usr/local/bin/elastalert", line 11, in <module>
    load_entry_point('elastalert==0.1.38', 'console_scripts', 'elastalert')()
  File "/usr/local/lib/python2.7/dist-packages/elastalert/elastalert.py", line 1919, in main
    client.start()
  File "/usr/local/lib/python2.7/dist-packages/elastalert/elastalert.py", line 1100, in start
    self.run_all_rules()
  File "/usr/local/lib/python2.7/dist-packages/elastalert/elastalert.py", line 1162, in run_all_rules
    endtime = ts_now() - delay
TypeError: unsupported operand type(s) for -: 'datetime.datetime' and 'dict'
```
Inspecting the code, it looks like this [line](https://github.com/Yelp/elastalert/blob/master/elastalert/config.py#L216) is setting `query_delay` to the `dict` instead of converting it to a `datetime`. This PR should fix the issue for all the relevant `timedelta` fields.