### PR TITLE
Switching test_rule to use load_yaml

### DIFF
--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -410,7 +410,7 @@ class MockElastAlerter(object):
         args.es_debug_trace = False
 
         conf = load_conf(args, defaults, overwrites)
-        rule_yaml = conf['rules_loader'].get_yaml(args.file)
+        rule_yaml = conf['rules_loader'].load_yaml(args.file)
         conf['rules_loader'].load_options(rule_yaml, conf, args.file)
 
         if args.json:


### PR DESCRIPTION
Fixing the issue described in https://github.com/Yelp/elastalert/issues/2450

`get_yaml` does not load `import` files, leaving the rules incomplete.