### PR TITLE
Fix query_string syntax in writing_filters.rst

### DIFF
--- a/docs/source/recipes/writing_filters.rst
+++ b/docs/source/recipes/writing_filters.rst
@@ -28,18 +28,14 @@ The query_string type follows the Lucene query format and can be used for partia
 See http://lucene.apache.org/core/2_9_4/queryparsersyntax.html for more information::
 
     filter:
-    - query:
-        query_string:
-          query: "username: bob"
-    - query:
-        query_string:
-          query: "_type: login_logs"
-    - query:
-        query_string:
-          query: "field: value OR otherfield: othervalue"
-    - query:
-        query_string:
-           query: "this: that AND these: those"
+    - query_string:
+        query: "username: bob"
+    - query_string:
+        query: "_type: login_logs"
+    - query_string:
+        query: "field: value OR otherfield: othervalue"
+    - query_string:
+        query: "this: that AND these: those"
 
 term
 ****


### PR DESCRIPTION
I tested correct syntax with elastalert == 0.2.0b2.

Using syntax from documentation(with additional `query:` key on top) produces errors:

```
WARNING:elasticsearch:GET http://127.0.0.1:9200/syslog-nginx__access_json-2019.06.03/_search?ignore_unavailable=true&size=0 [status:400 request:0.004s]
ERROR:root:Error running query: RequestError(400, u'parsing_exception', u'[query] query malformed, no start_object after query name')
INFO:elastalert:Skipping writing to ES: {'message': "Error running query: RequestError(400, u'parsing_exception', u'[query] query malformed, no start_object after query name')", 'traceback': ['Traceback (most recent call last):', '  File "/usr/local/lib/python2.7/dist-packages/elastalert/elastalert.py", line 559, in get_hits_aggregation', '    body=query, size=0, ignore_unavailable=True)', '  File "/usr/local/lib/python2.7/dist-packages/elasticsearch-7.0.1-py2.7.egg/elasticsearch/client/utils.py", line 84, in _wrapped', '    return func(*args, params=params, **kwargs)', '  File "/usr/local/lib/python2.7/dist-packages/elastalert/__init__.py", line 244, in deprecated_search', '    "GET", _make_path(index, doc_type, "_search"), params=params, body=body', '  File "/usr/local/lib/python2.7/dist-packages/elasticsearch-7.0.1-py2.7.egg/elasticsearch/transport.py", line 353, in perform_request', '    timeout=timeout,', '  File "/usr/local/lib/python2.7/dist-packages/elasticsearch-7.0.1-py2.7.egg/elasticsearch/connection/http_requests.py", line 143, in perform_request', '    self._raise_error(response.status_code, raw_data)', '  File "/usr/local/lib/python2.7/dist-packages/elasticsearch-7.0.1-py2.7.egg/elasticsearch/connection/base.py", line 168, in _raise_error', '    status_code, error_message, additional_info', "RequestError: RequestError(400, u'parsing_exception', u'[query] query malformed, no start_object after query name')"], 'data': {'rule': 'Example rule: nginx access status 200 > 1% for 60 sec'}}
```
