### PR TITLE
Enable to select whether to prohibit enhancement from being run on alert information to be written back to ES

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -625,6 +625,11 @@ run_enhancements_first
 or dropped before affecting realert or being added to an aggregation. Silence stashes will still be created before the
 enhancement runs, meaning even if a ``DropMatchException`` is raised, the rule will still be silenced. (Optional, boolean, default false)
 
+block_enhancements_in_writeback
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``block_enhancements_in_writeback``: If true, enhancements will be run only on the content of alerts send by Alerters,
+whereas info about the alerts to be written back into Elasticsearch will not processed by enhancements. (Optional, boolean, default false)
+
 query_key
 ^^^^^^^^^
 


### PR DESCRIPTION
# Background and problem

With running enhancements, the data type of elements in a match could be changed from original one due to the enhancements.
As a result, when the data type that Elasticsearch's writeback_index expects does not match the data type in a match to be written to ES, trying to write alert info to Elasticsearch will fail. 

This problem especially tends to occur when using enhancements that change the format of @timestamp (or timestamp_field).
In that case, the following error would appear.

```
ERROR:root:Error writing alert info to Elasticsearch: RequestError(400, 'mapper_parsing_exception', "failed to parse field [match_time] of type [date] in document with id 'XXXXXXXXXXX'")
Traceback (most recent call last):
  File "/<path_to>/venv/lib/python3.6/site-packages/elastalert/elastalert.py", line 1625, in writeback
    res = self.writeback_es.index(index=index, body=body)
  File "/<path_to>/venv/lib/python3.6/site-packages/elasticsearch/client/utils.py", line 84, in _wrapped
    return func(*args, params=params, **kwargs)
  File "/<path_to>/venv/lib/python3.6/site-packages/elasticsearch/client/__init__.py", line 364, in index
    "POST", _make_path(index, doc_type, id), params=params, body=body
  File "/<path_to>/venv/lib/python3.6/site-packages/elasticsearch/transport.py", line 350, in perform_request
    timeout=timeout,
  File "/<path_to>/venv/lib/python3.6/site-packages/elasticsearch/connection/http_requests.py", line 156, in perform_request
    self._raise_error(response.status_code, raw_data)
  File "/<path_to>/venv/lib/python3.6/site-packages/elasticsearch/connection/base.py", line 181, in _raise_error
    status_code, error_message, additional_info
elasticsearch.exceptions.RequestError: RequestError(400, 'mapper_parsing_exception', "failed to parse field [match_time] of type [date] in document with id 'XXXXXXXXXXX'")
```

Several related issues have also been reported.
#1047 #2036

# Cause
The cause of this problem is that, in the current code, it is the alert info modified by enhancements that will be written back to ES. 

# Solution
Add an option which realizes that enhancements will be run only on the content of alerts send by Alerters, whereas info about the alerts to be written back into Elasticsearch will not processed by enhancements.
