### PR TITLE
Delete multiline code in TG alert

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1601,7 +1601,7 @@ class TelegramAlerter(Alerter):
         self.telegram_proxy_password = self.rule.get('telegram_proxy_pass', None)
 
     def alert(self, matches):
-        body = u'⚠ *%s* ⚠ ```\n' % (self.create_title(matches))
+        body = u'⚠ *%s* ⚠ \n' % (self.create_title(matches))
         for match in matches:
             body += unicode(BasicMatchString(self.rule, match))
             # Separate text of aggregated alerts with dashes
@@ -1609,7 +1609,6 @@ class TelegramAlerter(Alerter):
                 body += '\n----------------------------------------\n'
         if len(body) > 4095:
             body = body[0:4000] + u"\n⚠ *message was cropped according to telegram limits!* ⚠"
-        body += u' ```'
 
         headers = {'content-type': 'application/json'}
         # set https proxy, if it was provided


### PR DESCRIPTION
Remove multiline code in the text of an alert. This makes url clickable