### PR TITLE
Add retries and caching to ES info

### DIFF
--- a/elastalert/__init__.py
+++ b/elastalert/__init__.py
@@ -49,6 +49,8 @@ class ElasticSearchClient(Elasticsearch):
                     self._es_version = self.info()['version']['number']
                     break
                 except TransportError:
+                    if retry == 2:
+                        raise
                     time.sleep(3)
         return self._es_version
 

--- a/elastalert/__init__.py
+++ b/elastalert/__init__.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 import copy
+import time
 
 from elasticsearch import Elasticsearch
 from elasticsearch import RequestsHttpConnection
 from elasticsearch.client import _make_path
 from elasticsearch.client import query_params
+from elasticsearch.exceptions import TransportError
 
 
 class ElasticSearchClient(Elasticsearch):
@@ -42,7 +44,12 @@ class ElasticSearchClient(Elasticsearch):
         Returns the reported version from the Elasticsearch server.
         """
         if self._es_version is None:
-            self._es_version = self.info()['version']['number']
+            for retry in range(3):
+                try:
+                    self._es_version = self.info()['version']['number']
+                    break
+                except TransportError:
+                    time.sleep(3)
         return self._es_version
 
     def is_atleastfive(self):

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -516,7 +516,7 @@ def test_agg_no_writeback_connectivity(ea):
     ea.thread_data.current_es.search.return_value = {'hits': {'total': 0, 'hits': []}}
     ea.add_aggregated_alert = mock.Mock()
 
-    with mock.patch('elastalert.elastalert.elasticsearch_client'):
+    with mock.patch.object(ea, 'run_query'):
         ea.run_rule(ea.rules[0], END, START)
 
     ea.add_aggregated_alert.assert_any_call({'@timestamp': hit1, 'num_hits': 0, 'num_matches': 3}, ea.rules[0])


### PR DESCRIPTION
- Add some retries to this so that a connectivity blip doesn't bring everything down.
- Cache the elasticsearch_client objects, otherwise we end up seriously spamming the Elasticsearch server with info requests. I think the one place where I pop on es_clients is the only place where rules could change their ES settings.
- Updated a rule to match the new es client caching behavior 