### PR TITLE
Fix test rule in beta

### DIFF
--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -402,6 +402,13 @@ class MockElastAlerter(object):
         overwrites = {
             'rules_loader': 'file',
         }
+
+        # Set arguments that ElastAlerter needs
+        args.verbose = args.alert
+        args.debug = not args.verbose
+        args.es_debug = False
+        args.es_debug_trace = False
+
         conf = load_conf(args, defaults, overwrites)
         rule_yaml = conf['rules_loader'].get_yaml(args.file)
         conf['rules_loader'].load_options(rule_yaml, conf, args.file)

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -405,7 +405,7 @@ class MockElastAlerter(object):
 
         # Set arguments that ElastAlerter needs
         args.verbose = args.alert
-        args.debug = not args.verbose
+        args.debug = not args.alert
         args.es_debug = False
         args.es_debug_trace = False
 


### PR DESCRIPTION
Fixes #2303, #2274

In #2030, a bug was introduced where the argument file passed to load_conf doesn't contain elastalert's required arguments, causing the above issue. This fixes it by setting some defaults.

I don't think these values end up actually being used because we instantiate the ElastAlerter object later and it parses it's own args. This one is just used by the rule loader.