### PR TITLE
Update schema.yaml

### DIFF
--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -349,3 +349,6 @@ properties:
   zbx_sender_port: {type: integer}
   zbx_host: {type: string}
   zbx_item: {type: string}
+  
+  ### Discord
+  discord_webhook_url: {type: string}


### PR DESCRIPTION
Add discord_webhook_url to the schema file and set the type to string.
This will prevent error while working with %s and % in the alerts.py.