### PR TITLE
Adding a timeout to all requests calls

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1039,11 +1039,17 @@ class HipChatAlerter(Alerter):
                     headers=headers,
                     verify=not self.hipchat_ignore_ssl_errors,
                     proxies=proxies,
-                    timeout=self.post_timeout)
+                    timeout=self.post_timeout
+                )
 
-            response = requests.post(self.url, data=json.dumps(payload, cls=DateTimeEncoder), headers=headers,
-                                     verify=not self.hipchat_ignore_ssl_errors,
-                                     proxies=proxies, timeout=self.post_timeout)
+            response = requests.post(
+                self.url,
+                data=json.dumps(payload, cls=DateTimeEncoder),
+                headers=headers,
+                verify=not self.hipchat_ignore_ssl_errors,
+                proxies=proxies,
+                timeout=self.post_timeout
+            )
             warnings.resetwarnings()
             response.raise_for_status()
         except RequestException as e:
@@ -1069,7 +1075,6 @@ class MsTeamsAlerter(Alerter):
         self.ms_teams_alert_fixed_width = self.rule.get('ms_teams_alert_fixed_width', False)
         self.ms_teams_theme_color = self.rule.get('ms_teams_theme_color', '')
         self.post_timeout = self.rule.get('ms_teams_post_timeout', 10)
-        
 
     def format_body(self, body):
         if self.ms_teams_alert_fixed_width:
@@ -1097,7 +1102,13 @@ class MsTeamsAlerter(Alerter):
 
         for url in self.ms_teams_webhook_url:
             try:
-                response = requests.post(url, data=json.dumps(payload, cls=DateTimeEncoder), headers=headers, proxies=proxies, timeout=self.post_timeout)
+                response = requests.post(
+                    url,
+                    data=json.dumps(payload, cls=DateTimeEncoder),
+                    headers=headers,
+                    proxies=proxies,
+                    timeout=self.post_timeout
+                )
                 response.raise_for_status()
             except RequestException as e:
                 raise EAException("Error posting to ms teams: %s" % e)
@@ -1209,7 +1220,8 @@ class SlackAlerter(Alerter):
                         url, data=json.dumps(payload, cls=DateTimeEncoder),
                         headers=headers, verify=verify,
                         proxies=proxies,
-                        timeout=self.post_timeout)
+                        timeout=self.post_timeout
+                    )
                     warnings.resetwarnings()
                     response.raise_for_status()
                 except RequestException as e:
@@ -1315,9 +1327,13 @@ class MattermostAlerter(Alerter):
                     requests.urllib3.disable_warnings()
 
                 response = requests.post(
-                    url, data=json.dumps(payload, cls=DateTimeEncoder),
-                    headers=headers, verify=not self.mattermost_ignore_ssl_errors,
-                    proxies=proxies, timeout=self.post_timeout)
+                    url,
+                    data=json.dumps(payload, cls=DateTimeEncoder),
+                    headers=headers,
+                    verify=not self.mattermost_ignore_ssl_errors,
+                    proxies=proxies,
+                    timeout=self.post_timeout
+                )
 
                 warnings.resetwarnings()
                 response.raise_for_status()
@@ -1490,7 +1506,13 @@ class PagerTreeAlerter(Alerter):
         }
 
         try:
-            response = requests.post(self.url, data=json.dumps(payload, cls=DateTimeEncoder), headers=headers, proxies=proxies, timeout=self.post_timeout)
+            response = requests.post(
+                self.url,
+                data=json.dumps(payload, cls=DateTimeEncoder),
+                headers=headers,
+                proxies=proxies,
+                timeout=self.post_timeout
+            )
             response.raise_for_status()
         except RequestException as e:
             raise EAException("Error posting to PagerTree: %s" % e)
@@ -1589,7 +1611,13 @@ class VictorOpsAlerter(Alerter):
             payload["entity_id"] = self.victorops_entity_id
 
         try:
