### PR TITLE
Add `max_scrolling_count` setting to limit scrolling behavior

### DIFF
--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -148,7 +148,11 @@ configuration.
 
 ``max_query_size``: The maximum number of documents that will be downloaded from Elasticsearch in a single query. The
 default is 10,000, and if you expect to get near this number, consider using ``use_count_query`` for the rule. If this
-limit is reached, ElastAlert will `scroll <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html>`_ through pages the size of ``max_query_size`` until processing all results.
+limit is reached, ElastAlert will `scroll <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html>`_
+using the size of ``max_query_size`` through the set amount of pages, when ``max_scrolling_count`` is set or until processing all results.
+
+``max_scrolling_count``: The maximum amount of pages to scroll through. The default is ``0``, which means the scrolling has no limit.
+For example if this value is set to ``5`` and the ``max_query_size`` is set to ``10000`` then ``50000`` documents will be downloaded at most.
 
 ``scroll_keepalive``: The maximum time (formatted in `Time Units <https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#time-units>`_) the scrolling context should be kept alive. Avoid using high values as it abuses resources in Elasticsearch, but be mindful to allow sufficient time to finish processing all the results.
 

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -475,6 +475,7 @@ def load_rules(args):
 
     conf.setdefault('max_query_size', 10000)
     conf.setdefault('scroll_keepalive', '30s')
+    conf.setdefault('max_scrolling_count', 0)
     conf.setdefault('disable_rules_on_error', True)
     conf.setdefault('scan_subdirectories', True)
 

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -48,6 +48,7 @@ from util import ts_add
 from util import ts_now
 from util import ts_to_dt
 from util import unix_to_dt
+from util import should_scrolling_continue
 
 
 class ElastAlerter():
@@ -601,6 +602,7 @@ class ElastAlerter():
 
         # Reset hit counter and query
         rule_inst = rule['type']
+        rule['scrolling_cycle'] = rule.get('scrolling_cycle', 0) + 1
         index = self.get_index(rule, start, end)
         if rule.get('use_count_query'):
             data = self.get_hits_count(rule, start, end, index)
@@ -629,7 +631,7 @@ class ElastAlerter():
                 rule_inst.add_data(data)
 
         try:
-            if rule.get('scroll_id') and self.num_hits < self.total_hits:
+            if rule.get('scroll_id') and self.num_hits < self.total_hits and should_scrolling_continue(rule):
                 self.run_query(rule, start, end, scroll=True)
         except RuntimeError:
             # It's possible to scroll far enough to hit max recursive depth
@@ -838,6 +840,7 @@ class ElastAlerter():
             self.set_starttime(rule, endtime)
 
         rule['original_starttime'] = rule['starttime']
+        rule['scrolling_cycle'] = 0
 
         # Don't run if starttime was set to the future
         if ts_now() <= rule['starttime']:

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -178,6 +178,7 @@ properties:
   buffer_time: *timeframe
   query_delay: *timeframe
   max_query_size: {type: integer}
+  max_scrolling: {type: integer}
 
   owner: {type: string}
   priority: {type: integer}

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -434,3 +434,16 @@ def resolve_string(string, match, missing_text='<MISSING VALUE>'):
             string = string.replace('{%s}' % e.message, '{_missing_value}')
 
     return string
+
+
+def should_scrolling_continue(rule_conf):
+    """
+    Tells about a rule config if it can scroll still or should stop the scrolling.
+
+    :param: rule_conf as dict
+    :rtype: bool
+    """
+    max_scrolling = rule_conf.get('max_scrolling_count')
+    stop_the_scroll = 0 < max_scrolling <= rule_conf.get('scrolling_cycle')
+
+    return not stop_the_scroll

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -14,6 +14,7 @@ from elastalert.util import parse_duration
 from elastalert.util import replace_dots_in_field_names
 from elastalert.util import resolve_string
 from elastalert.util import set_es_key
+from elastalert.util import should_scrolling_continue
 
 
 @pytest.mark.parametrize('spec, expected_delta', [
@@ -213,3 +214,17 @@ def test_format_index():
                                                                            'logstash-2018.06.25',
                                                                            'logstash-2018.06.26']
     assert sorted(format_index(pattern2, date, date2, True).split(',')) == ['logstash-2018.25', 'logstash-2018.26']
+
+
+def test_should_scrolling_continue():
+    rule_no_max_scrolling = {'max_scrolling_count': 0, 'scrolling_cycle': 1}
+    rule_reached_max_scrolling = {'max_scrolling_count': 2, 'scrolling_cycle': 2}
+    rule_before_first_run = {'max_scrolling_count': 0, 'scrolling_cycle': 0}
+    rule_before_max_scrolling = {'max_scrolling_count': 2, 'scrolling_cycle': 1}
+    rule_over_max_scrolling = {'max_scrolling_count': 2, 'scrolling_cycle': 3}
+
+    assert should_scrolling_continue(rule_no_max_scrolling) is True
+    assert should_scrolling_continue(rule_reached_max_scrolling) is False
+    assert should_scrolling_continue(rule_before_first_run) is True
+    assert should_scrolling_continue(rule_before_max_scrolling) is True
+    assert should_scrolling_continue(rule_over_max_scrolling) is False


### PR DESCRIPTION
Problem: when the rule query has a large result set (e.g.: more than 1 million documents) it starts to load all documents to memory which eats up all of the memory on the machine.

Solution: added the `max_scrolling_count` setting to potentially limit the number of scrolling requests.

The default `max_scrolling_count` setting is 0, which doesn't alter the current behavior.

Documentation has been updated.