### PR TITLE
Allow printing and formating of related_events

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -68,7 +68,7 @@ class BasicMatchString(object):
         if event is None:
             event = self.match
         missing = self.rule.get('alert_missing_value', '<MISSING VALUE>')
-        alert_text = unicode(self.rule.get(alert_text_key, ''))
+        alert_text = str(self.rule.get(alert_text_key, ''))
 
         if alert_text_key+'_args' in self.rule:
             alert_text_args = self.rule.get(alert_text_key+'_args')
@@ -162,7 +162,7 @@ class BasicMatchString(object):
                 if 'related_events' in self.match:
                     related_events = self.match['related_events']
                     del self.match['related_events']
-                    alert_text_related_event_text = unicode(self.rule.get('alert_text_related_event_text', ''))
+                    alert_text_related_event_text = str(self.rule.get('alert_text_related_event_text', ''))
                     if alert_text_related_event_text == '':
                         self.text += '\n----------------------------------------\n'
                         self._add_match_items()

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -64,12 +64,15 @@ class BasicMatchString(object):
         while self.text[-2:] != '\n\n':
             self.text += '\n'
 
-    def _add_custom_alert_text(self):
+    def _create_custom_alert_text(self, event=None, alert_text_key='alert_text'):
+        if event is None:
+            event = self.match
         missing = self.rule.get('alert_missing_value', '<MISSING VALUE>')
-        alert_text = str(self.rule.get('alert_text', ''))
-        if 'alert_text_args' in self.rule:
-            alert_text_args = self.rule.get('alert_text_args')
-            alert_text_values = [lookup_es_key(self.match, arg) for arg in alert_text_args]
+        alert_text = unicode(self.rule.get(alert_text_key, ''))
+
+        if alert_text_key+'_args' in self.rule:
+            alert_text_args = self.rule.get(alert_text_key+'_args')
+            alert_text_values = [lookup_es_key(event, arg) for arg in alert_text_args]
 
             # Support referencing other top-level rule properties
             # This technically may not work if there is a top-level rule property with the same name
@@ -82,10 +85,10 @@ class BasicMatchString(object):
 
             alert_text_values = [missing if val is None else val for val in alert_text_values]
             alert_text = alert_text.format(*alert_text_values)
-        elif 'alert_text_kw' in self.rule:
+        elif alert_text_key+'_kw' in self.rule:
             kw = {}
-            for name, kw_name in list(self.rule.get('alert_text_kw').items()):
-                val = lookup_es_key(self.match, name)
+            for name, kw_name in self.rule.get(alert_text_key+'_kw').items():
+                val = lookup_es_key(event, name)
 
                 # Support referencing other top-level rule properties
                 # This technically may not work if there is a top-level rule property with the same name
@@ -95,8 +98,12 @@ class BasicMatchString(object):
 
                 kw[kw_name] = missing if val is None else val
             alert_text = alert_text.format(**kw)
+        else:
+            alert_text = alert_text.format(**event)
+        return alert_text
 
-        self.text += alert_text
+    def _add_custom_alert_text(self):
+        self.text += self._create_custom_alert_text()
 
     def _add_rule_text(self):
         self.text += self.rule['type'].get_match_str(self.match)
@@ -152,7 +159,25 @@ class BasicMatchString(object):
             if self.rule.get('top_count_keys'):
                 self._add_top_counts()
             if self.rule.get('alert_text_type') != 'exclude_fields':
-                self._add_match_items()
+                if 'related_events' in self.match:
+                    related_events = self.match['related_events']
+                    del self.match['related_events']
+                    alert_text_related_event_text = unicode(self.rule.get('alert_text_related_event_text', ''))
+                    if alert_text_related_event_text == '':
+                        self.text += '\n----------------------------------------\n'
+                        self._add_match_items()
+                    else:
+                        self.text += self._create_custom_alert_text(self.match, 'alert_text_related_event_text')
+
+                    for related_event in related_events:
+                        if alert_text_related_event_text == '':
+                            self.text += '\n----------------------------------------\n'
+                            self.match = related_event
+                            self._add_match_items()
+                        else:
+                            self.text += self._create_custom_alert_text(related_event, 'alert_text_related_event_text')
+                else:
+                    self._add_match_items()
         return self.text
 
 


### PR DESCRIPTION
When `attach_related: true` there is no way to print back the `related_events`.

By default, `_add_match_items` is now called for the current match and each of the related events.

Using `debug` alerter

```
At least 4 events occurred between 2019-05-28 19:46 CEST and 2019-05-28 19:47 CEST


----------------------------------------
@timestamp: 2019-05-28T17:47:13.134Z
_id: yjWN_2oBYegyjQkzob55
_index: test
_type: _doc
field1: 1.2.3.4
field2: fourth
num_hits: 5
num_matches: 1
type: test

----------------------------------------
@timestamp: 2019-05-28 17:47:12.496000+00:00
_id: xzWN_2oBYegyjQkznr77
_index: test
_type: _doc
field1: 1.2.3.4
field2: first
type: test

----------------------------------------
@timestamp: 2019-05-28 17:47:12.727000+00:00
_id: yDWN_2oBYegyjQkzn77i
_index: test
_type: _doc
field1: 1.2.3.4
field2: second
type: test

----------------------------------------
@timestamp: 2019-05-28 17:47:12.912000+00:00
_id: yTWN_2oBYegyjQkzoL6c
_index: test
_type: _doc
field1: 1.2.3.4
field2: third
type: test

```

It's also possible to specify a format with same syntaxe as `alert_text`

```
alert_text_related_event_text: |
  * From {0} to {1}
alert_text_related_event_text_args:
  - field1
  - field2
```

```
At least 4 events occurred between 2019-05-28 19:47 CEST and 2019-05-28 19:48 CEST

* From 1.2.3.4 to fourth
* From 1.2.3.4 to first
* From 1.2.3.4 to second
* From 1.2.3.4 to third
```