### PR TITLE
Bug: import within import not getting imported

### DIFF
--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -193,6 +193,7 @@ class RulesLoader(object):
 
         self.import_rules.pop(filename, None)  # clear `filename` dependency
         while True:
+            rule['rule_file']=filename
             loaded = self.get_yaml(filename)
 
             # Special case for merging filters - if both files specify a filter merge (AND) them


### PR DESCRIPTION
Fix: updates the rule_name for every while loop causing it to import as many import within import within