### PR TITLE
Adding Zabbix as supported alert type.

### DIFF
--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -43,6 +43,7 @@ Currently, we have support built in for these alert types:
 - Debug
 - Stomp
 - theHive
+- Zabbix
 
 Additional rule types and alerts can be easily imported or written. (See :ref:`Writing rule types <writingrules>` and :ref:`Writing alerts <writingalerts>`)
 


### PR DESCRIPTION
Just adding it to the readthedocs.io documentation.

I'm not sure if this is the workflow for such a small change.