### PR TITLE
Add Support for Twilio Copilot

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1536,10 +1536,20 @@ class TwilioAlerter(Alerter):
         client = TwilioClient(self.twilio_account_sid, self.twilio_auth_token)
 
         try:
-            client.messages.create(body=self.rule['name'],
-                                   to=self.twilio_to_number,
-                                   from_=self.twilio_from_number)
+	    if self.twilio_use_copilot:
+                if self.twilio_message_service_sid == None:
+                    raise EAException("Twilio Copilot requires the 'twilio_message_service_sid' option")
 
+                client.messages.create(body=self.rule['name'],
+                                       to=self.twilio_to_number,
+                                       messaging_service_sid=self.twilio_message_service_sid)
+            else:
+                if self.twilio_from_number == None:
+                    raise EAException("Twilio SMS requires the 'twilio_from_number' option")
+
+                client.messages.create(body=self.rule['name'],
+                                       to=self.twilio_to_number,
+                                       from_=self.twilio_from_number)  
         except TwilioRestException as e:
             raise EAException("Error posting to twilio: %s" % e)
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1529,6 +1529,8 @@ class TwilioAlerter(Alerter):
         self.twilio_auth_token = self.rule['twilio_auth_token']
         self.twilio_to_number = self.rule['twilio_to_number']
         self.twilio_from_number = self.rule.get('twilio_from_number')
+        self.twilio_message_service_sid = self.rule.get('twilio_message_service_sid')
+        self.twilio_use_copilot = self.rule.get('twilio_use_copilot', False)
 
     def alert(self, matches):
         client = TwilioClient(self.twilio_account_sid, self.twilio_auth_token)

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1521,14 +1521,14 @@ class ExotelAlerter(Alerter):
 
 
 class TwilioAlerter(Alerter):
-    required_options = frozenset(['twilio_account_sid', 'twilio_auth_token', 'twilio_to_number', 'twilio_from_number'])
+    required_options = frozenset(['twilio_account_sid', 'twilio_auth_token', 'twilio_to_number'])
 
     def __init__(self, rule):
         super(TwilioAlerter, self).__init__(rule)
         self.twilio_account_sid = self.rule['twilio_account_sid']
         self.twilio_auth_token = self.rule['twilio_auth_token']
         self.twilio_to_number = self.rule['twilio_to_number']
-        self.twilio_from_number = self.rule['twilio_from_number']
+        self.twilio_from_number = self.rule.get('twilio_from_number')
 
     def alert(self, matches):
         client = TwilioClient(self.twilio_account_sid, self.twilio_auth_token)

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1537,14 +1537,14 @@ class TwilioAlerter(Alerter):
 
         try:
             if self.twilio_use_copilot:
-                if self.twilio_message_service_sid == None:
+                if self.twilio_message_service_sid is None:
                     raise EAException("Twilio Copilot requires the 'twilio_message_service_sid' option")
 
                 client.messages.create(body=self.rule['name'],
                                        to=self.twilio_to_number,
                                        messaging_service_sid=self.twilio_message_service_sid)
             else:
-                if self.twilio_from_number == None:
+                if self.twilio_from_number is None:
                     raise EAException("Twilio SMS requires the 'twilio_from_number' option")
 
                 client.messages.create(body=self.rule['name'],

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1536,7 +1536,7 @@ class TwilioAlerter(Alerter):
         client = TwilioClient(self.twilio_account_sid, self.twilio_auth_token)
 
         try:
-	    if self.twilio_use_copilot:
+            if self.twilio_use_copilot:
                 if self.twilio_message_service_sid == None:
                     raise EAException("Twilio Copilot requires the 'twilio_message_service_sid' option")
 
@@ -1549,7 +1549,7 @@ class TwilioAlerter(Alerter):
 
                 client.messages.create(body=self.rule['name'],
                                        to=self.twilio_to_number,
-                                       from_=self.twilio_from_number)  
+                                       from_=self.twilio_from_number)
         except TwilioRestException as e:
             raise EAException("Error posting to twilio: %s" % e)
 


### PR DESCRIPTION
Per [Twilio Docs](https://www.twilio.com/docs/sms/services#send-a-message-with-copilot) add support for alerts using Copilot. Compability with the existing Twilio SMS alerting method is maintained.

- Make 'twilio_from_number' optional
- Add setting 'twilio_message_service_sid'
- Add setting 'twilio_use_copilot', defaults to False

In case 'twilio_use_copilot' is False, 'twilio_from_number' is required. Otherwise, 'twilio_message_service_sid' is required.

I've tested this using an Elasticsearch 7.1.1 cluster, both SMS and Copilot alerting work.