### PR TITLE
Adding ability to specify opsgenie alert details

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1648,6 +1648,15 @@ Optional:
 
 ``opsgenie_priority``: Set the OpsGenie priority level. Possible values are P1, P2, P3, P4, P5.
 
+``opsgenie_details``: Map of custom key/value pairs to include in the alert's details. The value can sourced from either fields in the first match, environment variables, or a constant value.
+
+Example usage::
+
+    opsgenie_details:
+      Author: 'Bob Smith'          # constant value
+      Environment: '$VAR'          # environment variable
+      Message: { field: message }  # field in the first match
+
 SNS
 ~~~
 

--- a/elastalert/opsgenie.py
+++ b/elastalert/opsgenie.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 import logging
-
+import os.path
 import requests
 
 from .alerts import Alerter
@@ -33,6 +33,7 @@ class OpsGenieAlerter(Alerter):
         self.alias = self.rule.get('opsgenie_alias')
         self.opsgenie_proxy = self.rule.get('opsgenie_proxy', None)
         self.priority = self.rule.get('opsgenie_priority')
+        self.opsgenie_details = self.rule.get('opsgenie_details', {})
 
     def _parse_responders(self, responders, responder_args, matches, default_responders):
         if responder_args:
@@ -96,6 +97,10 @@ class OpsGenieAlerter(Alerter):
 
         if self.alias is not None:
             post['alias'] = self.alias.format(**matches[0])
+
+        details = self.get_details(matches)
+        if details:
+            post['details'] = details
 
         logging.debug(json.dumps(post))
 
@@ -162,3 +167,19 @@ class OpsGenieAlerter(Alerter):
         if self.teams:
             ret['teams'] = self.teams
         return ret
+
+    def get_details(self, matches):
+        details = {}
+
+        for key, value in self.opsgenie_details.items():
+
+            if type(value) is dict:
+                if 'field' in value:
+                    field_value = lookup_es_key(matches[0], value['field'])
+                    if field_value is not None:
+                        details[key] = str(field_value)
+
+            elif type(value) is str:
+                details[key] = os.path.expandvars(value)
+
+        return details

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -298,6 +298,20 @@ properties:
   mattermost_msg_pretext: {type: string}
   mattermost_msg_fields: *mattermostField
 
+  ## Opsgenie
+  opsgenie_details:
+    type: object
+    minProperties: 1
+    patternProperties:
+      "^.+$":
+        oneOf:
+          - type: string
+          - type: object
+            additionalProperties: false
+            required: [field]
+            properties:
+              field: {type: string, minLength: 1}
+
   ### PagerDuty
   pagerduty_service_key: {type: string}
   pagerduty_client_name: {type: string}


### PR DESCRIPTION
Adding support for Opsgenie alert details, that show up as extra properties.  Details are a key/value pair map.

https://docs.opsgenie.com/docs/alert-api#section-create-alert

Example config:

```
opsgenie_details:
  Kibana Url: { field: kibana_discover_url }
  Message: { field: message }
  Testing: 'yes'
```

![image](https://user-images.githubusercontent.com/12101120/65717766-1385b700-e070-11e9-93ac-1c83a2ab6341.png)
