### PR TITLE
Adds two option for more efficient reporting

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -44,6 +44,8 @@ Rule Configuration Cheat Sheet
 +--------------------------------------------------------------+           |
 | ``aggregation`` (time, no default)                           |           |
 +--------------------------------------------------------------+           |
+| ``aggregation_max_alerts`` (int, no default)                 |           |
++--------------------------------------------------------------+           |
 | ``description`` (string, default empty string)               |           |
 +--------------------------------------------------------------+           |
 | ``generate_kibana_link`` (boolean, default False)            |           |
@@ -69,6 +71,8 @@ Rule Configuration Cheat Sheet
 | ``top_count_number`` (int, default 5)                        |           |
 +--------------------------------------------------------------+           |
 | ``top_count_keys`` (list of strs)                            |           |
++--------------------------------------------------------------+           |
+| ``top_count_absolute_timeframe`` (boolean,  default False)   |           |
 +--------------------------------------------------------------+           |
 | ``raw_count_keys`` (boolean, default True)                   |           |
 +--------------------------------------------------------------+           |
@@ -366,6 +370,12 @@ aggregate_by_match_time
 Setting this to true will cause aggregations to be created relative to the timestamp of the first event, rather than the current time. This
 is useful for querying over historic data or if using a very large buffer_time and you want multiple aggregations to occur from a single query.
 
+aggregation_max_alerts
+^^^^^^^^^^^^^^^^^^^^^^^
+
+When doing an aggregation, this option limit the maximum alerts aggregated in on alert (And discard the rest), this can be useful when the alerter
+has a maximum message size.
+
 realert
 ^^^^^^^
 
@@ -450,6 +460,11 @@ top_count_number
 ^^^^^^^^^^^^^^^^
 
 ``top_count_number``: The number of terms to list if ``top_count_keys`` is set. (Optional, integer, default 5)
+
+top_count_absolute_timeframe
+^^^^^^^^^^^^^^^^
+
+``top_count_absolute_timeframe``: When True, the top count query is done using (alert_time - timeframe)
 
 raw_count_keys
 ^^^^^^^^^^^^^^

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -364,6 +364,8 @@ Then, for the same sample data shown above listing alice and bob's events, Elast
    past events will result in different alerts than if elastalert had been running while those events occured. This behavior can be changed
    by setting ``aggregate_by_match_time``.
 
+.. note:: In Alert field ``total_agg_hits`` and ``total_agg_matches`` contains the summation of all alerts hits & matches.
+
 aggregate_by_match_time
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -364,7 +364,7 @@ Then, for the same sample data shown above listing alice and bob's events, Elast
    past events will result in different alerts than if elastalert had been running while those events occured. This behavior can be changed
    by setting ``aggregate_by_match_time``.
 
-.. note:: In Alert field ``total_agg_hits`` and ``total_agg_matches`` contains the summation of all alerts hits & matches.
+.. note:: If aggregation is enabled, alert contains field ``total_agg_hits`` and ``total_agg_matches`` contains the summation of all alerts hits & matches.
 
 aggregate_by_match_time
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -464,7 +464,7 @@ top_count_number
 ``top_count_number``: The number of terms to list if ``top_count_keys`` is set. (Optional, integer, default 5)
 
 top_count_absolute_timeframe
-^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``top_count_absolute_timeframe``: When True, the top count query is done using (alert_time - timeframe)
 

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -530,7 +530,7 @@ class ElastAlerter(object):
             buckets = res['aggregations']['filtered']['counts']['buckets']
         else:
             buckets = res['aggregations']['counts']['buckets']
