### PR TITLE
Adding support for generating Kibana Discover app link

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -58,9 +58,9 @@ Rule Configuration Cheat Sheet
 +--------------------------------------------------------------+           |
 | ``kibana4_end_timedelta`` (time, default: 10 min)            |           |
 +--------------------------------------------------------------+           |
-| ``generate_kibana_discover_link`` (boolean, default False)   |           |
+| ``generate_kibana_discover_url`` (boolean, default False)    |           |
 +--------------------------------------------------------------+           |
-| ``kibana_discover_url`` (string, no default)                 |           |
+| ``kibana_discover_app_url`` (string, no default)             |           |
 +--------------------------------------------------------------+           |
 | ``kibana_discover_version`` (string, no default)             |           |
 +--------------------------------------------------------------+           |
@@ -524,28 +524,28 @@ This value is added in back of the event. For example,
 
 ``kibana4_end_timedelta: minutes: 2``
 
-generate_kibana_discover_link
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+generate_kibana_discover_url
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``generate_kibana_discover_link``: Enables the generation of the ``kibana_discover_link`` variable for the Kibana Discover application.
+``generate_kibana_discover_url``: Enables the generation of the ``kibana_discover_url`` variable for the Kibana Discover application.
 This setting requires the following settings are also configured:
 
-- ``kibana_discover_url``
+- ``kibana_discover_app_url``
 - ``kibana_discover_version``
 - ``kibana_discover_index_pattern_id``
 
-``generate_kibana_discover_link: true``
+``generate_kibana_discover_url: true``
 
-kibana_discover_url
-^^^^^^^^^^^^^^^^^^^^
+kibana_discover_app_url
+^^^^^^^^^^^^^^^^^^^^^^^
 
-``kibana_discover_url``: The url of the Kibana Discover application used to generate the ``kibana_discover_link`` variable.
+``kibana_discover_app_url``: The url of the Kibana Discover application used to generate the ``kibana_discover_url`` variable.
 This value can use `$VAR` and `${VAR}` references to expand environment variables.
 
-``kibana_discover_url: http://kibana:5601/#/discover``
+``kibana_discover_app_url: http://kibana:5601/#/discover``
 
 kibana_discover_version
-^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^
 
 ``kibana_discover_version``: Specifies the version of the Kibana Discover application.
 
@@ -558,7 +558,7 @@ The currently supported versions of Kibana Discover are:
 ``kibana_discover_version: '7.3'``
 
 kibana_discover_index_pattern_id
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``kibana_discover_index_pattern_id``: The id of the index pattern to link to in the Kibana Discover application.
 These ids are usually generated and can be found in url of the index pattern management page, or by exporting its saved object.
@@ -580,7 +580,7 @@ You can modify an index pattern's id by exporting the saved object, modifying th
 ``kibana_discover_index_pattern_id: 4e97d188-8a45-4418-8a37-07ed69b4d34c``
 
 kibana_discover_columns
-^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^
 
 ``kibana_discover_columns``: The columns to display in the generated Kibana Discover application link.
 Defaults to the ``_source`` column.
@@ -588,7 +588,7 @@ Defaults to the ``_source`` column.
 ``kibana_discover_columns: [ timestamp, message ]``
 
 kibana_discover_from_timedelta
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``kibana_discover_from_timedelta``:  The offset to the `from` time of the Kibana Discover link's time range.
 The `from` time is calculated by subtracting this timedelta from the event time.  Defaults to 10 minutes.
@@ -596,7 +596,7 @@ The `from` time is calculated by subtracting this timedelta from the event time.
 ``kibana_discover_from_timedelta: minutes: 2``
 
 kibana_discover_to_timedelta
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``kibana_discover_to_timedelta``:  The offset to the `to` time of the Kibana Discover link's time range.
 The `to` time is calculated by adding this timedelta to the event time.  Defaults to 10 minutes.

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -58,6 +58,20 @@ Rule Configuration Cheat Sheet
 +--------------------------------------------------------------+           |
 | ``kibana4_end_timedelta`` (time, default: 10 min)            |           |
 +--------------------------------------------------------------+           |
+| ``use_kibana_discover`` (boolean, default False)             |           |
++--------------------------------------------------------------+           |
+| ``kibana_discover_url`` (string, no default)                 |           |
++--------------------------------------------------------------+           |
+| ``kibana_discover_version`` (string, no default)             |           |
++--------------------------------------------------------------+           |
+| ``kibana_discover_index_pattern_id`` (string, no default)    |           |
++--------------------------------------------------------------+           |
+| ``kibana_discover_columns`` (list of strs, default _source)  |           |
++--------------------------------------------------------------+           |
+| ``kibana_discover_from_timedelta`` (time, default: 10 min)   |           |
++--------------------------------------------------------------+           |
+| ``kibana_discover_to_timedelta`` (time, default: 10 min)     |           |
++--------------------------------------------------------------+           |
 | ``use_local_time`` (boolean, default True)                   |           |
 +--------------------------------------------------------------+           |
 | ``realert`` (time, default: 1 min)                           |           |
@@ -509,6 +523,85 @@ kibana4_end_timedelta
 This value is added in back of the event. For example,
 
 ``kibana4_end_timedelta: minutes: 2``
+
+use_kibana_discover
+^^^^^^^^^^^^^^^^^^^
+
+``use_kibana_discover``: Enables the generation of the ``kibana_link`` variable for the Kibana Discover application.
+This setting requires the following settings are also configured:
+
+- ``kibana_discover_url``
+- ``kibana_discover_version``
+- ``kibana_discover_index_pattern_id``
+
+``use_kibana_discover: true``
+
+kibana_discover_url
+^^^^^^^^^^^^^^^^^^^^
+
+``kibana_discover_url``: The url of the Kibana Discover application used to generate the ``kibana_link`` variable.
+This value can use `$VAR` and `${VAR}` references to expand environment variables.
+
+``kibana_discover_url: http://kibana:5601/#/discover``
+
+kibana_discover_version
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+``kibana_discover_version``: Specifies the version of the Kibana Discover application.
+
+The currently supported versions of Kibana Discover are: 
+
+- `5.6`
+- `6.0`, `6.1`, `6.2`, `6.3`, `6.4`, `6.5`, `6.6`, `6.7`, `6.8`
+- `7.0`, `7.1`, `7.2`, `7.3`
+
+``kibana_discover_version: '7.3'``
+
+kibana_discover_index_pattern_id
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``kibana_discover_index_pattern_id``: The id of the index pattern to link to in the Kibana Discover application.
+These ids are usually generated and can be found in url of the index pattern management page, or by exporting its saved object.
+
+Example export of an index pattern's saved object:
+
+.. code-block:: text
+
+    [
+        {
+            "_id": "4e97d188-8a45-4418-8a37-07ed69b4d34c",
+            "_type": "index-pattern",
+            "_source": { ... }
+        }
+    ]
+
+You can modify an index pattern's id by exporting the saved object, modifying the ``_id`` field, and re-importing.
+
+``kibana_discover_index_pattern_id: 4e97d188-8a45-4418-8a37-07ed69b4d34c``
+
+kibana_discover_columns
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+``kibana_discover_columns``: The columns to display in the generated Kibana Discover application link.
+Defaults to the ``_source`` column.
+
+``kibana_discover_columns: [ timestamp, message ]``
+
+kibana_discover_from_timedelta
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``kibana_discover_from_timedelta``:  The offset to the `from` time of the Kibana Discover link's time range.
+The `from` time is calculated by subtracting this timedelta from the event time.  Defaults to 10 minutes.
+
+``kibana_discover_from_timedelta: minutes: 2``
+
+kibana_discover_to_timedelta
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``kibana_discover_to_timedelta``:  The offset to the `to` time of the Kibana Discover link's time range.
+The `to` time is calculated by adding this timedelta to the event time.  Defaults to 10 minutes.
+
+``kibana_discover_to_timedelta: minutes: 2``
 
 use_local_time
 ^^^^^^^^^^^^^^

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -58,7 +58,7 @@ Rule Configuration Cheat Sheet
 +--------------------------------------------------------------+           |
 | ``kibana4_end_timedelta`` (time, default: 10 min)            |           |
 +--------------------------------------------------------------+           |
-| ``use_kibana_discover`` (boolean, default False)             |           |
+| ``generate_kibana_discover_link`` (boolean, default False)   |           |
 +--------------------------------------------------------------+           |
 | ``kibana_discover_url`` (string, no default)                 |           |
 +--------------------------------------------------------------+           |
@@ -524,22 +524,22 @@ This value is added in back of the event. For example,
 
 ``kibana4_end_timedelta: minutes: 2``
 
-use_kibana_discover
-^^^^^^^^^^^^^^^^^^^
+generate_kibana_discover_link
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``use_kibana_discover``: Enables the generation of the ``kibana_link`` variable for the Kibana Discover application.
+``generate_kibana_discover_link``: Enables the generation of the ``kibana_discover_link`` variable for the Kibana Discover application.
 This setting requires the following settings are also configured:
 
 - ``kibana_discover_url``
 - ``kibana_discover_version``
 - ``kibana_discover_index_pattern_id``
 
