### PR TITLE
Handling non-compound query keys defined as an array

### DIFF
--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -324,9 +324,15 @@ class RulesLoader(object):
         if 'include' in rule and type(rule['include']) != list:
             raise EAException('include option must be a list')
 
-        if isinstance(rule.get('query_key'), list):
-            rule['compound_query_key'] = rule['query_key']
-            rule['query_key'] = ','.join(rule['query_key'])
+        raw_query_key = rule.get('query_key')
+        if isinstance(raw_query_key, list):
+            if len(raw_query_key) > 1:
+                rule['compound_query_key'] = raw_query_key
+                rule['query_key'] = ','.join(raw_query_key)
+            elif len(raw_query_key) == 1:
+                rule['query_key'] = raw_query_key[0]
+            else:
+                del(rule['query_key'])
 
         if isinstance(rule.get('aggregation_key'), list):
             rule['compound_aggregation_key'] = rule['aggregation_key']

--- a/tests/loaders_test.py
+++ b/tests/loaders_test.py
@@ -358,6 +358,29 @@ def test_compound_query_key():
     assert test_rule_copy['compound_query_key'] == ['field1', 'field2']
 
 
+def test_query_key_with_single_value():
+    test_config_copy = copy.deepcopy(test_config)
+    rules_loader = FileRulesLoader(test_config_copy)
+    test_rule_copy = copy.deepcopy(test_rule)
+    test_rule_copy.pop('use_count_query')
+    test_rule_copy['query_key'] = ['field1']
+    rules_loader.load_options(test_rule_copy, test_config, 'filename.yaml')
+    assert 'field1' in test_rule_copy['include']
+    assert test_rule_copy['query_key'] == 'field1'
+    assert 'compound_query_key' not in test_rule_copy
+
+
+def test_query_key_with_no_values():
+    test_config_copy = copy.deepcopy(test_config)
+    rules_loader = FileRulesLoader(test_config_copy)
+    test_rule_copy = copy.deepcopy(test_rule)
+    test_rule_copy.pop('use_count_query')
+    test_rule_copy['query_key'] = []
+    rules_loader.load_options(test_rule_copy, test_config, 'filename.yaml')
+    assert 'query_key' not in test_rule_copy
+    assert 'compound_query_key' not in test_rule_copy
+
+
 def test_name_inference():
     test_config_copy = copy.deepcopy(test_config)
     rules_loader = FileRulesLoader(test_config_copy)


### PR DESCRIPTION
The following `query_key` configurations should be equivalent:

```query_key: status```
```query_key: [ status ]```

I accidentally defined my singular query key as an array, and noticed that the type was forced to a string.  This is because `elastalert.py` assumes `compound_query_key` to always have more than 1 value.  If there is only one element in the array, the value gets overriden with a string.

https://github.com/Yelp/elastalert/blob/a5322f25b80828cc2183970c9c9f81f32867ce3b/elastalert/elastalert.py#L336