-            response = requests.post(self.url, data=json.dumps(payload, cls=DateTimeEncoder), headers=headers, proxies=proxies, timeout=self.post_timeout)
+            response = requests.post(
+                self.url,
+                data=json.dumps(payload, cls=DateTimeEncoder),
+                headers=headers,
+                proxies=proxies,
+                timeout=self.post_timeout
+            )
             response.raise_for_status()
         except RequestException as e:
             raise EAException("Error posting to VictorOps: %s" % e)
@@ -1638,7 +1666,14 @@ class TelegramAlerter(Alerter):
         }
 
         try:
-            response = requests.post(self.url, data=json.dumps(payload, cls=DateTimeEncoder), headers=headers, proxies=proxies, auth=auth, timeout=self.post_timeout)
+            response = requests.post(
+                self.url,
+                data=json.dumps(payload, cls=DateTimeEncoder),
+                headers=headers,
+                proxies=proxies,
+                auth=auth,
+                timeout=self.post_timeout
+            )
             warnings.resetwarnings()
             response.raise_for_status()
         except RequestException as e:
@@ -1731,7 +1766,12 @@ class GoogleChatAlerter(Alerter):
         headers = {'content-type': 'application/json'}
         for url in self.googlechat_webhook_url:
             try:
-                response = requests.post(url, data=json.dumps(message), headers=headers, timeout=self.post_timeout)
+                response = requests.post(
+                    url,
+                    data=json.dumps(message),
+                    headers=headers,
+                    timeout=self.post_timeout
+                )
                 response.raise_for_status()
             except RequestException as e:
                 raise EAException("Error posting to google chat: {}".format(e))
@@ -1766,7 +1806,13 @@ class GitterAlerter(Alerter):
         }
 
         try:
-            response = requests.post(self.gitter_webhook_url, json.dumps(payload, cls=DateTimeEncoder), headers=headers, proxies=proxies, timeout=self.post_timeout)
+            response = requests.post(
+                self.gitter_webhook_url,
+                json.dumps(payload, cls=DateTimeEncoder),
+                headers=headers,
+                proxies=proxies,
+                timeout=self.post_timeout
+            )
             response.raise_for_status()
         except RequestException as e:
             raise EAException("Error posting to Gitter: %s" % e)
@@ -1882,7 +1928,13 @@ class AlertaAlerter(Alerter):
         alerta_payload = self.get_json_payload(matches[0])
 
         try:
-            response = requests.post(self.url, data=alerta_payload, headers=headers, verify=self.verify_ssl, timeout=self.post_timeout)
+            response = requests.post(
+                self.url,
+                data=alerta_payload,
+                headers=headers,
+                verify=self.verify_ssl,
+                timeout=self.post_timeout
+            )
             response.raise_for_status()
         except RequestException as e:
             raise EAException("Error posting to Alerta: %s" % e)
@@ -1980,8 +2032,13 @@ class HTTPPostAlerter(Alerter):
             proxies = {'https': self.post_proxy} if self.post_proxy else None
             for url in self.post_url:
                 try:
-                    response = requests.post(url, data=json.dumps(payload, cls=DateTimeEncoder),
-                                             headers=headers, proxies=proxies, timeout=self.post_timeout)
+                    response = requests.post(
+                        url,
+                        data=json.dumps(payload, cls=DateTimeEncoder),
+                        headers=headers,
+                        proxies=proxies,
+                        timeout=self.post_timeout
+                    )
                     response.raise_for_status()
                 except RequestException as e:
                     raise EAException("Error posting HTTP Post alert: %s" % e)
@@ -2070,9 +2127,13 @@ class StrideAlerter(Alerter):
             if self.stride_ignore_ssl_errors:
                 requests.packages.urllib3.disable_warnings()
             response = requests.post(
-                self.url, data=json.dumps(payload, cls=DateTimeEncoder),
-                headers=headers, verify=not self.stride_ignore_ssl_errors,
-                proxies=proxies, timeout=self.post_timeout)
+                self.url,
+                data=json.dumps(payload, cls=DateTimeEncoder),
+                headers=headers,
+                verify=not self.stride_ignore_ssl_errors,
+                proxies=proxies,
+                timeout=self.post_timeout
+            )
             warnings.resetwarnings()
             response.raise_for_status()
         except RequestException as e:
