### PR TITLE
Add Prometheus Metrics

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -17,6 +17,7 @@ from socket import error
 
 import dateutil.tz
 import kibana
+import prometheus_client
 import yaml
 from alerts import DebugAlerter
 from config import get_rule_hashes
@@ -48,6 +49,18 @@ from util import ts_add
 from util import ts_now
 from util import ts_to_dt
 from util import unix_to_dt
+
+# initialize prometheus metrics to be exposed
+prom_hits = prometheus_client.Gauge('elastalert_hits', 'Number of hits', ['rule_name'])
+prom_matches = prometheus_client.Gauge('elastalert_matches', 'Number of matches', ['rule_name'])
+prom_time_taken = prometheus_client.Gauge('elastalert_time_taken', 'Time taken to evaluate rule', ['rule_name'])
+
+prom_alerts_sent = prometheus_client.Counter('elastalert_alerts_sent', 'Number of alerts sent', ['rule_name'])
+prom_alerts_not_sent = prometheus_client.Counter('elastalert_alerts_not_sent', 'Number of alerts not sent', ['rule_name'])
+
+prom_errors = prometheus_client.Counter('elastalert_errors', 'Number of errors')
+
+prom_alerts_silenced = prometheus_client.Counter('elastalert_alerts_silenced', 'Number of silenced alerts', ['rule_name'])
 
 
 class ElastAlerter():
@@ -1495,6 +1508,8 @@ class ElastAlerter():
         if '@timestamp' not in writeback_body:
             writeback_body['@timestamp'] = dt_to_ts(ts_now())
 
+        update_metrics(doc_type, body)
+
         try:
             res = self.writeback_es.index(index=writeback_index,
                                           doc_type=doc_type, body=body)
@@ -1910,6 +1925,23 @@ class ElastAlerter():
         return timestamp + wait, exponent
 
 
+def update_metrics(doc_type, body):
+    """ Update various prometheus metrics accoording to the doc_type """
+    if doc_type == 'elastalert_status':
+        prom_hits.labels(body['rule_name']).set(int(body['hits']))
+        prom_matches.labels(body['rule_name']).set(int(body['matches']))
+        prom_time_taken.labels(body['rule_name']).set(float(body['time_taken']))
+    elif doc_type == 'elastalert':
+        if body['alert_sent']:
+            prom_alerts_sent.labels(body['rule_name']).inc()
+        else:
+            prom_alerts_not_sent.labels(body['rule_name']).inc()
+    elif doc_type == 'elastalert_error':
+        prom_errors.inc()
+    elif doc_type == 'silence':
+        prom_alerts_silenced.labels(body['rule_name']).inc()
+
+
 def handle_signal(signal, frame):
     elastalert_logger.info('SIGINT received, stopping ElastAlert...')
     # use os._exit to exit immediately and avoid someone catching SystemExit
@@ -1921,6 +1953,10 @@ def main(args=None):
     if not args:
         args = sys.argv[1:]
     client = ElastAlerter(args)
+
+    # start serving metrics
+    prometheus_client.start_http_server(9090)
+
     if not client.args.silence:
         client.start()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ exotel>=0.1.3
 jira>=1.0.10,<1.0.15
 jsonschema>=2.6.0
 mock>=2.0.0
+prometheus_client>=0.6.0
 PyStaticConfiguration>=0.10.3
 python-dateutil>=2.6.0,<2.7.0
 PyYAML>=3.12

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         'jsonschema>=2.6.0,<3.0.0',
         'mock>=2.0.0',
         'PyStaticConfiguration>=0.10.3',
+        'prometheus_client>=0.6.0',
         'python-dateutil>=2.6.0,<2.7.0',
         'PyYAML>=3.12',
         'requests>=2.10.0',


### PR DESCRIPTION
Start exporting metrics in Prometheus format on port _9090_.

Relevant Metrics added, most of the metrics have a *rule_name*_label:
(All metrics except 6th are per rule)
1. Number of hits
2. Number of matches
3. Time taken to evaluate rule
4. Number of alerts sent
5. Number of alerts not sent
6. Total Number of elastalert_errors
7. Number of silenced alerts