### PR TITLE
Fix Invalid Example Rule File

### DIFF
--- a/example_rules/example_spike_single_metric_agg.yaml
+++ b/example_rules/example_spike_single_metric_agg.yaml
@@ -6,6 +6,9 @@ type: spike_aggregation
 
 index: metricbeat-*
 
+timeframe:
+  hours: 4
+
 buffer_time:
   hours: 1
 


### PR DESCRIPTION
Add `timeframe` key in `example_spike_single_metric_agg.yaml`, which is specified to be `required` in _schema.yaml_