### PR TITLE
Add dockerfile linter to pre-commit and clean up Dockerfile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,9 @@ repos:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
         exclude: .*tests/.*|.*yelp/testing/.*|\.pre-commit-config\.yaml
+
+-   repo: https://github.com/pryorda/dockerfilelint-precommit-hooks
+    rev: v0.1.0
+    hooks:
+    -   id: dockerfilelint
+        stages: [commit]

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,9 +1,18 @@
-FROM ubuntu:latest
+FROM ubuntu:18.04
 
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get -y install build-essential python3.6 python3.6-dev python3-pip libssl-dev git
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+        libssl-dev \
+        python3-pip \
+        python3.6-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /home/elastalert
 
-ADD requirements*.txt ./
-RUN pip3 install -r requirements-dev.txt
+COPY requirements*.txt ./
+
+RUN pip3 install -U pip setuptools \
+        && /usr/local/bin/pip3 install -r requirements-dev.txt


### PR DESCRIPTION
1. Added dockerlint to pre-commit.
2. Minimized the number of dependent packages.  
3. Pinned the FROM to ubuntu:18.04.
4. Use pip to update pip and then make sure we are using it.