### PR TITLE
Remove hive_port

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -2111,7 +2111,7 @@ class HiveAlerter(Alerter):
         connection_details = self.rule['hive_connection']
 
         api = TheHiveApi(
-            '{hive_host}:{hive_port}'.format(**connection_details),
+            connection_details.get('hive_host'),
             connection_details.get('hive_apikey', ''),
             proxies=connection_details.get('hive_proxies', {'http': '', 'https': ''}),
             cert=connection_details.get('hive_verify', False))


### PR DESCRIPTION
When using TheHive in a configuration that is not top-level (`https://IP/thehive/`), the current code does not work, as it concatenates `hive_host` & `hive_port` which creates `https://IP/thehive/:443`

This tweak removes the need to explicitly specify a port and instead specify only `hive_host`.  A couple examples: 
`hive_host: https://192.168.15.23:8080`
`hive_host: https://192.168.15.23/thehive/`
`hive_host: https://192.168.15.23:8080/thehive/`

This tweak should be considered a breaking change, as current users will need to update their `hive_connection` configuration if `hive_host` does not contain the required port.