### PR TITLE
Adding iso_us timestamp type which guarantees microseconds are not truncated

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -556,10 +556,11 @@ summary_table_fields
 timestamp_type
 ^^^^^^^^^^^^^^
 
-``timestamp_type``: One of ``iso``, ``unix``, ``unix_ms``, ``custom``. This option will set the type of ``@timestamp`` (or ``timestamp_field``)
-used to query Elasticsearch. ``iso`` will use ISO8601 timestamps, which will work with most Elasticsearch date type field. ``unix`` will
-query using an integer unix (seconds since 1/1/1970) timestamp. ``unix_ms`` will use milliseconds unix timestamp. ``custom`` allows you to define
-your own ``timestamp_format``. The default is ``iso``.
+``timestamp_type``: One of ``iso``, ``iso_us``, ``unix``, ``unix_ms``, ``custom``. This option will set the type of ``@timestamp`` (or ``timestamp_field``)
+used to query Elasticsearch. ``iso`` will use ISO8601 timestamps, which will work with most Elasticsearch date type field. ``iso_us`` will use ISO8601
+timestamps with microsecond precission, which will work with strict_date_time Elasticsearch date type field. ``unix`` will query using an integer unix
+(seconds since 1/1/1970) timestamp. ``unix_ms`` will use milliseconds unix timestamp. ``custom`` allows you to define your own ``timestamp_format``.
+The default is ``iso``.
 (Optional, string enum, default iso).
 
 timestamp_format

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -16,6 +16,7 @@ import yaml.scanner
 from envparse import Env
 from opsgenie import OpsGenieAlerter
 from staticconf.loader import yaml_loader
+from util import dt_to_iso_microseconds
 from util import dt_to_ts
 from util import dt_to_ts_with_format
 from util import dt_to_unix
@@ -235,6 +236,9 @@ def load_options(rule, conf, filename, args=None):
     if rule['timestamp_type'] == 'iso':
         rule['ts_to_dt'] = ts_to_dt
         rule['dt_to_ts'] = dt_to_ts
+    elif rule['timestamp_type'] == 'iso_us':
+        rule['ts_to_dt'] = ts_to_dt
+        rule['dt_to_ts'] = dt_to_iso_microseconds
     elif rule['timestamp_type'] == 'unix':
         rule['ts_to_dt'] = unix_to_dt
         rule['dt_to_ts'] = dt_to_unix

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -148,6 +148,21 @@ def dt_to_ts(dt):
     return ts.replace('000+00:00', 'Z').replace('+00:00', 'Z')
 
 
+def dt_to_iso_microseconds(dt):
+    ts = dt.isoformat()
+    if dt.tzinfo is None:
+        # isoformat omits microseconds if 0
+        if dt.microsecond == 0:
+            ts = ts + '.000000'
+        # implicitly convert to UTC
+        return ts + 'Z'
+    # isoformat omits microseconds if 0
+    if dt.microsecond == 0:
+        ts = ts.replace('+', '.000000+')
+    # convert 0 offset to UTC
+    return ts.replace('+00:00', 'Z')
+
+
 def ts_to_dt_with_format(timestamp, ts_format):
     if isinstance(timestamp, datetime.datetime):
         return timestamp

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 from datetime import timedelta
+from pytz import FixedOffset
+from pytz import utc
 
 import mock
 import pytest
 from dateutil.parser import parse as dt
 
 from elastalert.util import add_raw_postfix
+from elastalert.util import dt_to_iso_microseconds
 from elastalert.util import format_index
 from elastalert.util import lookup_es_key
 from elastalert.util import parse_deadline
@@ -15,6 +18,22 @@ from elastalert.util import replace_dots_in_field_names
 from elastalert.util import resolve_string
 from elastalert.util import set_es_key
 from elastalert.util import should_scrolling_continue
+
+
+@pytest.mark.parametrize('spec, expected_ts', [
+    (datetime(2019, 6, 24, 11, 24, 45, 000, tzinfo=None), '2019-06-24T11:24:45.000000Z'),
+    (datetime(2019, 6, 24, 11, 24, 45, 987, tzinfo=None), '2019-06-24T11:24:45.000987Z'),
+    (datetime(2019, 6, 24, 11, 24, 45, 987000, tzinfo=None), '2019-06-24T11:24:45.987000Z'),
+    (datetime(2019, 6, 24, 11, 24, 45, 000, tzinfo=utc), '2019-06-24T11:24:45.000000Z'),
+    (datetime(2019, 6, 24, 11, 24, 45, 987, tzinfo=utc), '2019-06-24T11:24:45.000987Z'),
+    (datetime(2019, 6, 24, 11, 24, 45, 987000, tzinfo=utc), '2019-06-24T11:24:45.987000Z'),
+    (datetime(2019, 6, 24, 11, 24, 45, 000, tzinfo=FixedOffset(60)), '2019-06-24T11:24:45.000000+01:00'),
+    (datetime(2019, 6, 24, 11, 24, 45, 987, tzinfo=FixedOffset(60)), '2019-06-24T11:24:45.000987+01:00'),
+    (datetime(2019, 6, 24, 11, 24, 45, 987000, tzinfo=FixedOffset(60)), '2019-06-24T11:24:45.987000+01:00'),
+])
+def test_dt_to_iso_microseconds(spec, expected_ts):
+    """``datetime`` specs can be translated into iso microseconds time strings."""
+    assert dt_to_iso_microseconds(spec) == expected_ts
 
 
 @pytest.mark.parametrize('spec, expected_delta', [


### PR DESCRIPTION
Solution for issue https://github.com/Yelp/elastalert/issues/2305