-``use_kibana_discover: true``
+``generate_kibana_discover_link: true``
 
 kibana_discover_url
 ^^^^^^^^^^^^^^^^^^^^
 
-``kibana_discover_url``: The url of the Kibana Discover application used to generate the ``kibana_link`` variable.
+``kibana_discover_url``: The url of the Kibana Discover application used to generate the ``kibana_discover_link`` variable.
 This value can use `$VAR` and `${VAR}` references to expand environment variables.
 
 ``kibana_discover_url: http://kibana:5601/#/discover``

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1498,10 +1498,10 @@ class ElastAlerter(object):
             if kb_link:
                 matches[0]['kibana_link'] = kb_link
 
-        if rule.get('use_kibana_discover'):
+        if rule.get('generate_kibana_discover_link'):
             kb_link = generate_kibana_discover_link(rule, matches[0])
             if kb_link:
-                matches[0]['kibana_link'] = kb_link
+                matches[0]['kibana_discover_link'] = kb_link
 
         # Enhancements were already run at match time if
         # run_enhancements_first is set or

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -27,7 +27,7 @@ from elasticsearch.exceptions import TransportError
 from elasticsearch.exceptions import NotFoundError
 
 from . import kibana
-from .kibana_discover import kibana_discover_url
+from .kibana_discover import generate_kibana_discover_link
 from .alerts import DebugAlerter
 from .config import load_conf
 from .enhancements import DropMatchException
@@ -1499,7 +1499,7 @@ class ElastAlerter(object):
                 matches[0]['kibana_link'] = kb_link
 
         if rule.get('use_kibana_discover'):
-            kb_link = kibana_discover_url(rule, matches[0])
+            kb_link = generate_kibana_discover_link(rule, matches[0])
             if kb_link:
                 matches[0]['kibana_link'] = kb_link
 

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -27,6 +27,7 @@ from elasticsearch.exceptions import TransportError
 from elasticsearch.exceptions import NotFoundError
 
 from . import kibana
+from .kibana_discover import kibana_discover_url
 from .alerts import DebugAlerter
 from .config import load_conf
 from .enhancements import DropMatchException
@@ -1494,6 +1495,11 @@ class ElastAlerter(object):
 
         if rule.get('use_kibana4_dashboard'):
             kb_link = self.generate_kibana4_db(rule, matches[0])
+            if kb_link:
+                matches[0]['kibana_link'] = kb_link
+
+        if rule.get('use_kibana_discover'):
+            kb_link = kibana_discover_url(rule, matches[0])
             if kb_link:
                 matches[0]['kibana_link'] = kb_link
 

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -27,7 +27,7 @@ from elasticsearch.exceptions import TransportError
 from elasticsearch.exceptions import NotFoundError
 
 from . import kibana
-from .kibana_discover import generate_kibana_discover_link
+from .kibana_discover import generate_kibana_discover_url
 from .alerts import DebugAlerter
 from .config import load_conf
 from .enhancements import DropMatchException
@@ -1498,10 +1498,10 @@ class ElastAlerter(object):
             if kb_link:
                 matches[0]['kibana_link'] = kb_link
 
-        if rule.get('generate_kibana_discover_link'):
-            kb_link = generate_kibana_discover_link(rule, matches[0])
+        if rule.get('generate_kibana_discover_url'):
+            kb_link = generate_kibana_discover_url(rule, matches[0])
             if kb_link:
-                matches[0]['kibana_discover_link'] = kb_link
+                matches[0]['kibana_discover_url'] = kb_link
 
         # Enhancements were already run at match time if
         # run_enhancements_first is set or

--- a/elastalert/kibana_discover.py
+++ b/elastalert/kibana_discover.py
@@ -19,19 +19,19 @@ kibana7_versions = frozenset(['7.0', '7.1', '7.2', '7.3'])
 def generate_kibana_discover_link(rule, match):
     ''' Creates a link for a kibana discover app. '''
 