@@ -2106,7 +2167,12 @@ class LineNotifyAlerter(Alerter):
             "message": body
         }
         try:
-            response = requests.post("https://notify-api.line.me/api/notify", data=payload, headers=headers, timeout=self.post_timeout)
+            response = requests.post(
+                "https://notify-api.line.me/api/notify",
+                data=payload,
+                headers=headers,
+                timeout=self.post_timeout
+            )
             response.raise_for_status()
         except RequestException as e:
             raise EAException("Error posting to Line Notify: %s" % e)

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -903,7 +903,7 @@ def test_ms_teams():
         rule['ms_teams_webhook_url'],
         data=mock.ANY,
         headers={'content-type': 'application/json'},
-        proxies=None
+        proxies=None, timeout=10
     )
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
@@ -943,7 +943,8 @@ def test_ms_teams_uses_color_and_fixed_width_text():
         rule['ms_teams_webhook_url'],
         data=mock.ANY,
         headers={'content-type': 'application/json'},
-        proxies=None
+        proxies=None,
+        timeout=10
     )
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
@@ -1317,7 +1318,7 @@ def test_pagerduty_alerter():
         'service_key': 'magicalbadgers',
     }
     mock_post_request.assert_called_once_with('https://events.pagerduty.com/generic/2010-04-15/create_event.json',
-                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, timeout=10)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -1363,7 +1364,7 @@ def test_pagerduty_alerter_v2():
         'routing_key': 'magicalbadgers',
     }
     mock_post_request.assert_called_once_with('https://events.pagerduty.com/v2/enqueue',
-                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, timeout=10)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -1395,7 +1396,7 @@ def test_pagerduty_alerter_custom_incident_key():
         'incident_key': 'custom key',
         'service_key': 'magicalbadgers',
     }
-    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, timeout=10)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -1428,7 +1429,7 @@ def test_pagerduty_alerter_custom_incident_key_with_args():
         'incident_key': 'custom foobarbaz',
         'service_key': 'magicalbadgers',
     }
-    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, timeout=10)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -1462,7 +1463,7 @@ def test_pagerduty_alerter_custom_alert_subject():
         'incident_key': 'custom foobarbaz',
         'service_key': 'magicalbadgers',
     }
-    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, timeout=10)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -1498,7 +1499,7 @@ def test_pagerduty_alerter_custom_alert_subject_with_args():
         'incident_key': 'custom foobarbaz',
         'service_key': 'magicalbadgers',
     }
-    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, timeout=10)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -1535,7 +1536,7 @@ def test_pagerduty_alerter_custom_alert_subject_with_args_specifying_trigger():
         'incident_key': 'custom foobarbaz',
         'service_key': 'magicalbadgers',
     }
-    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, timeout=10)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -1669,7 +1670,8 @@ def test_stride_plain_text():
             'content-type': 'application/json',
             'Authorization': 'Bearer {}'.format(rule['stride_access_token'])},
         verify=True,
-        proxies=None
+        proxies=None,
+        timeout=10
     )
     assert expected_data == json.loads(
         mock_post_request.call_args_list[0][1]['data'])
@@ -1715,7 +1717,8 @@ def test_stride_underline_text():
             'content-type': 'application/json',
             'Authorization': 'Bearer {}'.format(rule['stride_access_token'])},
         verify=True,
-        proxies=None
+        proxies=None,
+        timeout=10
     )
     assert expected_data == json.loads(
         mock_post_request.call_args_list[0][1]['data'])
@@ -1761,7 +1764,8 @@ def test_stride_bold_text():
             'content-type': 'application/json',
             'Authorization': 'Bearer {}'.format(rule['stride_access_token'])},
         verify=True,
-        proxies=None
+        proxies=None,
+        timeout=10
     )
     assert expected_data == json.loads(
         mock_post_request.call_args_list[0][1]['data'])
@@ -1807,7 +1811,8 @@ def test_stride_strong_text():
             'content-type': 'application/json',
             'Authorization': 'Bearer {}'.format(rule['stride_access_token'])},
         verify=True,
-        proxies=None
+        proxies=None,
+        timeout=10
     )
     assert expected_data == json.loads(
         mock_post_request.call_args_list[0][1]['data'])