-        if getattr(self.thread_data,"num_hits",None):
+        if getattr(self.thread_data, "num_hits", None):
             self.thread_data.num_hits += len(buckets)
         lt = rule.get('use_local_time')
         elastalert_logger.info(

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1458,13 +1458,13 @@ class ElastAlerter(object):
         if alert_time is None:
             alert_time = ts_now()
 
-        # Calculate Total Hits (useful in-case of aggregation)
-        total_agg_hits = 0
-        total_agg_matches = len(matches)
-        for match in matches:
-            total_agg_hits += match['num_hits']
-
         if rule.get('aggregation'):
+            # Calculate Total Hits (useful in-case of aggregation)
+            total_agg_hits = 0
+            total_agg_matches = len(matches)
+            for match in matches:
+                total_agg_hits += match['num_hits']
+
             num_matches = rule.get('aggregation_max_alerts', len(matches))
             matches = matches[:num_matches]
             for match in matches:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1458,6 +1458,10 @@ class ElastAlerter(object):
         if alert_time is None:
             alert_time = ts_now()
 
+        if rule.get('aggregation'):
+            num_matches = rule.get('aggregation_max_alerts', len(matches))
+            matches = matches[:num_matches]
+
         # Compute top count keys
         if rule.get('top_count_keys'):
             for match in matches:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1478,8 +1478,13 @@ class ElastAlerter(object):
                 else:
                     timeframe = rule.get('timeframe', datetime.timedelta(minutes=10))
 
-                start = ts_to_dt(lookup_es_key(match, rule['timestamp_field'])) - timeframe
-                end = ts_to_dt(lookup_es_key(match, rule['timestamp_field'])) + datetime.timedelta(minutes=10)
+                if rule.get('top_count_absolute_timeframe'):
+                    start = ts_to_dt(alert_time) - timeframe
+                    end = ts_to_dt(alert_time)
+                else:
+                    start = ts_to_dt(lookup_es_key(match, rule['timestamp_field'])) - timeframe
+                    end = ts_to_dt(lookup_es_key(match, rule['timestamp_field'])) + datetime.timedelta(minutes=10)
+
                 keys = rule.get('top_count_keys')
                 counts = self.get_top_counts(rule, start, end, keys, qk=qk)
                 match.update(counts)

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1460,10 +1460,9 @@ class ElastAlerter(object):
 
         # Calculate Total Hits (useful in-case of aggregation)
         total_agg_hits = 0
-        total_agg_matches = 0
+        total_agg_matches = len(matches)
         for match in matches:
             total_agg_hits += match['num_hits']
-            total_agg_matches += match['num_matches']
 
         if rule.get('aggregation'):
             num_matches = rule.get('aggregation_max_alerts', len(matches))

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1458,9 +1458,19 @@ class ElastAlerter(object):
         if alert_time is None:
             alert_time = ts_now()
 
+        # Calculate Total Hits (useful in-case of aggregation)
+        total_agg_hits = 0
+        total_agg_matches = 0
+        for match in matches:
+            total_agg_hits += match['num_hits']
+            total_agg_matches += match['num_matches']
+
         if rule.get('aggregation'):
             num_matches = rule.get('aggregation_max_alerts', len(matches))
             matches = matches[:num_matches]
+            for match in matches:
+                match['total_agg_hits'] = total_agg_hits
+                match['total_agg_matches'] = total_agg_matches
 
         # Compute top count keys
         if rule.get('top_count_keys'):

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -530,7 +530,8 @@ class ElastAlerter(object):
             buckets = res['aggregations']['filtered']['counts']['buckets']
         else:
             buckets = res['aggregations']['counts']['buckets']
-        self.thread_data.num_hits += len(buckets)
+        if getattr(self.thread_data,"num_hits",None):
+            self.thread_data.num_hits += len(buckets)
         lt = rule.get('use_local_time')
         elastalert_logger.info(
             'Queried rule %s from %s to %s: %s buckets' % (rule['name'], pretty_ts(starttime, lt), pretty_ts(endtime, lt), len(buckets))
@@ -1986,7 +1987,8 @@ class ElastAlerter(object):
                 buckets = list(hits_terms.values())[0]
 
                 # get_hits_terms adds to num_hits, but we don't want to count these
-                self.thread_data.num_hits -= len(buckets)
+                if getattr(self.thread_data, "num_hits", None):
+                    self.thread_data.num_hits -= len(buckets)
                 terms = {}
                 for bucket in buckets:
                     terms[bucket['key']] = bucket['doc_count']

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -274,6 +274,7 @@ class RulesLoader(object):
         rule.setdefault('_source_enabled', True)
         rule.setdefault('use_local_time', True)
         rule.setdefault('description', "")
+        rule.setdefault('top_count_absolute_timeframe', False)
 
         # Set timestamp_type conversion function, used when generating queries and processing hits
         rule['timestamp_type'] = rule['timestamp_type'].strip().lower()

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -314,7 +314,7 @@ def test_match_with_module_from_pending(ea):
     mod.process = mock.Mock()
     ea.rules[0]['match_enhancements'] = [mod]
     ea.rules[0].pop('aggregation')
-    pending_alert = {'match_body': {'foo': 'bar'}, 'rule_name': ea.rules[0]['name'],
+    pending_alert = {'match_body': {'foo': 'bar'}, 'num_matches': 1, 'num_hits': 1, 'rule_name': ea.rules[0]['name'],
                      'alert_time': START_TIMESTAMP, '@timestamp': START_TIMESTAMP}
     # First call, return the pending alert, second, no associated aggregated alerts
     ea.writeback_es.deprecated_search.side_effect = [{'hits': {'hits': [{'_id': 'ABCD', '_index': 'wb', '_source': pending_alert}]}},
@@ -323,7 +323,7 @@ def test_match_with_module_from_pending(ea):
     assert mod.process.call_count == 0
 
     # If aggregation is set, enhancement IS called
-    pending_alert = {'match_body': {'foo': 'bar'}, 'rule_name': ea.rules[0]['name'],
+    pending_alert = {'match_body': {'foo': 'bar'}, 'num_matches': 1, 'num_hits': 1, 'rule_name': ea.rules[0]['name'],
                      'alert_time': START_TIMESTAMP, '@timestamp': START_TIMESTAMP}
     ea.writeback_es.deprecated_search.side_effect = [{'hits': {'hits': [{'_id': 'ABCD', '_index': 'wb', '_source': pending_alert}]}},
                                                      {'hits': {'hits': []}}]


### PR DESCRIPTION
These two options work together to create efficient reports that use count query and top keys along with aggregation.

For example, an hourly report that uses a frequency aggregated rule, which uses count query (but we still need data for the report, so we uses top count query too)

`top_count_absolute_timeframe` will make top count query spans time (alert_time - timeframe)
`aggregation_max_alerts` = 1, will allow us to send only one alert with the top count keys of the entire report.

