### PR TITLE
Fixing the outstanding documentation warnings

### DIFF
--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -203,7 +203,6 @@ The default value is ``.raw`` for Elasticsearch 2 and ``.keyword`` for Elasticse
 
 ``skip_invalid``: If ``True``, skip invalid files instead of exiting.
 
-=======
 Logging
 -------
 

--- a/docs/source/recipes/writing_filters.rst
+++ b/docs/source/recipes/writing_filters.rst
@@ -57,7 +57,7 @@ a field that appears to have the value "foo bar", unless it is not analyzed. Con
 matching on analyzed fields, use query_string. See https://www.elastic.co/guide/en/elasticsearch/guide/current/term-vs-full-text.html
 
 `terms <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html>`_
-*****
+*****************************************************************************************************
 
 
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1305,7 +1305,7 @@ With ``alert_text_type: aggregation_summary_only``::
     body                = rule_name
 
                           aggregation_summary
-+
+
 ruletype_text is the string returned by RuleType.get_match_str.
 
 field_values will contain every key value pair included in the results from Elasticsearch. These fields include "@timestamp" (or the value of ``timestamp_field``),
@@ -1689,7 +1689,7 @@ Provide absolute address of the pciture, for example: http://some.address.com/im
 ``slack_timeout``: You can specify a timeout value, in seconds, for making communicating with Slac. The default is 10. If a timeout occurs, the alert will be retried next time elastalert cycles.
 
 Mattermost
-~~~~~
+~~~~~~~~~~
 
 Mattermost alerter will send a notification to a predefined Mattermost channel. The body of the notification is formatted the same as with other alerters.
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,4 +27,4 @@ norecursedirs = .* virtualenv_run docs build venv env
 deps = {[testenv]deps}
     sphinx==1.6.6
 changedir = docs
-commands = sphinx-build -b html -d build/doctrees source build/html
+commands = sphinx-build -b html -d build/doctrees -W source build/html


### PR DESCRIPTION
From the latest master build:  https://travis-ci.org/Yelp/elastalert/jobs/585790045

```
/home/travis/build/Yelp/elastalert/docs/source/elastalert.rst:206: WARNING: Title overline & underline mismatch.
=======
Logging
-------
/home/travis/build/Yelp/elastalert/docs/source/recipes/writing_filters.rst:60: WARNING: Title underline too short.
`terms <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html>`_
*****
/home/travis/build/Yelp/elastalert/docs/source/recipes/writing_filters.rst:60: WARNING: Title underline too short.
`terms <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html>`_
*****
/home/travis/build/Yelp/elastalert/docs/source/ruletypes.rst:1308: WARNING: Literal block ends without a blank line; unexpected unindent.
/home/travis/build/Yelp/elastalert/docs/source/ruletypes.rst:1309: WARNING: Bullet list ends without a blank line; unexpected unindent.
/home/travis/build/Yelp/elastalert/docs/source/ruletypes.rst:1692: WARNING: Title underline too short.
Mattermost
~~~~~
/home/travis/build/Yelp/elastalert/docs/source/ruletypes.rst:1692: WARNING: Title underline too short.
Mattermost
~~~~~
```