### PR TITLE
Remove the error "Included term may be missing or null" when using metric aggregation on multiple filelds

### DIFF
--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -139,9 +139,11 @@ class MockElastAlerter(object):
 
         include = conf.get('include')
         if include:
-            for term in include:
-                if not lookup_es_key(terms, term) and '*' not in term:
-                    print("Included term %s may be missing or null" % (term), file=sys.stderr)
+            for item in include:
+                # items in includes are potentially compound fields, so split them
+                for term in item.split(','):
+                    if not lookup_es_key(terms, term) and '*' not in term:
+                        print("Included term %s may be missing or null" % (term), file=sys.stderr)
 
         for term in conf.get('top_count_keys', []):
             # If the index starts with 'logstash', fields with .raw will be available but won't in _source


### PR DESCRIPTION
If `rule.get('query_key')`is a list, it is transformed into a concatenation of names by the code:
```
        if isinstance(rule.get('query_key'), list):
            rule['compound_query_key'] = rule['query_key']
            rule['query_key'] = ','.join(rule['query_key'])
```
Then is appended to `include` by the code:
```
        if 'query_key' in rule:
            include.append(rule['query_key'])
```
So if, for example, `rule.get('query_key')` contains `['Image', 'Hostname']`, the string `'Image,Hostname'` is append to `include`. This is not taken into account in `test_rule.py`:
```
        include = conf.get('include')
        if include:
            for term in include:
                if not lookup_es_key(terms, term) and '*' not in term:
                    print("Included term %s may be missing or null" % (term), file=sys.stderr)
```
There is no field named `'Image,Hostname'` but two fields named `'Image'` and `'Hostname'`. As the consequence, the code generate the error:
```
Included term Image,Hostname may be missing or null"
```
The solution is to take into account this case and to split the item before the lookup.