-    kibana_version = rule.get('kibana_discover_version')
-    if not kibana_version:
+    discover_url = rule.get('kibana_discover_url')
+    if not discover_url:
         logging.warning(
-            'use_kibana_discover was configured without kibana_discover_version for rule %s' % (
+            'Missing kibana_discover_url for rule %s' % (
                 rule.get('name', '<MISSING NAME>')
             )
         )
         return None
 
-    discover_url = rule.get('kibana_discover_url')
-    if not discover_url:
+    kibana_version = rule.get('kibana_discover_version')
+    if not kibana_version:
         logging.warning(
-            'use_kibana_discover was configured without kibana_discover_url for rule %s' % (
+            'Missing kibana_discover_version for rule %s' % (
                 rule.get('name', '<MISSING NAME>')
             )
         )
@@ -40,7 +40,7 @@ def generate_kibana_discover_link(rule, match):
     index = rule.get('kibana_discover_index_pattern_id')
     if not index:
         logging.warning(
-            'use_kibana_discover was configured without kibana_discover_index_pattern_id for rule %s' % (
+            'Missing kibana_discover_index_pattern_id for rule %s' % (
                 rule.get('name', '<MISSING NAME>')
             )
         )

--- a/elastalert/kibana_discover.py
+++ b/elastalert/kibana_discover.py
@@ -16,13 +16,13 @@ kibana_default_timedelta = datetime.timedelta(minutes=10)
 kibana5_kibana6_versions = frozenset(['5.6', '6.0', '6.1', '6.2', '6.3', '6.4', '6.5', '6.6', '6.7', '6.8'])
 kibana7_versions = frozenset(['7.0', '7.1', '7.2', '7.3'])
 
-def generate_kibana_discover_link(rule, match):
+def generate_kibana_discover_url(rule, match):
     ''' Creates a link for a kibana discover app. '''
 
-    discover_url = rule.get('kibana_discover_url')
-    if not discover_url:
+    discover_app_url = rule.get('kibana_discover_app_url')
+    if not discover_app_url:
         logging.warning(
-            'Missing kibana_discover_url for rule %s' % (
+            'Missing kibana_discover_app_url for rule %s' % (
                 rule.get('name', '<MISSING NAME>')
             )
         )
@@ -79,7 +79,7 @@ def generate_kibana_discover_link(rule, match):
         return None
 
     return "%s?_g=%s&_a=%s" % (
-        os.path.expandvars(discover_url),
+        os.path.expandvars(discover_app_url),
         urllib.parse.quote(globalState),
         urllib.parse.quote(appState)
     )

--- a/elastalert/kibana_discover.py
+++ b/elastalert/kibana_discover.py
@@ -16,7 +16,7 @@ kibana_default_timedelta = datetime.timedelta(minutes=10)
 kibana5_kibana6_versions = frozenset(['5.6', '6.0', '6.1', '6.2', '6.3', '6.4', '6.5', '6.6', '6.7', '6.8'])
 kibana7_versions = frozenset(['7.0', '7.1', '7.2', '7.3'])
 
-def kibana_discover_url(rule, match):
+def generate_kibana_discover_link(rule, match):
     ''' Creates a link for a kibana discover app. '''
 
     kibana_version = rule.get('kibana_discover_version')

--- a/elastalert/kibana_discover.py
+++ b/elastalert/kibana_discover.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+import datetime
+import logging
+import json
+import os.path
+import prison
+import urllib.parse
+
+from .util import EAException
+from .util import lookup_es_key
+from .util import ts_add
+
+kibana_default_timedelta = datetime.timedelta(minutes=10)
+
+kibana5_kibana6_versions = frozenset(['5.6', '6.0', '6.1', '6.2', '6.3', '6.4', '6.5', '6.6', '6.7', '6.8'])
+kibana7_versions = frozenset(['7.0', '7.1', '7.2', '7.3'])
+
+def kibana_discover_url(rule, match):
+    ''' Creates a link for a kibana discover app. '''
+
+    kibana_version = rule.get('kibana_discover_version')
+    if not kibana_version:
+        logging.warning(
+            'use_kibana_discover was configured without kibana_discover_version for rule %s' % (
+                rule.get('name', '<MISSING NAME>')
+            )
+        )
+        return None
+
+    discover_url = rule.get('kibana_discover_url')
+    if not discover_url:
+        logging.warning(
+            'use_kibana_discover was configured without kibana_discover_url for rule %s' % (
+                rule.get('name', '<MISSING NAME>')
+            )
+        )
+        return None
+
+    index = rule.get('kibana_discover_index_pattern_id')
+    if not index:
+        logging.warning(
+            'use_kibana_discover was configured without kibana_discover_index_pattern_id for rule %s' % (
+                rule.get('name', '<MISSING NAME>')
+            )
+        )
+        return None
+
+    columns = rule.get('kibana_discover_columns', ['_source'])
+    filters = rule.get('filter', [])
+
+    if 'query_key' in rule:
+        query_keys = rule.get('compound_query_key', [rule['query_key']])
+    else:
+        query_keys = []
+
+    timestamp = lookup_es_key(match, rule['timestamp_field'])
+    timeframe = rule.get('timeframe', kibana_default_timedelta)
+    from_timedelta = rule.get('kibana_discover_from_timedelta', timeframe)
+    from_time = ts_add(timestamp, -from_timedelta)
+    to_timedelta = rule.get('kibana_discover_to_timedelta', timeframe)
+    to_time = ts_add(timestamp, to_timedelta)
+
+    if kibana_version in kibana5_kibana6_versions:
+        globalState = kibana6_disover_global_state(from_time, to_time)
+        appState = kibana_discover_app_state(index, columns, filters, query_keys, match)
+
+    elif kibana_version in kibana7_versions:
+        globalState = kibana7_disover_global_state(from_time, to_time)
+        appState = kibana_discover_app_state(index, columns, filters, query_keys, match)
+
+    else:
+        logging.warning(
+            'Unknown kibana discover application version %s for rule %s' % (
+                kibana_version,
+                rule.get('name', '<MISSING NAME>')
+            )
+        )
+        return None
+
+    return "%s?_g=%s&_a=%s" % (
+        os.path.expandvars(discover_url),
+        urllib.parse.quote(globalState),
+        urllib.parse.quote(appState)
+    )
+
+
+def kibana6_disover_global_state(from_time, to_time):
+    return prison.dumps( {
+        'refreshInterval': {
+            'pause': True,
+            'value': 0
+        },
+        'time': {
+            'from': from_time,
+            'mode': 'absolute',
+            'to': to_time
+        }
+    } )
+
+
+def kibana7_disover_global_state(from_time, to_time):
+    return prison.dumps( {
+        'filters': [],
+        'refreshInterval': {
+            'pause': True,
+            'value': 0
+        },
+        'time': {
+            'from': from_time,
+            'to': to_time
+        }
+    } )
+
+
+def kibana_discover_app_state(index, columns, filters, query_keys, match):
+    app_filters = []
+
+    if filters:
+        bool_filter = { 'must': filters }
+        app_filters.append( {
+            '$state': {
+                'store': 'appState'
+            },
+            'bool': bool_filter,
+            'meta': {
+                'alias': 'filter',
+                'disabled': False,
+                'index': index,
+                'key': 'bool',
+                'negate': False,
+                'type': 'custom',
+                'value': json.dumps(bool_filter, separators=(',', ':'))
+            },
+        } )
+
+    for query_key in query_keys:
+        query_value = lookup_es_key(match, query_key)
+
+        if query_value is None:
+            app_filters.append( {
+                '$state': {
+                    'store': 'appState'
+                },
+                'exists': {
+                    'field': query_key
+                },
+                'meta': {
+                    'alias': None,
+                    'disabled': False,
+                    'index': index,
+                    'key': query_key,
+                    'negate': True,
+                    'type': 'exists',
+                    'value': 'exists'
+                }
+            } )
+
+        else:
+            app_filters.append( {
+                '$state': {
+                    'store': 'appState'
+                },
+                'meta': {
+                    'alias': None,
+                    'disabled': False,
+                    'index': index,
+                    'key': query_key,
+                    'negate': False,
+                    'params': {
+                        'query': query_value,
+                        'type': 'phrase'
+                    },
+                    'type': 'phrase',
+                    'value': str(query_value)
+                },
+                'query': {
+                    'match': {
+                        query_key: {
+                            'query': query_value,
+                            'type': 'phrase'
+                        }
+                    }
+                }
+            } )
+
+    return prison.dumps( {
+        'columns': columns,
+        'filters': app_filters,
+        'index': index,
+        'interval': 'auto'
+    } )

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -257,6 +257,10 @@ class RulesLoader(object):
                 rule['kibana4_start_timedelta'] = datetime.timedelta(**rule['kibana4_start_timedelta'])
             if 'kibana4_end_timedelta' in rule:
                 rule['kibana4_end_timedelta'] = datetime.timedelta(**rule['kibana4_end_timedelta'])
+            if 'kibana_discover_from_timedelta' in rule:
+                rule['kibana_discover_from_timedelta'] = datetime.timedelta(**rule['kibana_discover_from_timedelta'])
+            if 'kibana_discover_to_timedelta' in rule:
+                rule['kibana_discover_to_timedelta'] = datetime.timedelta(**rule['kibana_discover_to_timedelta'])
         except (KeyError, TypeError) as e:
             raise EAException('Invalid time format used: %s' % e)
 

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -203,6 +203,15 @@ properties:
   replace_dots_in_field_names: {type: boolean}
   scan_entire_timeframe: {type: boolean}
 
+  ### Kibana Discover App Link
+  use_kibana_discover: {type: boolean}
+  kibana_discover_url: {type: string}
+  kibana_discover_version: {enum: ['7.3', '7.2', '7.1', '7.0', '6.8', '6.7', '6.6', '6.5', '6.4', '6.3', '6.2', '6.1', '6.0', '5.6']}
+  kibana_discover_index_pattern_id: {type: string}
+  kibana_discover_columns: {type: array, items: {type: string}}
+  kibana_discover_from_timedelta: *timeframe
+  kibana_discover_to_timedelta: *timeframe
+
   # Alert Content
   alert_text: {type: string} # Python format string
   alert_text_args: {type: array, items: {type: string}}

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -204,7 +204,7 @@ properties:
   scan_entire_timeframe: {type: boolean}
 
   ### Kibana Discover App Link
-  use_kibana_discover: {type: boolean}
+  generate_kibana_discover_link: {type: boolean}
   kibana_discover_url: {type: string}
   kibana_discover_version: {enum: ['7.3', '7.2', '7.1', '7.0', '6.8', '6.7', '6.6', '6.5', '6.4', '6.3', '6.2', '6.1', '6.0', '5.6']}
   kibana_discover_index_pattern_id: {type: string}

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -206,7 +206,7 @@ properties:
   ### Kibana Discover App Link
   generate_kibana_discover_url: {type: boolean}
   kibana_discover_app_url: {type: string}
-  kibana_discover_version: {enum: ['7.3', '7.2', '7.1', '7.0', '6.8', '6.7', '6.6', '6.5', '6.4', '6.3', '6.2', '6.1', '6.0', '5.6']}
+  kibana_discover_version: {type: string, enum: ['7.3', '7.2', '7.1', '7.0', '6.8', '6.7', '6.6', '6.5', '6.4', '6.3', '6.2', '6.1', '6.0', '5.6']}
   kibana_discover_index_pattern_id: {type: string}
   kibana_discover_columns: {type: array, items: {type: string}}
   kibana_discover_from_timedelta: *timeframe

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -204,8 +204,8 @@ properties:
   scan_entire_timeframe: {type: boolean}
 
   ### Kibana Discover App Link
-  generate_kibana_discover_link: {type: boolean}
-  kibana_discover_url: {type: string}
+  generate_kibana_discover_url: {type: boolean}
+  kibana_discover_app_url: {type: string}
   kibana_discover_version: {enum: ['7.3', '7.2', '7.1', '7.0', '6.8', '6.7', '6.6', '6.5', '6.4', '6.3', '6.2', '6.1', '6.0', '5.6']}
   kibana_discover_index_pattern_id: {type: string}
   kibana_discover_columns: {type: array, items: {type: string}}

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -11,6 +11,17 @@ definitions:
     type: [string, array]
     items: {type: [string, array]}
 
+  timedelta: &timedelta
+    type: object
+    additionalProperties: false
+    properties:
+      days: {type: number}
+      weeks: {type: number}
+      hours: {type: number}
+      minutes: {type: number}
+      seconds: {type: number}
+      milliseconds: {type: number}
+
   timeFrame: &timeframe
     type: object
     additionalProperties: false
@@ -205,12 +216,12 @@ properties:
 
   ### Kibana Discover App Link
   generate_kibana_discover_url: {type: boolean}
-  kibana_discover_app_url: {type: string}
+  kibana_discover_app_url: {type: string, format: uri}
   kibana_discover_version: {type: string, enum: ['7.3', '7.2', '7.1', '7.0', '6.8', '6.7', '6.6', '6.5', '6.4', '6.3', '6.2', '6.1', '6.0', '5.6']}
-  kibana_discover_index_pattern_id: {type: string}
-  kibana_discover_columns: {type: array, items: {type: string}}
-  kibana_discover_from_timedelta: *timeframe
-  kibana_discover_to_timedelta: *timeframe
+  kibana_discover_index_pattern_id: {type: string, minLength: 1}
+  kibana_discover_columns: {type: array, items: {type: string, minLength: 1}, minItems: 1}
+  kibana_discover_from_timedelta: *timedelta
+  kibana_discover_to_timedelta: *timedelta
 
   # Alert Content
   alert_text: {type: string} # Python format string

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ exotel>=0.1.3
 jira>=1.0.10,<1.0.15
 jsonschema>=2.6.0
 mock>=2.0.0
+prison>=0.1.2
 py-zabbix==1.1.3
 PyStaticConfiguration>=0.10.3
 python-dateutil>=2.6.0,<2.7.0

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         'jira>=1.0.10,<1.0.15',
         'jsonschema>=2.6.0,<3.0.0',
         'mock>=2.0.0',
+        'prison>=0.1.2',
         'PyStaticConfiguration>=0.10.3',
         'python-dateutil>=2.6.0,<2.7.0',
         'PyYAML>=3.12',

--- a/tests/kibana_discover_test.py
+++ b/tests/kibana_discover_test.py
@@ -1,0 +1,858 @@
+# -*- coding: utf-8 -*-
+from datetime import timedelta
+import pytest
+
+from elastalert.kibana_discover import kibana_discover_url
+
+
+@pytest.mark.parametrize("kibana_version", ['5.6', '6.0', '6.1', '6.2', '6.3', '6.4', '6.5', '6.6', '6.7', '6.8'])
+def test_kibana_discover_url_with_kibana_5x_and_6x(kibana_version):
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_version': kibana_version,
+            'kibana_discover_index_pattern_id': 'd6cabfb6-aaef-44ea-89c5-600e9a76991a',
+            'timestamp_field': 'timestamp'
+        },
+        match={
+            'timestamp': '2019-09-01T00:30:00Z'
+        }
+    )
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T00%3A20%3A00Z%27%2C'
+        + 'mode%3Aabsolute%2C'
+        + 'to%3A%272019-09-01T00%3A40%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28_source%29%2C'
+        + 'filters%3A%21%28%29%2C'
+        + 'index%3Ad6cabfb6-aaef-44ea-89c5-600e9a76991a%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl
+
+
+@pytest.mark.parametrize("kibana_version", ['7.0', '7.1', '7.2', '7.3'])
+def test_kibana_discover_url_with_kibana_7x(kibana_version):
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_version': kibana_version,
+            'kibana_discover_index_pattern_id': 'd6cabfb6-aaef-44ea-89c5-600e9a76991a',
+            'timestamp_field': 'timestamp'
+        },
+        match={
+            'timestamp': '2019-09-01T00:30:00Z'
+        }
+    )
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'filters%3A%21%28%29%2C'
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T00%3A20%3A00Z%27%2C'
+        + 'to%3A%272019-09-01T00%3A40%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28_source%29%2C'
+        + 'filters%3A%21%28%29%2C'
+        + 'index%3Ad6cabfb6-aaef-44ea-89c5-600e9a76991a%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl
+
+
+def test_kibana_discover_url_with_missing_kibana_discover_version():
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_index_pattern_id': 'logs',
+            'timestamp_field': 'timestamp',
+            'name': 'test'
+        },
+        match={
+            'timestamp': '2019-09-01T00:30:00Z'
+        }
+    )
+    assert url is None
+
+
+def test_kibana_discover_url_with_missing_kibana_discover_url():
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_version': '6.8',
+            'kibana_discover_index_pattern_id': 'logs',
+            'timestamp_field': 'timestamp',
+            'name': 'test'
+        },
+        match={
+            'timestamp': '2019-09-01T00:30:00Z'
+        }
+    )
+    assert url is None
+
+
+def test_kibana_discover_url_with_missing_kibana_discover_index_pattern_id():
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_version': '6.8',
+            'timestamp_field': 'timestamp',
+            'name': 'test'
+        },
+        match={
+            'timestamp': '2019-09-01T00:30:00Z'
+        }
+    )
+    assert url is None
+
+
+def test_kibana_discover_url_with_invalid_kibana_version():
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_version': '4.5',
+            'kibana_discover_index_pattern_id': 'logs-*',
+            'timestamp_field': 'timestamp'
+        },
+        match={
+            'timestamp': '2019-09-01T00:30:00Z'
+        }
+    )
+    assert url is None
+
+
+def test_kibana_discover_url_with_discover_url_env_substitution(environ):
+    environ.update({
+        'KIBANA_HOST': 'kibana',
+        'KIBANA_PORT': '5601',
+    })
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_url': 'http://$KIBANA_HOST:$KIBANA_PORT/#/discover',
+            'kibana_discover_version': '6.8',
+            'kibana_discover_index_pattern_id': 'd6cabfb6-aaef-44ea-89c5-600e9a76991a',
+            'timestamp_field': 'timestamp'
+        },
+        match={
+            'timestamp': '2019-09-01T00:30:00Z'
+        }
+    )
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T00%3A20%3A00Z%27%2C'
+        + 'mode%3Aabsolute%2C'
+        + 'to%3A%272019-09-01T00%3A40%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28_source%29%2C'
+        + 'filters%3A%21%28%29%2C'
+        + 'index%3Ad6cabfb6-aaef-44ea-89c5-600e9a76991a%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl
+
+
+def test_kibana_discover_url_with_from_timedelta():
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_version': '7.3',
+            'kibana_discover_index_pattern_id': 'd6cabfb6-aaef-44ea-89c5-600e9a76991a',
+            'kibana_discover_from_timedelta': timedelta(hours=1),
+            'timestamp_field': 'timestamp'
+        },
+        match={
+            'timestamp': '2019-09-01T04:00:00Z'
+        }
+    )
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'filters%3A%21%28%29%2C'
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T03%3A00%3A00Z%27%2C'
+        + 'to%3A%272019-09-01T04%3A10%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28_source%29%2C'
+        + 'filters%3A%21%28%29%2C'
+        + 'index%3Ad6cabfb6-aaef-44ea-89c5-600e9a76991a%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl
+
+
+def test_kibana_discover_url_with_from_timedelta_and_timeframe():
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_version': '7.3',
+            'kibana_discover_index_pattern_id': 'd6cabfb6-aaef-44ea-89c5-600e9a76991a',
+            'kibana_discover_from_timedelta': timedelta(hours=1),
+            'timeframe': timedelta(minutes=20),
+            'timestamp_field': 'timestamp'
+        },
+        match={
+            'timestamp': '2019-09-01T04:00:00Z'
+        }
+    )
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'filters%3A%21%28%29%2C'
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T03%3A00%3A00Z%27%2C'
+        + 'to%3A%272019-09-01T04%3A20%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28_source%29%2C'
+        + 'filters%3A%21%28%29%2C'
+        + 'index%3Ad6cabfb6-aaef-44ea-89c5-600e9a76991a%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl
+
+
+def test_kibana_discover_url_with_to_timedelta():
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_version': '7.3',
+            'kibana_discover_index_pattern_id': 'd6cabfb6-aaef-44ea-89c5-600e9a76991a',
+            'kibana_discover_to_timedelta': timedelta(hours=1),
+            'timestamp_field': 'timestamp'
+        },
+        match={
+            'timestamp': '2019-09-01T04:00:00Z'
+        }
+    )
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'filters%3A%21%28%29%2C'
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T03%3A50%3A00Z%27%2C'
+        + 'to%3A%272019-09-01T05%3A00%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28_source%29%2C'
+        + 'filters%3A%21%28%29%2C'
+        + 'index%3Ad6cabfb6-aaef-44ea-89c5-600e9a76991a%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl
+
+
+def test_kibana_discover_url_with_to_timedelta_and_timeframe():
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_version': '7.3',
+            'kibana_discover_index_pattern_id': 'd6cabfb6-aaef-44ea-89c5-600e9a76991a',
+            'kibana_discover_to_timedelta': timedelta(hours=1),
+            'timeframe': timedelta(minutes=20),
+            'timestamp_field': 'timestamp'
+        },
+        match={
+            'timestamp': '2019-09-01T04:00:00Z'
+        }
+    )
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'filters%3A%21%28%29%2C'
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T03%3A40%3A00Z%27%2C'
+        + 'to%3A%272019-09-01T05%3A00%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28_source%29%2C'
+        + 'filters%3A%21%28%29%2C'
+        + 'index%3Ad6cabfb6-aaef-44ea-89c5-600e9a76991a%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl
+
+
+def test_kibana_discover_url_with_timeframe():
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_version': '7.3',
+            'kibana_discover_index_pattern_id': 'd6cabfb6-aaef-44ea-89c5-600e9a76991a',
+            'timeframe': timedelta(minutes=20),
+            'timestamp_field': 'timestamp'
+        },
+        match={
+            'timestamp': '2019-09-01T04:30:00Z'
+        }
+    )
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'filters%3A%21%28%29%2C'
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T04%3A10%3A00Z%27%2C'
+        + 'to%3A%272019-09-01T04%3A50%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28_source%29%2C'
+        + 'filters%3A%21%28%29%2C'
+        + 'index%3Ad6cabfb6-aaef-44ea-89c5-600e9a76991a%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl
+
+
+def test_kibana_discover_url_with_custom_columns():
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_version': '6.8',
+            'kibana_discover_index_pattern_id': 'logs-*',
+            'kibana_discover_columns': ['level', 'message'],
+            'timestamp_field': 'timestamp'
+        },
+        match={
+            'timestamp': '2019-09-01T00:30:00Z'
+        }
+    )
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T00%3A20%3A00Z%27%2C'
+        + 'mode%3Aabsolute%2C'
+        + 'to%3A%272019-09-01T00%3A40%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28level%2Cmessage%29%2C'
+        + 'filters%3A%21%28%29%2C'
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl
+
+
+def test_kibana_discover_url_with_single_filter():
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_version': '6.8',
+            'kibana_discover_index_pattern_id': 'logs-*',
+            'timestamp_field': 'timestamp',
+            'filter': [
+                {'term': {'level': 30}}
+            ]
+        },
+        match={
+            'timestamp': '2019-09-01T00:30:00Z'
+        }
+    )
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T00%3A20%3A00Z%27%2C'
+        + 'mode%3Aabsolute%2C'
+        + 'to%3A%272019-09-01T00%3A40%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28_source%29%2C'
+        + 'filters%3A%21%28'  # filters start
+
+        + '%28'  # filter start
+        + '%27%24state%27%3A%28store%3AappState%29%2C'
+        + 'bool%3A%28must%3A%21%28%28term%3A%28level%3A30%29%29%29%29%2C'
+        + 'meta%3A%28'  # meta start
+        + 'alias%3Afilter%2C'
+        + 'disabled%3A%21f%2C'
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'key%3Abool%2C'
+        + 'negate%3A%21f%2C'
+        + 'type%3Acustom%2C'
+        + 'value%3A%27%7B%22must%22%3A%5B%7B%22term%22%3A%7B%22level%22%3A30%7D%7D%5D%7D%27'
+        + '%29'  # meta end
+        + '%29'  # filter end
+
+        + '%29%2C'  # filters end
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl
+
+
+def test_kibana_discover_url_with_multiple_filters():
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_version': '6.8',
+            'kibana_discover_index_pattern_id': '90943e30-9a47-11e8-b64d-95841ca0b247',
+            'timestamp_field': 'timestamp',
+            'filter': [
+                {'term': {'app': 'test'}},
+                {'term': {'level': 30}}
+            ]
+        },
+        match={
+            'timestamp': '2019-09-01T00:30:00Z'
+        }
+    )
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T00%3A20%3A00Z%27%2C'
+        + 'mode%3Aabsolute%2C'
+        + 'to%3A%272019-09-01T00%3A40%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28_source%29%2C'
+        + 'filters%3A%21%28'  # filters start
+
+        + '%28'  # filter start
+        + '%27%24state%27%3A%28store%3AappState%29%2C'
+        + 'bool%3A%28must%3A%21%28%28term%3A%28app%3Atest%29%29%2C%28term%3A%28level%3A30%29%29%29%29%2C'
+        + 'meta%3A%28'  # meta start
+        + 'alias%3Afilter%2C'
+        + 'disabled%3A%21f%2C'
+        + 'index%3A%2790943e30-9a47-11e8-b64d-95841ca0b247%27%2C'
+        + 'key%3Abool%2C'
+        + 'negate%3A%21f%2C'
+        + 'type%3Acustom%2C'
+        + 'value%3A%27%7B%22must%22%3A%5B'  # value start
+        + '%7B%22term%22%3A%7B%22app%22%3A%22test%22%7D%7D%2C%7B%22term%22%3A%7B%22level%22%3A30%7D%7D'
+        + '%5D%7D%27'  # value end
+        + '%29'  # meta end
+        + '%29'  # filter end
+
+        + '%29%2C'  # filters end
+        + 'index%3A%2790943e30-9a47-11e8-b64d-95841ca0b247%27%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl
+
+
+def test_kibana_discover_url_with_int_query_key():
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_version': '6.8',
+            'kibana_discover_index_pattern_id': 'logs-*',
+            'timestamp_field': 'timestamp',
+            'query_key': 'geo.dest'
+        },
+        match={
+            'timestamp': '2019-09-01T00:30:00Z',
+            'geo.dest': 200
+        }
+    )
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T00%3A20%3A00Z%27%2C'
+        + 'mode%3Aabsolute%2C'
+        + 'to%3A%272019-09-01T00%3A40%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28_source%29%2C'
+        + 'filters%3A%21%28'  # filters start
+
+        + '%28'  # filter start
+        + '%27%24state%27%3A%28store%3AappState%29%2C'
+        + 'meta%3A%28'  # meta start
+        + 'alias%3A%21n%2C'
+        + 'disabled%3A%21f%2C'
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'key%3Ageo.dest%2C'
+        + 'negate%3A%21f%2C'
+        + 'params%3A%28query%3A200%2C'  # params start
+        + 'type%3Aphrase'
+        + '%29%2C'  # params end
+        + 'type%3Aphrase%2C'
+        + 'value%3A%27200%27'
+        + '%29%2C'  # meta end
+        + 'query%3A%28'  # query start
+        + 'match%3A%28'  # match start
+        + 'geo.dest%3A%28'  # reponse start
+        + 'query%3A200%2C'
+        + 'type%3Aphrase'
+        + '%29'  # geo.dest end
+        + '%29'  # match end
+        + '%29'  # query end
+        + '%29'  # filter end
+
+        + '%29%2C'  # filters end
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl
+
+
+def test_kibana_discover_url_with_str_query_key():
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_version': '6.8',
+            'kibana_discover_index_pattern_id': 'logs-*',
+            'timestamp_field': 'timestamp',
+            'query_key': 'geo.dest'
+        },
+        match={
+            'timestamp': '2019-09-01T00:30:00Z',
+            'geo': {
+                'dest': 'ok'
+            }
+        }
+    )
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T00%3A20%3A00Z%27%2C'
+        + 'mode%3Aabsolute%2C'
+        + 'to%3A%272019-09-01T00%3A40%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28_source%29%2C'
+        + 'filters%3A%21%28'  # filters start
+
+        + '%28'  # filter start
+        + '%27%24state%27%3A%28store%3AappState%29%2C'
+        + 'meta%3A%28'  # meta start
+        + 'alias%3A%21n%2C'
+        + 'disabled%3A%21f%2C'
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'key%3Ageo.dest%2C'
+        + 'negate%3A%21f%2C'
+        + 'params%3A%28query%3Aok%2C'  # params start
+        + 'type%3Aphrase'
+        + '%29%2C'  # params end
+        + 'type%3Aphrase%2C'
+        + 'value%3Aok'
+        + '%29%2C'  # meta end
+        + 'query%3A%28'  # query start
+        + 'match%3A%28'  # match start
+        + 'geo.dest%3A%28'  # geo.dest start
+        + 'query%3Aok%2C'
+        + 'type%3Aphrase'
+        + '%29'  # geo.dest end
+        + '%29'  # match end
+        + '%29'  # query end
+        + '%29'  # filter end
+
+        + '%29%2C'  # filters end
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl
+
+
+def test_kibana_discover_url_with_null_query_key_value():
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_version': '6.8',
+            'kibana_discover_index_pattern_id': 'logs-*',
+            'timestamp_field': 'timestamp',
+            'query_key': 'status'
+        },
+        match={
+            'timestamp': '2019-09-01T00:30:00Z',
+            'status': None
+        }
+    )
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T00%3A20%3A00Z%27%2C'
+        + 'mode%3Aabsolute%2C'
+        + 'to%3A%272019-09-01T00%3A40%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28_source%29%2C'
+        + 'filters%3A%21%28'  # filters start
+
+        + '%28'  # filter start
+        + '%27%24state%27%3A%28store%3AappState%29%2C'
+        + 'exists%3A%28field%3Astatus%29%2C'
+        + 'meta%3A%28'  # meta start
+        + 'alias%3A%21n%2C'
+        + 'disabled%3A%21f%2C'
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'key%3Astatus%2C'
+        + 'negate%3A%21t%2C'
+        + 'type%3Aexists%2C'
+        + 'value%3Aexists'
+        + '%29'  # meta end
+        + '%29'  # filter end
+
+        + '%29%2C'  # filters end
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl
+
+
+def test_kibana_discover_url_with_missing_query_key_value():
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_version': '6.8',
+            'kibana_discover_index_pattern_id': 'logs-*',
+            'timestamp_field': 'timestamp',
+            'query_key': 'status'
+        },
+        match={
+            'timestamp': '2019-09-01T00:30:00Z'
+        }
+    )
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T00%3A20%3A00Z%27%2C'
+        + 'mode%3Aabsolute%2C'
+        + 'to%3A%272019-09-01T00%3A40%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28_source%29%2C'
+        + 'filters%3A%21%28'  # filters start
+
+        + '%28'  # filter start
+        + '%27%24state%27%3A%28store%3AappState%29%2C'
+        + 'exists%3A%28field%3Astatus%29%2C'
+        + 'meta%3A%28'  # meta start
+        + 'alias%3A%21n%2C'
+        + 'disabled%3A%21f%2C'
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'key%3Astatus%2C'
+        + 'negate%3A%21t%2C'
+        + 'type%3Aexists%2C'
+        + 'value%3Aexists'
+        + '%29'  # meta end
+        + '%29'  # filter end
+
+        + '%29%2C'  # filters end
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl
+
+
+def test_kibana_discover_url_with_compound_query_key():
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_version': '6.8',
+            'kibana_discover_index_pattern_id': 'logs-*',
+            'timestamp_field': 'timestamp',
+            'compound_query_key': ['geo.src', 'geo.dest'],
+            'query_key': 'geo.src,geo.dest'
+        },
+        match={
+            'timestamp': '2019-09-01T00:30:00Z',
+            'geo': {
+                'src': 'CA',
+                'dest': 'US'
+            }
+        }
+    )
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T00%3A20%3A00Z%27%2C'
+        + 'mode%3Aabsolute%2C'
+        + 'to%3A%272019-09-01T00%3A40%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28_source%29%2C'
+        + 'filters%3A%21%28'  # filters start
+
+        + '%28'  # geo.src filter start
+        + '%27%24state%27%3A%28store%3AappState%29%2C'
+        + 'meta%3A%28'  # meta start
+        + 'alias%3A%21n%2C'
+        + 'disabled%3A%21f%2C'
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'key%3Ageo.src%2C'
+        + 'negate%3A%21f%2C'
+        + 'params%3A%28query%3ACA%2C'  # params start
+        + 'type%3Aphrase'
+        + '%29%2C'  # params end
+        + 'type%3Aphrase%2C'
+        + 'value%3ACA'
+        + '%29%2C'  # meta end
+        + 'query%3A%28'  # query start
+        + 'match%3A%28'  # match start
+        + 'geo.src%3A%28'  # reponse start
+        + 'query%3ACA%2C'
+        + 'type%3Aphrase'
+        + '%29'  # geo.src end
+        + '%29'  # match end
+        + '%29'  # query end
+        + '%29%2C'  # geo.src filter end
+
+        + '%28'  # geo.dest filter start
+        + '%27%24state%27%3A%28store%3AappState%29%2C'
+        + 'meta%3A%28'  # meta start
+        + 'alias%3A%21n%2C'
+        + 'disabled%3A%21f%2C'
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'key%3Ageo.dest%2C'
+        + 'negate%3A%21f%2C'
+        + 'params%3A%28query%3AUS%2C'  # params start
+        + 'type%3Aphrase'
+        + '%29%2C'  # params end
+        + 'type%3Aphrase%2C'
+        + 'value%3AUS'
+        + '%29%2C'  # meta end
+        + 'query%3A%28'  # query start
+        + 'match%3A%28'  # match start
+        + 'geo.dest%3A%28'  # geo.dest start
+        + 'query%3AUS%2C'
+        + 'type%3Aphrase'
+        + '%29'  # geo.dest end
+        + '%29'  # match end
+        + '%29'  # query end
+        + '%29'  # geo.dest filter end
+
+        + '%29%2C'  # filters end
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl
+
+
+def test_kibana_discover_url_with_filter_and_query_key():
+    url = kibana_discover_url(
+        rule={
+            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_version': '6.8',
+            'kibana_discover_index_pattern_id': 'logs-*',
+            'timestamp_field': 'timestamp',
+            'filter': [
+                {'term': {'level': 30}}
+            ],
+            'query_key': 'status'
+        },
+        match={
+            'timestamp': '2019-09-01T00:30:00Z',
+            'status': 'ok'
+        }
+    )
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T00%3A20%3A00Z%27%2C'
+        + 'mode%3Aabsolute%2C'
+        + 'to%3A%272019-09-01T00%3A40%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28_source%29%2C'
+        + 'filters%3A%21%28'  # filters start
+
+        + '%28'  # filter start
+        + '%27%24state%27%3A%28store%3AappState%29%2C'
+        + 'bool%3A%28must%3A%21%28%28term%3A%28level%3A30%29%29%29%29%2C'
+        + 'meta%3A%28'  # meta start
+        + 'alias%3Afilter%2C'
+        + 'disabled%3A%21f%2C'
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'key%3Abool%2C'
+        + 'negate%3A%21f%2C'
+        + 'type%3Acustom%2C'
+        + 'value%3A%27%7B%22must%22%3A%5B%7B%22term%22%3A%7B%22level%22%3A30%7D%7D%5D%7D%27'
+        + '%29'  # meta end
+        + '%29%2C'  # filter end
+
+        + '%28'  # filter start
+        + '%27%24state%27%3A%28store%3AappState%29%2C'
+        + 'meta%3A%28'  # meta start
+        + 'alias%3A%21n%2C'
+        + 'disabled%3A%21f%2C'
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'key%3Astatus%2C'
+        + 'negate%3A%21f%2C'
+        + 'params%3A%28query%3Aok%2C'  # params start
+        + 'type%3Aphrase'
+        + '%29%2C'  # params end
+        + 'type%3Aphrase%2C'
+        + 'value%3Aok'
+        + '%29%2C'  # meta end
+        + 'query%3A%28'  # query start
+        + 'match%3A%28'  # match start
+        + 'status%3A%28'  # status start
+        + 'query%3Aok%2C'
+        + 'type%3Aphrase'
+        + '%29'  # status end
+        + '%29'  # match end
+        + '%29'  # query end
+        + '%29'  # filter end
+
+        + '%29%2C'  # filters end
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl

