### PR TITLE
Add ability to lookup into arrays

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1312,6 +1312,8 @@ field_values will contain every key value pair included in the results from Elas
 every key in ``include``, every key in ``top_count_keys``, ``query_key``, and ``compare_key``. If the alert spans multiple events, these values may
 come from an individual event, usually the one which triggers the alert.
 
+When using ``alert_text_args``, you can access nested fields and index into arrays. For example, if your match was ``{"data": {"ips": ["127.0.0.1", "12.34.56.78"]}}``, then by using ``"data.ips[1]"`` in ``alert_text_args``, it would replace value with ``"12.34.56.78"``. This can go arbitrarily deep into fields and will still work on keys that contain dots themselves.
+
 Command
 ~~~~~~~
 
@@ -2117,4 +2119,3 @@ Example usage::
         - domain: "{match[field1]}_{rule[name]}"
         - domain: "{match[field]}"
         - ip: "{match[ip_field]}"
-

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -3,6 +3,7 @@ import collections
 import datetime
 import logging
 import os
+import re
 
 import dateutil.parser
 import dateutil.tz
@@ -60,27 +61,46 @@ def _find_es_dict_by_key(lookup_dict, term):
     # For example:
     #  {'foo.bar': {'bar': 'ray'}} to look up foo.bar will return {'bar': 'ray'}, not 'ray'
     dict_cursor = lookup_dict
-    subkeys = term.split('.')
-    subkey = ''
 
-    while len(subkeys) > 0:
-        if not dict_cursor:
-            return {}, None
-
-        subkey += subkeys.pop(0)
-
-        if subkey in dict_cursor:
-            if len(subkeys) == 0:
-                break
-
-            dict_cursor = dict_cursor[subkey]
-            subkey = ''
-        elif len(subkeys) == 0:
-            # If there are no keys left to match, return None values
-            dict_cursor = None
-            subkey = None
+    while term:
+        split_results = re.split(r'\[(\d?)\]', term, 1)
+        if len(split_results) == 3:
+            sub_term, index, term = split_results
+            index = index or '0'
+            index = int(index)
         else:
-            subkey += '.'
+            sub_term, index, term = split_results + [None, '']
+
+        subkeys = sub_term.split('.')
+
+        subkey = ''
+
+        while len(subkeys) > 0:
+            if not dict_cursor:
+                return {}, None
+
+            subkey += subkeys.pop(0)
+
+            if subkey in dict_cursor:
+                if len(subkeys) == 0:
+                    break
+                dict_cursor = dict_cursor[subkey]
+                subkey = ''
+            elif len(subkeys) == 0:
+                # If there are no keys left to match, return None values
+                dict_cursor = None
+                subkey = None
+            else:
+                subkey += '.'
+
+        if index is not None and subkey:
+            dict_cursor = dict_cursor[subkey]
+            if type(dict_cursor) == list and len(dict_cursor) > index:
+                subkey = index
+                if term:
+                    dict_cursor = dict_cursor[subkey]
+            else:
+                return {}, None
 
     return dict_cursor, subkey
 

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -63,10 +63,9 @@ def _find_es_dict_by_key(lookup_dict, term):
     dict_cursor = lookup_dict
 
     while term:
-        split_results = re.split(r'\[(\d?)\]', term, 1)
+        split_results = re.split(r'\[(\d)\]', term, maxsplit=1)
         if len(split_results) == 3:
             sub_term, index, term = split_results
-            index = index or '0'
             index = int(index)
         else:
             sub_term, index, term = split_results + [None, '']

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -105,6 +105,24 @@ def test_looking_up_nested_composite_keys(ea):
     assert lookup_es_key(record, 'Fields.ts.value') == expected
 
 
+def test_looking_up_arrays(ea):
+    record = {
+        'flags': [1, 2, 3],
+        'objects': [
+            {'foo': 'bar'},
+            {'foo': [{'bar': 'baz'}]},
+            {'foo': {'bar': 'baz'}}
+        ]
+    }
+    assert lookup_es_key(record, 'flags[]') == 1
+    assert lookup_es_key(record, 'flags[1]') == 2
+    assert lookup_es_key(record, 'objects[]foo') == 'bar'
+    assert lookup_es_key(record, 'objects[1]foo[0]bar') == 'baz'
+    assert lookup_es_key(record, 'objects[2]foo.bar') == 'baz'
+    assert lookup_es_key(record, 'objects[1]foo[1]bar') is None
+    assert lookup_es_key(record, 'objects[1]foo[0]baz') is None
+
+
 def test_add_raw_postfix(ea):
     expected = 'foo.raw'
     assert add_raw_postfix('foo', False) == expected

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -114,9 +114,9 @@ def test_looking_up_arrays(ea):
             {'foo': {'bar': 'baz'}}
         ]
     }
-    assert lookup_es_key(record, 'flags[]') == 1
+    assert lookup_es_key(record, 'flags[0]') == 1
     assert lookup_es_key(record, 'flags[1]') == 2
-    assert lookup_es_key(record, 'objects[]foo') == 'bar'
+    assert lookup_es_key(record, 'objects[0]foo') == 'bar'
     assert lookup_es_key(record, 'objects[1]foo[0]bar') == 'baz'
     assert lookup_es_key(record, 'objects[2]foo.bar') == 'baz'
     assert lookup_es_key(record, 'objects[1]foo[1]bar') is None


### PR DESCRIPTION
When using lookup_es_key, you can now access arrays. See tests for examples and usage

(It looks nicer if you remove whitespace changes from the diff view settings, I removed some blank lines)
The diff detector didn't do great here so I'll explain the the changes:
I wrapped most of the method in a while loop that tries to split the full search term by each array lookup. For each section, lookup on sub_term will proceed as before, but at the end, it tries to index into the final cursor object, and continues with the next term. 
