### PR TITLE
Fixed top_count_keys not showing in message for compound query_key and Added feature for OpsGenie integration

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -439,7 +439,6 @@ class ElastAlerter(object):
     def get_hits_terms(self, rule, starttime, endtime, index, key, qk=None, size=None):
         rule_filter = copy.copy(rule['filter'])
         if qk:
-            qk_tmp = qk.replace(" ", "")
             qk_list = qk.split(",")
             end = None
             if rule['five']:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -439,7 +439,8 @@ class ElastAlerter(object):
     def get_hits_terms(self, rule, starttime, endtime, index, key, qk=None, size=None):
         rule_filter = copy.copy(rule['filter'])
         if qk:
-            qk_list = qk.split(", ")
+            qk_tmp = qk.replace(" ", "")
+            qk_list = qk.split(",")
             end = None
             if rule['five']:
                 end = '.keyword'

--- a/elastalert/opsgenie.py
+++ b/elastalert/opsgenie.py
@@ -81,7 +81,10 @@ class OpsGenieAlerter(Alerter):
             post['teams'] = [{'name': r, 'type': 'team'} for r in self.teams]
         post['description'] = body
         post['source'] = 'ElastAlert'
-        post['tags'] = self.tags
+
+        if self.tags is not None:
+            post['tags'] = self.tags.format(**matches[0])
+
         if self.priority and self.priority not in ('P1', 'P2', 'P3', 'P4', 'P5'):
             logging.warn("Priority level does not appear to be specified correctly. \
                          Please make sure to set it to a value between P1 and P5")

--- a/elastalert/opsgenie.py
+++ b/elastalert/opsgenie.py
@@ -81,9 +81,6 @@ class OpsGenieAlerter(Alerter):
             post['teams'] = [{'name': r, 'type': 'team'} for r in self.teams]
         post['description'] = body
         post['source'] = 'ElastAlert'
-        for tag in self.tags:
-        if self.tags is not None:
-            post['tags'] = self.tags.format(**matches[0])
 
         for i, tag in enumerate(self.tags):
             self.tags[i] = tag.format(**matches[0])

--- a/elastalert/opsgenie.py
+++ b/elastalert/opsgenie.py
@@ -81,9 +81,13 @@ class OpsGenieAlerter(Alerter):
             post['teams'] = [{'name': r, 'type': 'team'} for r in self.teams]
         post['description'] = body
         post['source'] = 'ElastAlert'
-
+        for tag in self.tags:
         if self.tags is not None:
             post['tags'] = self.tags.format(**matches[0])
+
+        for i, tag in enumerate(self.tags):
+            self.tags[i] = tag.format(**matches[0])
+        post['tags'] = self.tags
 
         if self.priority and self.priority not in ('P1', 'P2', 'P3', 'P4', 'P5'):
             logging.warn("Priority level does not appear to be specified correctly. \


### PR DESCRIPTION
When user chooses a **compound query key**, the split is not performed correctly due to a blank in text.

Therefore, a malformed query is performed to Elasticsearch.

This reflects in results not available when using **top_count_keys** directive in rule file.