### PR TITLE
Fix Documentation Build Warnings

### DIFF
--- a/docs/source/recipes/writing_filters.rst
+++ b/docs/source/recipes/writing_filters.rst
@@ -56,12 +56,10 @@ Note that a term query may not behave as expected if a field is analyzed. By def
 a field that appears to have the value "foo bar", unless it is not analyzed. Conversely, a term query for "foo" will match analyzed strings "foo bar" and "foo baz". For full text
 matching on analyzed fields, use query_string. See https://www.elastic.co/guide/en/elasticsearch/guide/current/term-vs-full-text.html
 
-`terms <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html>`_
+terms
 *****
 
-
-
-Terms allows for easy combination of multiple term filters::
+Terms  allows for easy combination of multiple term filters::
 
     filter:
     - terms:
@@ -73,6 +71,9 @@ You can also match on multiple fields::
         fieldX: ["value1", "value2"]
         fieldY: ["something", "something_else"]
         fieldZ: ["foo", "bar", "baz"]
+
+See Elasticsearch Documentation: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html
+
 
 wildcard
 ********

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1305,7 +1305,7 @@ With ``alert_text_type: aggregation_summary_only``::
     body                = rule_name
 
                           aggregation_summary
-+
+
 ruletype_text is the string returned by RuleType.get_match_str.
 
 field_values will contain every key value pair included in the results from Elasticsearch. These fields include "@timestamp" (or the value of ``timestamp_field``),
@@ -1689,7 +1689,7 @@ Provide absolute address of the pciture, for example: http://some.address.com/im
 ``slack_timeout``: You can specify a timeout value, in seconds, for making communicating with Slac. The default is 10. If a timeout occurs, the alert will be retried next time elastalert cycles.
 
 Mattermost
-~~~~~
+~~~~~~~~~~
 
 Mattermost alerter will send a notification to a predefined Mattermost channel. The body of the notification is formatted the same as with other alerters.
 


### PR DESCRIPTION
* `writing_filters.rst:60`: Remove documentation hyper link from `terms` header into the text body. The link was not even clickable.
* `ruletypes.rst:1308`: Remove a stray `+`, giving warning `Literal block ends without a blank line`
* `ruletypes.rst:1692`: Fix WARNING: Title underline too short for Mattermost Heading