### PR TITLE
Adds writeback_suffix/alias functionality back into code base

### DIFF
--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -149,6 +149,8 @@ configuration.
 
 ``writeback_index``: The index on ``es_host`` to use.
 
+``writeback_alias``: Optional; the alias to use for alert indices. The default is ``elastalert_alerts``.
+
 ``max_query_size``: The maximum number of documents that will be downloaded from Elasticsearch in a single query. The
 default is 10,000, and if you expect to get near this number, consider using ``use_count_query`` for the rule. If this
 limit is reached, ElastAlert will `scroll <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html>`_ through pages the size of ``max_query_size`` until processing all results.

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -28,6 +28,8 @@ Rule Configuration Cheat Sheet
 +--------------------------------------------------------------+-----------+
 | ``name`` (string, defaults to the filename)                  |           |
 +--------------------------------------------------------------+           |
+| ``writeback_suffix`` (string, no default)                    |           |
++--------------------------------------------------------------+           |
 | ``use_strftime_index`` (boolean, default False)              |  Optional |
 +--------------------------------------------------------------+           |
 | ``use_ssl`` (boolean, default False)                         |           |
@@ -225,6 +227,12 @@ or loaded from a module. For loading from a module, the alert should be specifie
 
 Optional Settings
 ~~~~~~~~~~~~~~~~~
+
+writeback_suffix
+^^^^^^^^^^^^^^^^
+``writeback_suffix``: If specified the index that alerts are written to is changed from ``<writeback_index>`` to ``<writeback_index>_<writeback_suffix>``.
+The suffix can include a ``datetime`` format which will be dynamically formatted using the current utc time and references
+to ``match_body`` fields, e.g.: ``{match_body_field}_%Y.%M.%d``, ``%Y.%M.%d``, or ``{match_body_field}``.
 
 import
 ^^^^^^

--- a/docs/source/running_elastalert.rst
+++ b/docs/source/running_elastalert.rst
@@ -70,6 +70,8 @@ Next, open up config.yaml.example. In it, you will find several configuration op
 
 ``writeback_index`` is the name of the index in which ElastAlert will store data. We will create this index later.
 
+``writeback_alias``: Optional; the alias to use for alert indices. The default is ``elastalert_alerts``.
+
 ``alert_time_limit`` is the retry window for failed alerts.
 
 Save the file as ``config.yaml``

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -20,7 +20,7 @@ from envparse import Env
 env = Env(ES_USE_SSL=bool)
 
 
-def create_index_mappings(es_client, ea_index, recreate=False, old_ea_index=None):
+def create_index_mappings(es_client, ea_index, ea_alias=None, recreate=False, old_ea_index=None):
     esversion = es_client.info()["version"]["number"]
     print("Elastic Version: " + esversion)
 
