### PR TITLE
Clear scroll if not used anymore

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -351,7 +351,8 @@ class ElastAlerter(object):
                     ignore_unavailable=True,
                     **extra_args
                 )
-                rule['scroll_id'] = res['_scroll_id']
+                if '_scroll_id' in res:
+                    rule['scroll_id'] = res['_scroll_id']
 
                 if self.current_es.is_atleastseven():
                     self.total_hits = int(res['hits']['total']['value'])

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -351,6 +351,7 @@ class ElastAlerter(object):
                     ignore_unavailable=True,
                     **extra_args
                 )
+                rule['scroll_id'] = res['_scroll_id']
 
                 if self.current_es.is_atleastseven():
                     self.total_hits = int(res['hits']['total']['value'])
@@ -386,7 +387,6 @@ class ElastAlerter(object):
         )
         if self.total_hits > rule.get('max_query_size', self.max_query_size):
             elastalert_logger.info("%s (scrolling..)" % status_log)
-            rule['scroll_id'] = res['_scroll_id']
         else:
             elastalert_logger.info(status_log)
 
@@ -624,7 +624,8 @@ class ElastAlerter(object):
             pass
 
         if 'scroll_id' in rule:
-            rule.pop('scroll_id')
+            scroll_id = rule.pop('scroll_id')
+            self.current_es.clear_scroll(scroll_id=scroll_id)
 
         return True
 


### PR DESCRIPTION
Following this commit https://github.com/elastic/elasticsearch/commit/d27aa72b17f1ceda156f705a262ef8c5f4106c35 in elasticsearch. A scroll parallel limit of 500 is set.

This seems related to this issue : https://github.com/Yelp/elastalert/issues/2249

Elastalert create scroll for each research with default to 30s for keeping the scroll context alive. 

But it never clears the scroll if it's not used anymore

As it's really easy to open 500 scroll in 30 seconds, the scroll should be clear after usage.