### PR TITLE
Fix a bug when using an aggregation with multiple fields: wrong usage of "query_key"

### DIFF
--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -339,8 +339,6 @@ class RulesLoader(object):
             rule['compound_compare_key'] = [rule['compare_key']]
         # Add QK, CK and timestamp to include
         include = rule.get('include', ['*'])
-        if 'query_key' in rule:
-            include.append(rule['query_key'])
         if 'compound_query_key' in rule:
             include += rule['compound_query_key']
         if 'compound_aggregation_key' in rule:


### PR DESCRIPTION
The current code does not work when you have an aggregation on multiple fields. The code
```
        if 'query_key' in rule:
            include.append(rule['compound_query_key'])
```
assumes that `rule['compound_query_key']` is still a list of strings. But `rule['compound_query_key']` was converted to a concatenation of strings earlier:
```
        if isinstance(rule.get('query_key'), list):
            rule['compound_query_key'] = rule['query_key']
            rule['query_key'] = ','.join(rule['query_key'])
```
As a consequence of the wrong code, `include` now has an item such as `"Hostname,Image"` (literally). Of course, this field does not exist and the code fails later. For example in `test_rule`(`elastalert-test-rule`) line 140 and after and it produces the error `Included term Hostname,Image may be missing or null`.

The old value of `rule['query_key']` is copied into `rule['compound_query_key']` by the current code. It is then correctly used to construct `include`. As a consequence, the wrong code can simply be removed.