@@ -31,6 +31,10 @@ def create_index_mappings(es_client, ea_index, recreate=False, old_ea_index=None
         if es_index.exists(ea_index):
             print('Index ' + ea_index + ' already exists. Skipping index creation.')
             return None
+
+    if es_index.exists_template(ea_index):
+        print('Template ' + ea_index + ' already exists. Deleting in preparation for creating indices.')
+        es_index.delete_template(ea_index)
 
     # (Re-)Create indices.
     if is_atleastsix(esversion):
@@ -71,6 +75,9 @@ def create_index_mappings(es_client, ea_index, recreate=False, old_ea_index=None
                                       body=es_index_mappings['elastalert_error'], include_type_name=True)
         es_client.indices.put_mapping(index=ea_index + '_past', doc_type='_doc',
                                       body=es_index_mappings['past_elastalert'], include_type_name=True)
+        es_client.indices.put_template(name=ea_index, body={'index_patterns': [ea_index + '_*'],
+                                                            'aliases': {ea_alias: {}},
+                                                            'mappings': es_index_mappings['elastalert']})
     elif is_atleastsixtwo(esversion):
         es_client.indices.put_mapping(index=ea_index, doc_type='_doc',
                                       body=es_index_mappings['elastalert'])
@@ -82,6 +89,9 @@ def create_index_mappings(es_client, ea_index, recreate=False, old_ea_index=None
                                       body=es_index_mappings['elastalert_error'])
         es_client.indices.put_mapping(index=ea_index + '_past', doc_type='_doc',
                                       body=es_index_mappings['past_elastalert'])
+        es_client.indices.put_template(name=ea_index, body={'index_patterns': [ea_index + '_*'],
+                                                            'aliases': {ea_alias: {}},
+                                                            'mappings': es_index_mappings['elastalert']})
     elif is_atleastsix(esversion):
         es_client.indices.put_mapping(index=ea_index, doc_type='elastalert',
                                       body=es_index_mappings['elastalert'])
@@ -93,6 +103,9 @@ def create_index_mappings(es_client, ea_index, recreate=False, old_ea_index=None
                                       body=es_index_mappings['elastalert_error'])
         es_client.indices.put_mapping(index=ea_index + '_past', doc_type='past_elastalert',
                                       body=es_index_mappings['past_elastalert'])
+        es_client.indices.put_template(name=ea_index, body={'index_patterns': [ea_index + '_*'],
+                                                            'aliases': {ea_alias: {}},
+                                                            'mappings': es_index_mappings['elastalert']})
     else:
         es_client.indices.put_mapping(index=ea_index, doc_type='elastalert',
                                       body=es_index_mappings['elastalert'])
@@ -104,6 +117,9 @@ def create_index_mappings(es_client, ea_index, recreate=False, old_ea_index=None
                                       body=es_index_mappings['elastalert_error'])
         es_client.indices.put_mapping(index=ea_index, doc_type='past_elastalert',
                                       body=es_index_mappings['past_elastalert'])
+        es_client.indices.put_template(name=ea_index, body={'template': ea_index + '_*',
+                                                            'aliases': {ea_alias: {}},
+                                                            'mappings': es_index_mappings['elastalert']})
 
     print('New index %s created' % ea_index)
     if old_ea_index:
@@ -262,7 +278,7 @@ def main():
         ca_certs=ca_certs,
         client_key=client_key)
 
-    create_index_mappings(es_client=es, ea_index=index, recreate=args.recreate, old_ea_index=old_index)
+    create_index_mappings(es_client=es, ea_index=index, ea_alias=alias, recreate=args.recreate, old_ea_index=old_index)
 
 
 if __name__ == '__main__':

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1553,7 +1553,7 @@ class ElastAlerter(object):
             body['alert_exception'] = alert_exception
         return body
 
-    def writeback(self, doc_type, body, rule=None, match_body=None):
+    def writeback(self, doc_type, body, rule=None):
         # ES 2.0 - 2.3 does not support dots in field names.
         if self.replace_dots_in_field_names:
             writeback_body = replace_dots_in_field_names(body)
@@ -1574,10 +1574,17 @@ class ElastAlerter(object):
 
         try:
             index = self.writeback_es.resolve_writeback_index(self.writeback_index, doc_type)
+            if rule is not None and 'writeback_suffix' in rule:
+                try:
+                    suffix = rule['writeback_suffix'].format(writeback_body['match_body'] or {})
+                    suffix = datetime.datetime.utcnow().strftime(suffix)
+                    index += '_' + suffix
+                except KeyError as e:
+                    elastalert_logger.critical('Failed to add suffix. Unknown key ' + str(e))
             if self.writeback_es.is_atleastsixtwo():
-                res = self.writeback_es.index(index=index, body=body)
+                res = self.writeback_es.index(index=index, body=writeback_body)
             else:
-                res = self.writeback_es.index(index=index, doc_type=doc_type, body=body)
+                res = self.writeback_es.index(index=index, doc_type=doc_type, body=writeback_body)
             return res
         except ElasticsearchException as e:
             logging.exception("Error writing alert info to Elasticsearch: %s" % (e))
@@ -1601,9 +1608,9 @@ class ElastAlerter(object):
         query.update(sort)
         try:
             if self.writeback_es.is_atleastsixtwo():