--- a/tests/kibana_discover_test.py
+++ b/tests/kibana_discover_test.py
@@ -2,14 +2,14 @@
 from datetime import timedelta
 import pytest
 
-from elastalert.kibana_discover import generate_kibana_discover_link
+from elastalert.kibana_discover import generate_kibana_discover_url
 
 
 @pytest.mark.parametrize("kibana_version", ['5.6', '6.0', '6.1', '6.2', '6.3', '6.4', '6.5', '6.6', '6.7', '6.8'])
-def test_generate_kibana_discover_link_with_kibana_5x_and_6x(kibana_version):
-    url = generate_kibana_discover_link(
+def test_generate_kibana_discover_url_with_kibana_5x_and_6x(kibana_version):
+    url = generate_kibana_discover_url(
         rule={
-            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': kibana_version,
             'kibana_discover_index_pattern_id': 'd6cabfb6-aaef-44ea-89c5-600e9a76991a',
             'timestamp_field': 'timestamp'
@@ -39,10 +39,10 @@ def test_generate_kibana_discover_link_with_kibana_5x_and_6x(kibana_version):
 
 
 @pytest.mark.parametrize("kibana_version", ['7.0', '7.1', '7.2', '7.3'])
-def test_generate_kibana_discover_link_with_kibana_7x(kibana_version):
-    url = generate_kibana_discover_link(
+def test_generate_kibana_discover_url_with_kibana_7x(kibana_version):
+    url = generate_kibana_discover_url(
         rule={
-            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': kibana_version,
             'kibana_discover_index_pattern_id': 'd6cabfb6-aaef-44ea-89c5-600e9a76991a',
             'timestamp_field': 'timestamp'
@@ -71,10 +71,10 @@ def test_generate_kibana_discover_link_with_kibana_7x(kibana_version):
     assert url == expectedUrl
 
 
-def test_generate_kibana_discover_link_with_missing_kibana_discover_version():
-    url = generate_kibana_discover_link(
+def test_generate_kibana_discover_url_with_missing_kibana_discover_version():
+    url = generate_kibana_discover_url(
         rule={
-            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
             'kibana_discover_index_pattern_id': 'logs',
             'timestamp_field': 'timestamp',
             'name': 'test'
@@ -86,8 +86,8 @@ def test_generate_kibana_discover_link_with_missing_kibana_discover_version():
     assert url is None
 
 
-def test_generate_kibana_discover_link_with_missing_kibana_discover_url():
-    url = generate_kibana_discover_link(
+def test_generate_kibana_discover_url_with_missing_kibana_discover_app_url():
+    url = generate_kibana_discover_url(
         rule={
             'kibana_discover_version': '6.8',
             'kibana_discover_index_pattern_id': 'logs',
@@ -101,10 +101,10 @@ def test_generate_kibana_discover_link_with_missing_kibana_discover_url():
     assert url is None
 
 
-def test_generate_kibana_discover_link_with_missing_kibana_discover_index_pattern_id():
-    url = generate_kibana_discover_link(
+def test_generate_kibana_discover_url_with_missing_kibana_discover_index_pattern_id():
+    url = generate_kibana_discover_url(
         rule={
-            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '6.8',
             'timestamp_field': 'timestamp',
             'name': 'test'
@@ -116,10 +116,10 @@ def test_generate_kibana_discover_link_with_missing_kibana_discover_index_patter
     assert url is None
 
 
-def test_generate_kibana_discover_link_with_invalid_kibana_version():
-    url = generate_kibana_discover_link(
+def test_generate_kibana_discover_url_with_invalid_kibana_version():
+    url = generate_kibana_discover_url(
         rule={
-            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '4.5',
             'kibana_discover_index_pattern_id': 'logs-*',
             'timestamp_field': 'timestamp'
@@ -131,14 +131,14 @@ def test_generate_kibana_discover_link_with_invalid_kibana_version():
     assert url is None
 
 
-def test_generate_kibana_discover_link_with_discover_url_env_substitution(environ):
+def test_generate_kibana_discover_url_with_kibana_discover_app_url_env_substitution(environ):
     environ.update({
         'KIBANA_HOST': 'kibana',
         'KIBANA_PORT': '5601',
     })
-    url = generate_kibana_discover_link(
+    url = generate_kibana_discover_url(
         rule={
-            'kibana_discover_url': 'http://$KIBANA_HOST:$KIBANA_PORT/#/discover',
+            'kibana_discover_app_url': 'http://$KIBANA_HOST:$KIBANA_PORT/#/discover',
             'kibana_discover_version': '6.8',
             'kibana_discover_index_pattern_id': 'd6cabfb6-aaef-44ea-89c5-600e9a76991a',
             'timestamp_field': 'timestamp'
@@ -167,10 +167,10 @@ def test_generate_kibana_discover_link_with_discover_url_env_substitution(enviro
     assert url == expectedUrl
 
 
-def test_generate_kibana_discover_link_with_from_timedelta():
-    url = generate_kibana_discover_link(
+def test_generate_kibana_discover_url_with_from_timedelta():
+    url = generate_kibana_discover_url(
         rule={
-            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '7.3',
             'kibana_discover_index_pattern_id': 'd6cabfb6-aaef-44ea-89c5-600e9a76991a',
             'kibana_discover_from_timedelta': timedelta(hours=1),
@@ -200,10 +200,10 @@ def test_generate_kibana_discover_link_with_from_timedelta():
     assert url == expectedUrl
 
 
-def test_generate_kibana_discover_link_with_from_timedelta_and_timeframe():
-    url = generate_kibana_discover_link(
+def test_generate_kibana_discover_url_with_from_timedelta_and_timeframe():
+    url = generate_kibana_discover_url(
         rule={
-            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '7.3',
             'kibana_discover_index_pattern_id': 'd6cabfb6-aaef-44ea-89c5-600e9a76991a',
             'kibana_discover_from_timedelta': timedelta(hours=1),
@@ -234,10 +234,10 @@ def test_generate_kibana_discover_link_with_from_timedelta_and_timeframe():
     assert url == expectedUrl
 
 
-def test_generate_kibana_discover_link_with_to_timedelta():
-    url = generate_kibana_discover_link(
+def test_generate_kibana_discover_url_with_to_timedelta():
+    url = generate_kibana_discover_url(
         rule={
-            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '7.3',
             'kibana_discover_index_pattern_id': 'd6cabfb6-aaef-44ea-89c5-600e9a76991a',
             'kibana_discover_to_timedelta': timedelta(hours=1),
@@ -267,10 +267,10 @@ def test_generate_kibana_discover_link_with_to_timedelta():
     assert url == expectedUrl
 
 
-def test_generate_kibana_discover_link_with_to_timedelta_and_timeframe():
-    url = generate_kibana_discover_link(
+def test_generate_kibana_discover_url_with_to_timedelta_and_timeframe():
+    url = generate_kibana_discover_url(
         rule={
-            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '7.3',
             'kibana_discover_index_pattern_id': 'd6cabfb6-aaef-44ea-89c5-600e9a76991a',
             'kibana_discover_to_timedelta': timedelta(hours=1),
@@ -301,10 +301,10 @@ def test_generate_kibana_discover_link_with_to_timedelta_and_timeframe():
     assert url == expectedUrl
 
 
-def test_generate_kibana_discover_link_with_timeframe():
-    url = generate_kibana_discover_link(
+def test_generate_kibana_discover_url_with_timeframe():
+    url = generate_kibana_discover_url(
         rule={
-            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '7.3',
             'kibana_discover_index_pattern_id': 'd6cabfb6-aaef-44ea-89c5-600e9a76991a',
             'timeframe': timedelta(minutes=20),
@@ -334,10 +334,10 @@ def test_generate_kibana_discover_link_with_timeframe():
     assert url == expectedUrl
 
 
-def test_generate_kibana_discover_link_with_custom_columns():
-    url = generate_kibana_discover_link(
+def test_generate_kibana_discover_url_with_custom_columns():
+    url = generate_kibana_discover_url(
         rule={
-            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '6.8',
             'kibana_discover_index_pattern_id': 'logs-*',
             'kibana_discover_columns': ['level', 'message'],
@@ -367,10 +367,10 @@ def test_generate_kibana_discover_link_with_custom_columns():
     assert url == expectedUrl
 
 
-def test_generate_kibana_discover_link_with_single_filter():
-    url = generate_kibana_discover_link(
+def test_generate_kibana_discover_url_with_single_filter():
+    url = generate_kibana_discover_url(
         rule={
-            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '6.8',
             'kibana_discover_index_pattern_id': 'logs-*',
             'timestamp_field': 'timestamp',
@@ -418,10 +418,10 @@ def test_generate_kibana_discover_link_with_single_filter():
     assert url == expectedUrl
 
 
-def test_generate_kibana_discover_link_with_multiple_filters():
-    url = generate_kibana_discover_link(
+def test_generate_kibana_discover_url_with_multiple_filters():
+    url = generate_kibana_discover_url(
         rule={
-            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '6.8',
             'kibana_discover_index_pattern_id': '90943e30-9a47-11e8-b64d-95841ca0b247',
             'timestamp_field': 'timestamp',
@@ -472,10 +472,10 @@ def test_generate_kibana_discover_link_with_multiple_filters():
     assert url == expectedUrl
 
 
-def test_generate_kibana_discover_link_with_int_query_key():
-    url = generate_kibana_discover_link(
+def test_generate_kibana_discover_url_with_int_query_key():
+    url = generate_kibana_discover_url(
         rule={
-            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '6.8',
             'kibana_discover_index_pattern_id': 'logs-*',
             'timestamp_field': 'timestamp',
@@ -532,10 +532,10 @@ def test_generate_kibana_discover_link_with_int_query_key():
     assert url == expectedUrl
 
 
-def test_generate_kibana_discover_link_with_str_query_key():
-    url = generate_kibana_discover_link(
+def test_generate_kibana_discover_url_with_str_query_key():
+    url = generate_kibana_discover_url(
         rule={
-            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '6.8',
             'kibana_discover_index_pattern_id': 'logs-*',
             'timestamp_field': 'timestamp',
@@ -594,10 +594,10 @@ def test_generate_kibana_discover_link_with_str_query_key():
     assert url == expectedUrl
 
 
-def test_generate_kibana_discover_link_with_null_query_key_value():
-    url = generate_kibana_discover_link(
+def test_generate_kibana_discover_url_with_null_query_key_value():
+    url = generate_kibana_discover_url(
         rule={
-            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '6.8',
             'kibana_discover_index_pattern_id': 'logs-*',
             'timestamp_field': 'timestamp',
@@ -644,10 +644,10 @@ def test_generate_kibana_discover_link_with_null_query_key_value():
     assert url == expectedUrl
 
 
-def test_generate_kibana_discover_link_with_missing_query_key_value():
-    url = generate_kibana_discover_link(
+def test_generate_kibana_discover_url_with_missing_query_key_value():
+    url = generate_kibana_discover_url(
         rule={
-            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '6.8',
             'kibana_discover_index_pattern_id': 'logs-*',
             'timestamp_field': 'timestamp',
@@ -693,10 +693,10 @@ def test_generate_kibana_discover_link_with_missing_query_key_value():
     assert url == expectedUrl
 
 
-def test_generate_kibana_discover_link_with_compound_query_key():
-    url = generate_kibana_discover_link(
+def test_generate_kibana_discover_url_with_compound_query_key():
+    url = generate_kibana_discover_url(
         rule={
-            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '6.8',
             'kibana_discover_index_pattern_id': 'logs-*',
             'timestamp_field': 'timestamp',
@@ -781,10 +781,10 @@ def test_generate_kibana_discover_link_with_compound_query_key():
     assert url == expectedUrl
 
 
-def test_generate_kibana_discover_link_with_filter_and_query_key():
-    url = generate_kibana_discover_link(
+def test_generate_kibana_discover_url_with_filter_and_query_key():
+    url = generate_kibana_discover_url(
         rule={
-            'kibana_discover_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '6.8',
             'kibana_discover_index_pattern_id': 'logs-*',
             'timestamp_field': 'timestamp',

--- a/tests/kibana_discover_test.py
+++ b/tests/kibana_discover_test.py
@@ -2,12 +2,12 @@
 from datetime import timedelta
 import pytest
 
-from elastalert.kibana_discover import kibana_discover_url
+from elastalert.kibana_discover import generate_kibana_discover_link
 
 
 @pytest.mark.parametrize("kibana_version", ['5.6', '6.0', '6.1', '6.2', '6.3', '6.4', '6.5', '6.6', '6.7', '6.8'])
-def test_kibana_discover_url_with_kibana_5x_and_6x(kibana_version):
-    url = kibana_discover_url(
+def test_generate_kibana_discover_link_with_kibana_5x_and_6x(kibana_version):
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': kibana_version,
@@ -39,8 +39,8 @@ def test_kibana_discover_url_with_kibana_5x_and_6x(kibana_version):
 
 
 @pytest.mark.parametrize("kibana_version", ['7.0', '7.1', '7.2', '7.3'])
-def test_kibana_discover_url_with_kibana_7x(kibana_version):
-    url = kibana_discover_url(
+def test_generate_kibana_discover_link_with_kibana_7x(kibana_version):
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': kibana_version,
@@ -71,8 +71,8 @@ def test_kibana_discover_url_with_kibana_7x(kibana_version):
     assert url == expectedUrl
 
 
-def test_kibana_discover_url_with_missing_kibana_discover_version():
-    url = kibana_discover_url(
+def test_generate_kibana_discover_link_with_missing_kibana_discover_version():
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_url': 'http://kibana:5601/#/discover',
             'kibana_discover_index_pattern_id': 'logs',
@@ -86,8 +86,8 @@ def test_kibana_discover_url_with_missing_kibana_discover_version():
     assert url is None
 
 
-def test_kibana_discover_url_with_missing_kibana_discover_url():
-    url = kibana_discover_url(
+def test_generate_kibana_discover_link_with_missing_kibana_discover_url():
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_version': '6.8',
             'kibana_discover_index_pattern_id': 'logs',
@@ -101,8 +101,8 @@ def test_kibana_discover_url_with_missing_kibana_discover_url():
     assert url is None
 
 
-def test_kibana_discover_url_with_missing_kibana_discover_index_pattern_id():
-    url = kibana_discover_url(
+def test_generate_kibana_discover_link_with_missing_kibana_discover_index_pattern_id():
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '6.8',
@@ -116,8 +116,8 @@ def test_kibana_discover_url_with_missing_kibana_discover_index_pattern_id():
     assert url is None
 
 
-def test_kibana_discover_url_with_invalid_kibana_version():
-    url = kibana_discover_url(
+def test_generate_kibana_discover_link_with_invalid_kibana_version():
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '4.5',
@@ -131,12 +131,12 @@ def test_kibana_discover_url_with_invalid_kibana_version():
     assert url is None
 
 
-def test_kibana_discover_url_with_discover_url_env_substitution(environ):
+def test_generate_kibana_discover_link_with_discover_url_env_substitution(environ):
     environ.update({
         'KIBANA_HOST': 'kibana',
         'KIBANA_PORT': '5601',
     })
-    url = kibana_discover_url(
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_url': 'http://$KIBANA_HOST:$KIBANA_PORT/#/discover',
             'kibana_discover_version': '6.8',
@@ -167,8 +167,8 @@ def test_kibana_discover_url_with_discover_url_env_substitution(environ):
     assert url == expectedUrl
 
 
-def test_kibana_discover_url_with_from_timedelta():
-    url = kibana_discover_url(
+def test_generate_kibana_discover_link_with_from_timedelta():
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '7.3',
@@ -200,8 +200,8 @@ def test_kibana_discover_url_with_from_timedelta():
     assert url == expectedUrl
 
 
-def test_kibana_discover_url_with_from_timedelta_and_timeframe():
-    url = kibana_discover_url(
+def test_generate_kibana_discover_link_with_from_timedelta_and_timeframe():
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '7.3',
@@ -234,8 +234,8 @@ def test_kibana_discover_url_with_from_timedelta_and_timeframe():
     assert url == expectedUrl
 
 
-def test_kibana_discover_url_with_to_timedelta():
-    url = kibana_discover_url(
+def test_generate_kibana_discover_link_with_to_timedelta():
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '7.3',
@@ -267,8 +267,8 @@ def test_kibana_discover_url_with_to_timedelta():
     assert url == expectedUrl
 
 
-def test_kibana_discover_url_with_to_timedelta_and_timeframe():
-    url = kibana_discover_url(
+def test_generate_kibana_discover_link_with_to_timedelta_and_timeframe():
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '7.3',
@@ -301,8 +301,8 @@ def test_kibana_discover_url_with_to_timedelta_and_timeframe():
     assert url == expectedUrl
 
 
-def test_kibana_discover_url_with_timeframe():
-    url = kibana_discover_url(
+def test_generate_kibana_discover_link_with_timeframe():
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '7.3',
@@ -334,8 +334,8 @@ def test_kibana_discover_url_with_timeframe():
     assert url == expectedUrl
 
 
-def test_kibana_discover_url_with_custom_columns():
-    url = kibana_discover_url(
+def test_generate_kibana_discover_link_with_custom_columns():
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '6.8',
@@ -367,8 +367,8 @@ def test_kibana_discover_url_with_custom_columns():
     assert url == expectedUrl
 
 
-def test_kibana_discover_url_with_single_filter():
-    url = kibana_discover_url(
+def test_generate_kibana_discover_link_with_single_filter():
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '6.8',
@@ -418,8 +418,8 @@ def test_kibana_discover_url_with_single_filter():
     assert url == expectedUrl
 
 
-def test_kibana_discover_url_with_multiple_filters():
-    url = kibana_discover_url(
+def test_generate_kibana_discover_link_with_multiple_filters():
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '6.8',
@@ -472,8 +472,8 @@ def test_kibana_discover_url_with_multiple_filters():
     assert url == expectedUrl
 
 
-def test_kibana_discover_url_with_int_query_key():
-    url = kibana_discover_url(
+def test_generate_kibana_discover_link_with_int_query_key():
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '6.8',
@@ -532,8 +532,8 @@ def test_kibana_discover_url_with_int_query_key():
     assert url == expectedUrl
 
 
-def test_kibana_discover_url_with_str_query_key():
-    url = kibana_discover_url(
+def test_generate_kibana_discover_link_with_str_query_key():
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '6.8',
@@ -594,8 +594,8 @@ def test_kibana_discover_url_with_str_query_key():
     assert url == expectedUrl
 
 
-def test_kibana_discover_url_with_null_query_key_value():
-    url = kibana_discover_url(
+def test_generate_kibana_discover_link_with_null_query_key_value():
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '6.8',
@@ -644,8 +644,8 @@ def test_kibana_discover_url_with_null_query_key_value():
     assert url == expectedUrl
 
 
-def test_kibana_discover_url_with_missing_query_key_value():
-    url = kibana_discover_url(
+def test_generate_kibana_discover_link_with_missing_query_key_value():
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '6.8',
@@ -693,8 +693,8 @@ def test_kibana_discover_url_with_missing_query_key_value():
     assert url == expectedUrl
 
 
-def test_kibana_discover_url_with_compound_query_key():
-    url = kibana_discover_url(
+def test_generate_kibana_discover_link_with_compound_query_key():
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '6.8',
@@ -781,8 +781,8 @@ def test_kibana_discover_url_with_compound_query_key():
     assert url == expectedUrl
 
 
-def test_kibana_discover_url_with_filter_and_query_key():
-    url = kibana_discover_url(
+def test_generate_kibana_discover_link_with_filter_and_query_key():
+    url = generate_kibana_discover_link(
         rule={
             'kibana_discover_url': 'http://kibana:5601/#/discover',
             'kibana_discover_version': '6.8',

--- a/tests/loaders_test.py
+++ b/tests/loaders_test.py
@@ -395,3 +395,23 @@ def test_raises_on_bad_generate_kibana_filters():
                 test_rule_copy['filter'] = good + bad
                 with pytest.raises(EAException):
                     rules_loader.load_configuration('blah', test_config)
+
+
+def test_kibana_discover_from_timedelta():
+    test_config_copy = copy.deepcopy(test_config)
+    rules_loader = FileRulesLoader(test_config_copy)
+    test_rule_copy = copy.deepcopy(test_rule)
+    test_rule_copy['kibana_discover_from_timedelta'] = {'minutes': 2}
+    rules_loader.load_options(test_rule_copy, test_config, 'filename.yaml')
+    assert isinstance(test_rule_copy['kibana_discover_from_timedelta'], datetime.timedelta)
+    assert test_rule_copy['kibana_discover_from_timedelta'] == datetime.timedelta(minutes=2)
+
+
+def test_kibana_discover_to_timedelta():
+    test_config_copy = copy.deepcopy(test_config)
+    rules_loader = FileRulesLoader(test_config_copy)
+    test_rule_copy = copy.deepcopy(test_rule)
+    test_rule_copy['kibana_discover_to_timedelta'] = {'minutes': 2}
+    rules_loader.load_options(test_rule_copy, test_config, 'filename.yaml')
+    assert isinstance(test_rule_copy['kibana_discover_to_timedelta'], datetime.timedelta)
+    assert test_rule_copy['kibana_discover_to_timedelta'] == datetime.timedelta(minutes=2)


### PR DESCRIPTION
This PR adds support generating Kibana links to the Discover application.  This is low overhead alternative to the existing dashboard mechanism.  At D2L we immediately that the creation and maintaining of dashboards to match the rules to be a deterrent.

Kibana uses the rison encoding ([rison-node](https://www.npmjs.com/package/rison-node)) to represent its global and application state.  By using the python encoder [prison](https://pypi.org/project/prison/) (MIT License), we can more easily build more complex links to Kibana.  I based the state on the same state produced by creating filters in the Kibana application.  This state has remained mostly the same between 5.x, 6.x, and 7.x.
