### PR TITLE
Scroll Clear: Catch NotFoundError

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -657,7 +657,10 @@ class ElastAlerter(object):
 
         if 'scroll_id' in rule:
             scroll_id = rule.pop('scroll_id')
-            self.thread_data.current_es.clear_scroll(scroll_id=scroll_id)
+            try:
+                self.thread_data.current_es.clear_scroll(scroll_id=scroll_id)    
+            except NotFoundError:
+                pass
 
         return True
 


### PR DESCRIPTION
ElastAlert throws an error when it tries clearing a scroll that doesn't exist.
This PR fixes this behavior by catching the exception

Relevant Logs:
```INFO:elastalert:Queried rule FOO RULE from 2019-08-12 09:51 UTC to 2019-08-12 10:09 UTC: 0 / 0 hits
WARNING:elasticsearch:DELETE https://elasticsearch-data-01.com:9200/_search/scroll [status:404 request:0.032s]
Traceback (most recent call last):
  File "/usr/local/bin/elastalert-test-rule", line 11, in <module>
    load_entry_point('elastalert==0.1.39', 'console_scripts', 'elastalert-test-rule')()
  File "/usr/local/lib/python2.7/site-packages/elastalert-0.1.39-py2.7.egg/elastalert/test_rule.py", line 463, in main
    test_instance.run_rule_test()
  File "/usr/local/lib/python2.7/site-packages/elastalert-0.1.39-py2.7.egg/elastalert/test_rule.py", line 455, in run_rule_test
    self.run_elastalert(rule_yaml, conf, args)
  File "/usr/local/lib/python2.7/site-packages/elastalert-0.1.39-py2.7.egg/elastalert/test_rule.py", line 311, in run_elastalert
    client.run_rule(rule, endtime, starttime)
  File "/usr/local/lib/python2.7/site-packages/elastalert-0.1.39-py2.7.egg/elastalert/elastalert.py", line 874, in run_rule
    if not self.run_query(rule, rule['starttime'], endtime):
  File "/usr/local/lib/python2.7/site-packages/elastalert-0.1.39-py2.7.egg/elastalert/elastalert.py", line 634, in run_query
    self.current_es.clear_scroll(scroll_id=scroll_id)
  File "/usr/local/lib/python2.7/site-packages/elasticsearch-7.0.2-py2.7.egg/elasticsearch/client/utils.py", line 84, in _wrapped
    return func(*args, params=params, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/elasticsearch-7.0.2-py2.7.egg/elasticsearch/client/__init__.py", line 1337, in clear_scroll
    "DELETE", "/_search/scroll", params=params, body=body
  File "/usr/local/lib/python2.7/site-packages/elasticsearch-7.0.2-py2.7.egg/elasticsearch/transport.py", line 353, in perform_request
    timeout=timeout,
  File "/usr/local/lib/python2.7/site-packages/elasticsearch-7.0.2-py2.7.egg/elasticsearch/connection/http_requests.py", line 155, in perform_request
    self._raise_error(response.status_code, raw_data)
  File "/usr/local/lib/python2.7/site-packages/elasticsearch-7.0.2-py2.7.egg/elasticsearch/connection/base.py", line 178, in _raise_error
    status_code, error_message, additional_info
elasticsearch.exceptions.NotFoundError: NotFoundError(404, u'{"succeeded":true,"num_freed":0}')```