### PR TITLE
Stop job when it gets disabled

### DIFF
--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -1049,6 +1049,15 @@ def test_rule_changes(ea):
             ea.load_rule_changes()
     assert len(ea.rules) == 4
 
+    # Disable a rule by removing the file
+    new_hashes.pop('rules/rule4.yaml')
+    with mock.patch.object(ea.conf['rules_loader'], 'get_hashes') as mock_hashes:
+        with mock.patch.object(ea.conf['rules_loader'], 'load_configuration') as mock_load:
+            mock_load.return_value = {'filter': [], 'name': 'rule4', 'new': 'stuff', 'rule_file': 'rules/rule4.yaml'}
+            mock_hashes.return_value = new_hashes
+            ea.load_rule_changes()
+    ea.scheduler.remove_job.assert_called_with(job_id='rule4')
+
 
 def test_strf_index(ea):
     """ Test that the get_index function properly generates indexes spanning days """


### PR DESCRIPTION
As a consequence of moving rules to run on a scheduler, they didn't actually get disabled properly when you removed the file.

Instead of just modifying self.rules, we need to call scheduler.remove_job too. To do that, I had to change the code so that we could grab it's name first before we delete it.

Tested this using a trivial example (some lines cut out)
```
INFO:elastalert:Ran test-rule-2 from 2019-09-23 14:05 PDT to 2019-09-23 14:50 PDT: 0 query hits (0 already seen), 0 matches, 0 alerts sent
INFO:elastalert:Ran test-rule from 2019-09-23 14:05 PDT to 2019-09-23 14:50 PDT: 0 query hits (0 already seen), 0 matches, 0 alerts sent
INFO:elastalert:Background alerts thread 0 pending alerts sent at 2019-09-23 14:51 PDT
INFO:elastalert:Rule file elastalert_rules/test_2.yaml not found, stopping rule execution
INFO:elastalert:Background configuration change check run at 2019-09-23 14:51 PDT
INFO:elastalert:Disabled rules are: []
INFO:elastalert:Sleeping for 29.999797 seconds
INFO:elastalert:Ran test-rule from 2019-09-23 14:06 PDT to 2019-09-23 14:51 PDT: 0 query hits (0 already seen), 0 matches, 0 alerts sent
INFO:elastalert:Background alerts thread 0 pending alerts sent at 2019-09-23 14:51 PDT
INFO:elastalert:Background configuration change check run at 2019-09-23 14:51 PDT
INFO:elastalert:Disabled rules are: []
INFO:elastalert:Sleeping for 29.999795 seconds
...
```