@@ -1853,7 +1858,8 @@ def test_stride_hyperlink():
             'content-type': 'application/json',
             'Authorization': 'Bearer {}'.format(rule['stride_access_token'])},
         verify=True,
-        proxies=None
+        proxies=None,
+        timeout=10
     )
     assert expected_data == json.loads(
         mock_post_request.call_args_list[0][1]['data'])
@@ -1902,7 +1908,8 @@ def test_stride_html():
             'content-type': 'application/json',
             'Authorization': 'Bearer {}'.format(rule['stride_access_token'])},
         verify=True,
-        proxies=None
+        proxies=None,
+        timeout=10
     )
     assert expected_data == json.loads(
         mock_post_request.call_args_list[0][1]['data'])
@@ -2024,7 +2031,8 @@ def test_alerta_no_auth(ea):
         data=mock.ANY,
         headers={
             'content-type': 'application/json'},
-        verify=False
+        verify=False,
+        timeout=10
     )
     assert expected_data == json.loads(
         mock_post_request.call_args_list[0][1]['data'])
@@ -2059,6 +2067,7 @@ def test_alerta_auth(ea):
         alert.url,
         data=mock.ANY,
         verify=True,
+        timeout=10,
         headers={
             'content-type': 'application/json',
             'Authorization': 'Key {}'.format(rule['alerta_api_key'])})
@@ -2123,7 +2132,8 @@ def test_alerta_new_style(ea):
         data=mock.ANY,
         verify=True,
         headers={
-            'content-type': 'application/json'}
+            'content-type': 'application/json'},
+        timeout=10
     )
     assert expected_data == json.loads(
         mock_post_request.call_args_list[0][1]['data'])

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -1396,7 +1396,13 @@ def test_pagerduty_alerter_custom_incident_key():
         'incident_key': 'custom key',
         'service_key': 'magicalbadgers',
     }
-    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, timeout=10)
+    mock_post_request.assert_called_once_with(
+        alert.url,
+        data=mock.ANY,
+        headers={'content-type': 'application/json'},
+        proxies=None,
+        timeout=10
+    )
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -1429,7 +1435,13 @@ def test_pagerduty_alerter_custom_incident_key_with_args():
         'incident_key': 'custom foobarbaz',
         'service_key': 'magicalbadgers',
     }
-    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, timeout=10)
+    mock_post_request.assert_called_once_with(
+        alert.url,
+        data=mock.ANY,
+        headers={'content-type': 'application/json'},
+        proxies=None,
+        timeout=10
+    )
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -1463,7 +1475,13 @@ def test_pagerduty_alerter_custom_alert_subject():
         'incident_key': 'custom foobarbaz',
         'service_key': 'magicalbadgers',
     }
-    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, timeout=10)
+    mock_post_request.assert_called_once_with(
+        alert.url,
+        data=mock.ANY,
+        headers={'content-type': 'application/json'},
+        proxies=None,
+        timeout=10
+    )
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -1499,7 +1517,13 @@ def test_pagerduty_alerter_custom_alert_subject_with_args():
         'incident_key': 'custom foobarbaz',
         'service_key': 'magicalbadgers',
     }
-    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, timeout=10)
+    mock_post_request.assert_called_once_with(
+        alert.url,
+        data=mock.ANY,
+        headers={'content-type': 'application/json'},
+        proxies=None,
+        timeout=10
+    )
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -1536,7 +1560,13 @@ def test_pagerduty_alerter_custom_alert_subject_with_args_specifying_trigger():
         'incident_key': 'custom foobarbaz',
         'service_key': 'magicalbadgers',
     }
-    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, timeout=10)
+    mock_post_request.assert_called_once_with(
+        alert.url,
+        data=mock.ANY,
+        headers={'content-type': 'application/json'},
+        proxies=None,
+        timeout=10
+    )
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 


### PR DESCRIPTION
There  is no default timeout value for the python requests module - some alerts had a default, most did not, I have duplicated the format used by the http post alert to all the other alerts using a requests post.

All have a default of 10 seconds, overridable by a config item