### PR TITLE
updated rules_mapping to include spike_aggregation

### DIFF
--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -50,6 +50,7 @@ class RulesLoader(object):
         'cardinality': ruletypes.CardinalityRule,
         'metric_aggregation': ruletypes.MetricAggregationRule,
         'percentage_match': ruletypes.PercentageMatchRule,
+        'spike_aggregation': ruletypes.SpikeMetricAggregationRule,
     }
 
     # Used to map names of alerts to their classes


### PR DESCRIPTION
Was getting message "elastalert.util.EAException: Error loading file rules/apache_busy.yaml: Could not import module spike_aggregation: not enough values to unpack (expected 2, got 1)". Adding rule to mapping fixed issue.