-                res = self.writeback_es.search(index=self.writeback_index, body=query, size=1000)
+                res = self.writeback_es.search(index=self.writeback_alias, body=query, size=1000)
             else:
-                res = self.writeback_es.deprecated_search(index=self.writeback_index,
+                res = self.writeback_es.deprecated_search(index=self.writeback_alias,
                                                           doc_type='elastalert', body=query, size=1000)
             if res['hits']['hits']:
                 return res['hits']['hits']
@@ -1615,6 +1622,7 @@ class ElastAlerter(object):
         pending_alerts = self.find_recent_pending_alerts(self.alert_time_limit)
         for alert in pending_alerts:
             _id = alert['_id']
+            _index = alert['_index']
             alert = alert['_source']
             try:
                 rule_name = alert.pop('rule_name')
@@ -1657,9 +1665,9 @@ class ElastAlerter(object):
                 # Delete it from the index
                 try:
                     if self.writeback_es.is_atleastsixtwo():
-                        self.writeback_es.delete(index=self.writeback_index, id=_id)
+                        self.writeback_es.delete(index=_index, id=_id)
                     else:
-                        self.writeback_es.delete(index=self.writeback_index, doc_type='elastalert', id=_id)
+                        self.writeback_es.delete(index=_index, doc_type='elastalert', id=_id)
                 except ElasticsearchException:  # TODO: Give this a more relevant exception, try:except: is evil.
                     self.handle_error("Failed to delete alert %s at %s" % (_id, alert_time))
 
@@ -1690,17 +1698,17 @@ class ElastAlerter(object):
         matches = []
         try:
             if self.writeback_es.is_atleastsixtwo():
-                res = self.writeback_es.search(index=self.writeback_index, body=query,
+                res = self.writeback_es.search(index=self.writeback_alias, body=query,
                                                size=self.max_aggregation)
             else:
-                res = self.writeback_es.deprecated_search(index=self.writeback_index, doc_type='elastalert',
+                res = self.writeback_es.deprecated_search(index=self.writeback_alias, doc_type='elastalert',
                                                           body=query, size=self.max_aggregation)
             for match in res['hits']['hits']:
                 matches.append(match['_source'])
                 if self.writeback_es.is_atleastsixtwo():
-                    self.writeback_es.delete(index=self.writeback_index, id=match['_id'])
+                    self.writeback_es.delete(index=match['_index'], id=match['_id'])
                 else:
-                    self.writeback_es.delete(index=self.writeback_index, doc_type='elastalert', id=match['_id'])
+                    self.writeback_es.delete(index=match['_index'], doc_type='elastalert', id=match['_id'])
         except (KeyError, ElasticsearchException) as e:
             self.handle_error("Error fetching aggregated matches: %s" % (e), {'id': _id})
         return matches
@@ -1717,9 +1725,9 @@ class ElastAlerter(object):
         query['sort'] = {'alert_time': {'order': 'desc'}}
         try:
             if self.writeback_es.is_atleastsixtwo():
-                res = self.writeback_es.search(index=self.writeback_index, body=query, size=1)
+                res = self.writeback_es.search(index=self.writeback_alias, body=query, size=1)
             else:
-                res = self.writeback_es.deprecated_search(index=self.writeback_index, doc_type='elastalert', body=query, size=1)
+                res = self.writeback_es.deprecated_search(index=self.writeback_alias, doc_type='elastalert', body=query, size=1)
             if len(res['hits']['hits']) == 0:
                 return None
         except (KeyError, ElasticsearchException) as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -191,6 +191,7 @@ def ea():
     ea.thread_data.current_es = ea.current_es
     ea.thread_data.num_hits = 0
     ea.thread_data.num_dupes = 0
+    ea.thread_data.alerts_sent = 0
     return ea
 
 


### PR DESCRIPTION
This PR adds back into the beta branch the previously merged (#2025) in `writeback_alias` and `writeback_suffix` functionality that has seemingly being accidently removed.

This PR includes the bug fix specified in #2089 to repair cases where `writeback_index != 'elastalert'`.

This PR also includes documentation for using `writeback_alias` and `writeback_suffix`.