### PR TITLE
run on single writeback index option

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -59,6 +59,9 @@ es_port: 9200
 writeback_index: elastalert_status
 writeback_alias: elastalert_alerts
 
+#If you need elastalert to run on a single writeback index
+#run_on_single_index: True
+
 # If an alert fails for some reason, ElastAlert will retry
 # sending the alert until this time period has elapsed
 alert_time_limit:

--- a/docs/source/running_elastalert.rst
+++ b/docs/source/running_elastalert.rst
@@ -70,6 +70,8 @@ Next, open up config.yaml.example. In it, you will find several configuration op
 
 ``writeback_index`` is the name of the index in which ElastAlert will store data. We will create this index later.
 
+``run_on_single_index``: Optional; If ``True``, elastalert will only use a single writeback index instead of five. 
+
 ``alert_time_limit`` is the retry window for failed alerts.
 
 Save the file as ``config.yaml``

--- a/elastalert/__init__.py
+++ b/elastalert/__init__.py
@@ -54,6 +54,15 @@ class ElasticSearchClient(Elasticsearch):
                     time.sleep(3)
         return self._es_version
 
+    def run_on_single_index(self):
+        """
+        Returns True if elastalert has to run on a single index
+        """
+        if "run_on_single_index" in self._conf:
+            if self._conf["run_on_single_index"] is True:
+                return True
+        return False
+        
     def is_atleastfive(self):
         """
         Returns True when the Elasticsearch server version >= 5
@@ -90,6 +99,9 @@ class ElasticSearchClient(Elasticsearch):
         """ In ES6, you cannot have multiple _types per index,
         therefore we use self.writeback_index as the prefix for the actual
         index name, based on doc_type. """
+        if self.run_on_single_index():
+            return writeback_index
+            
         if not self.is_atleastsix():
             return writeback_index
         elif doc_type == 'silence':

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -19,7 +19,7 @@ from .auth import Auth
 env = Env(ES_USE_SSL=bool)
 
 
-def create_index_mappings(es_client, ea_index, recreate=False, old_ea_index=None):
+def create_index_mappings(es_client, ea_index, recreate=False, old_ea_index=None, single_index=False):
     esversion = es_client.info()["version"]["number"]
     print("Elastic Version: " + esversion)
 
@@ -32,7 +32,12 @@ def create_index_mappings(es_client, ea_index, recreate=False, old_ea_index=None
             return None
 
     # (Re-)Create indices.
-    if is_atleastsix(esversion):
+    if single_index or not is_atleastsix(esversion):
+        index_names = (
+            ea_index,
+        )
+
+    else:
         index_names = (
             ea_index,
             ea_index + '_status',
@@ -40,10 +45,7 @@ def create_index_mappings(es_client, ea_index, recreate=False, old_ea_index=None
             ea_index + '_error',
             ea_index + '_past',
         )
-    else:
-        index_names = (
-            ea_index,
-        )
+
     for index_name in index_names:
         if es_index.exists(index_name):
             print('Deleting index ' + index_name + '.')
@@ -60,38 +62,51 @@ def create_index_mappings(es_client, ea_index, recreate=False, old_ea_index=None
     if is_atleastseven(esversion):
         # TODO remove doc_type completely when elasicsearch client allows doc_type=None
         # doc_type is a deprecated feature and will be completely removed in Elasicsearch 8
-        es_client.indices.put_mapping(index=ea_index, doc_type='_doc',
-                                      body=es_index_mappings['elastalert'], include_type_name=True)
-        es_client.indices.put_mapping(index=ea_index + '_status', doc_type='_doc',
-                                      body=es_index_mappings['elastalert_status'], include_type_name=True)
-        es_client.indices.put_mapping(index=ea_index + '_silence', doc_type='_doc',
-                                      body=es_index_mappings['silence'], include_type_name=True)
-        es_client.indices.put_mapping(index=ea_index + '_error', doc_type='_doc',
-                                      body=es_index_mappings['elastalert_error'], include_type_name=True)
-        es_client.indices.put_mapping(index=ea_index + '_past', doc_type='_doc',
-                                      body=es_index_mappings['past_elastalert'], include_type_name=True)
+        
+        if single_index:
+            es_client.indices.put_mapping(index=ea_index, doc_type='_doc',
+                                          body=es_index_mappings['elastalert_single'], include_type_name=True)
+        else:
+            es_client.indices.put_mapping(index=ea_index, doc_type='_doc',
+                                          body=es_index_mappings['elastalert'], include_type_name=True)
+            es_client.indices.put_mapping(index=ea_index + '_status', doc_type='_doc',
+                                          body=es_index_mappings['elastalert_status'], include_type_name=True)
+            es_client.indices.put_mapping(index=ea_index + '_silence', doc_type='_doc',
+                                          body=es_index_mappings['silence'], include_type_name=True)
+            es_client.indices.put_mapping(index=ea_index + '_error', doc_type='_doc',
+                                          body=es_index_mappings['elastalert_error'], include_type_name=True)
+            es_client.indices.put_mapping(index=ea_index + '_past', doc_type='_doc',
+                                          body=es_index_mappings['past_elastalert'], include_type_name=True)
     elif is_atleastsixtwo(esversion):
-        es_client.indices.put_mapping(index=ea_index, doc_type='_doc',
-                                      body=es_index_mappings['elastalert'])
-        es_client.indices.put_mapping(index=ea_index + '_status', doc_type='_doc',
-                                      body=es_index_mappings['elastalert_status'])
-        es_client.indices.put_mapping(index=ea_index + '_silence', doc_type='_doc',
-                                      body=es_index_mappings['silence'])
-        es_client.indices.put_mapping(index=ea_index + '_error', doc_type='_doc',
-                                      body=es_index_mappings['elastalert_error'])
-        es_client.indices.put_mapping(index=ea_index + '_past', doc_type='_doc',
-                                      body=es_index_mappings['past_elastalert'])
+        if single_index:
+            es_client.indices.put_mapping(index=ea_index, doc_type='_doc',
+                                          body=es_index_mappings['elastalert_single'])
+        else:
+            es_client.indices.put_mapping(index=ea_index, doc_type='_doc',
+                                          body=es_index_mappings['elastalert'])
+            es_client.indices.put_mapping(index=ea_index + '_status', doc_type='_doc',
+                                          body=es_index_mappings['elastalert_status'])
+            es_client.indices.put_mapping(index=ea_index + '_silence', doc_type='_doc',
+                                          body=es_index_mappings['silence'])
+            es_client.indices.put_mapping(index=ea_index + '_error', doc_type='_doc',
+                                          body=es_index_mappings['elastalert_error'])
+            es_client.indices.put_mapping(index=ea_index + '_past', doc_type='_doc',
+                                          body=es_index_mappings['past_elastalert'])
     elif is_atleastsix(esversion):
-        es_client.indices.put_mapping(index=ea_index, doc_type='elastalert',
-                                      body=es_index_mappings['elastalert'])
-        es_client.indices.put_mapping(index=ea_index + '_status', doc_type='elastalert_status',
-                                      body=es_index_mappings['elastalert_status'])
-        es_client.indices.put_mapping(index=ea_index + '_silence', doc_type='silence',
-                                      body=es_index_mappings['silence'])
-        es_client.indices.put_mapping(index=ea_index + '_error', doc_type='elastalert_error',
-                                      body=es_index_mappings['elastalert_error'])
-        es_client.indices.put_mapping(index=ea_index + '_past', doc_type='past_elastalert',
-                                      body=es_index_mappings['past_elastalert'])
+        if single_index:
+            es_client.indices.put_mapping(index=ea_index, doc_type='elastalert',
+                                          body=es_index_mappings['elastalert_single'])
+        else:
+            es_client.indices.put_mapping(index=ea_index, doc_type='elastalert',
+                                          body=es_index_mappings['elastalert'])
+            es_client.indices.put_mapping(index=ea_index + '_status', doc_type='elastalert_status',
+                                          body=es_index_mappings['elastalert_status'])
+            es_client.indices.put_mapping(index=ea_index + '_silence', doc_type='silence',
+                                          body=es_index_mappings['silence'])
+            es_client.indices.put_mapping(index=ea_index + '_error', doc_type='elastalert_error',
+                                          body=es_index_mappings['elastalert_error'])
+            es_client.indices.put_mapping(index=ea_index + '_past', doc_type='past_elastalert',
+                                          body=es_index_mappings['past_elastalert'])
     else:
         es_client.indices.put_mapping(index=ea_index, doc_type='elastalert',
                                       body=es_index_mappings['elastalert'])
@@ -120,7 +135,8 @@ def read_es_index_mappings(es_version=6):
         'elastalert_status': read_es_index_mapping('elastalert_status', es_version),
         'elastalert': read_es_index_mapping('elastalert', es_version),
         'past_elastalert': read_es_index_mapping('past_elastalert', es_version),
-        'elastalert_error': read_es_index_mapping('elastalert_error', es_version)
+        'elastalert_error': read_es_index_mapping('elastalert_error', es_version),
+        'elastalert_single': read_es_index_mapping('elastalert_single', es_version)
     }
 
 
@@ -160,6 +176,7 @@ def main():
     parser.add_argument('--no-verify-certs', dest='verify_certs', action='store_false',
                         help='Do not verify TLS certificates')
     parser.add_argument('--index', help='Index name to create')
+    parser.add_argument('--single-index', action='store_true', default=None, help='Create one single index')
     parser.add_argument('--alias', help='Alias name to create')
     parser.add_argument('--old-index', help='Old index name to copy')
     parser.add_argument('--send_get_body_as', default='GET',
@@ -206,6 +223,7 @@ def main():
         client_cert = data.get('client_cert')
         client_key = data.get('client_key')
         index = args.index if args.index is not None else data.get('writeback_index')
+        single_index = args.single_index if args.single_index is not None else data.get('run_on_single_index') is not False
         alias = args.alias if args.alias is not None else data.get('writeback_alias')
         old_index = args.old_index if args.old_index is not None else None
     else:
@@ -233,6 +251,7 @@ def main():
         index = args.index if args.index is not None else input('New index name? (Default elastalert_status) ')
         if not index:
             index = 'elastalert_status'
+        single_index = False
         alias = args.alias if args.alias is not None else input('New alias name? (Default elastalert_alerts) ')
         if not alias:
             alias = 'elastalert_alias'
@@ -261,7 +280,7 @@ def main():
         ca_certs=ca_certs,
         client_key=client_key)
 
-    create_index_mappings(es_client=es, ea_index=index, recreate=args.recreate, old_ea_index=old_index)
+    create_index_mappings(es_client=es, ea_index=index, recreate=args.recreate, old_ea_index=old_index, single_index=single_index)
 
 
 if __name__ == '__main__':

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -682,6 +682,11 @@ class ElastAlerter(object):
             doc_type = 'elastalert_status'
             index = self.writeback_es.resolve_writeback_index(self.writeback_index, doc_type)
             if self.writeback_es.is_atleastsixtwo():
+                if self.writeback_es.run_on_single_index():
+                    # edit query to search on ea_type
+                    query["query"]["bool"]["must"]=[query["query"]["bool"]["filter"]]
+                    query["query"]["bool"]["must"].append({'term': {'ea_type': doc_type.replace("elastalert_","")}})
+                    query["query"]["bool"].pop("filter",None)
                 if self.writeback_es.is_atleastsixsix():
                     res = self.writeback_es.search(index=index, size=1, body=query,
                                                    _source_includes=['endtime', 'rule_name'])
@@ -1609,6 +1614,10 @@ class ElastAlerter(object):
         if '@timestamp' not in writeback_body:
             writeback_body['@timestamp'] = dt_to_ts(ts_now())
 
+        if self.writeback_es.run_on_single_index():
+           # ADD specific term to replace doc_type
+           body.update({"ea_type":doc_type.replace("elastalert_","")})
+
         try:
             index = self.writeback_es.resolve_writeback_index(self.writeback_index, doc_type)
             if self.writeback_es.is_atleastsixtwo():
@@ -1638,6 +1647,10 @@ class ElastAlerter(object):
         query.update(sort)
         try:
             if self.writeback_es.is_atleastsixtwo():
+                if self.writeback_es.run_on_single_index():
+                    # edit query to search on ea_type
+                    query["query"]["bool"]["must"]=[query["query"]["bool"]["must"]]
+                    query["query"]["bool"]["must"].append({"term":{"ea_type":"elastalert"}})
                 res = self.writeback_es.search(index=self.writeback_index, body=query, size=1000)
             else:
                 res = self.writeback_es.deprecated_search(index=self.writeback_index,
@@ -1727,6 +1740,9 @@ class ElastAlerter(object):
         matches = []
         try:
             if self.writeback_es.is_atleastsixtwo():
+                if self.writeback_es.run_on_single_index():
+                    # edit query to search on ea_type
+                    query = {'query':{'bool': {'must':[query["query"],{'term': {'ea_type': 'elastalert'}}]}},'sort':query["sort"]}
                 res = self.writeback_es.search(index=self.writeback_index, body=query,
                                                size=self.max_aggregation)
             else:
@@ -1754,6 +1770,9 @@ class ElastAlerter(object):
         query['sort'] = {'alert_time': {'order': 'desc'}}
         try:
             if self.writeback_es.is_atleastsixtwo():
+                if self.writeback_es.run_on_single_index():
+                    # edit query to search on ea_type
+                    query['filter']['bool']['must'].append({'term': {'ea_type': 'elastalert'}})
                 res = self.writeback_es.search(index=self.writeback_index, body=query, size=1)
             else:
                 res = self.writeback_es.deprecated_search(index=self.writeback_index, doc_type='elastalert', body=query, size=1)
@@ -1898,6 +1917,9 @@ class ElastAlerter(object):
             doc_type = 'silence'
             index = self.writeback_es.resolve_writeback_index(self.writeback_index, doc_type)
             if self.writeback_es.is_atleastsixtwo():
+                if self.writeback_es.run_on_single_index():
+                    # edit query to search on ea_type
+                    query = {"query": {"bool": {"must": [query["query"],{"term":{"ea_type":doc_type.replace("elastalert_","")}}]}}}
                 if self.writeback_es.is_atleastsixsix():
                     res = self.writeback_es.search(index=index, size=1, body=query,
                                                    _source_includes=['until', 'exponent'])

--- a/elastalert/es_mappings/6/elastalert_single.json
+++ b/elastalert/es_mappings/6/elastalert_single.json
@@ -1,0 +1,46 @@
+{
+  "numeric_detection": true,
+  "date_detection": false,
+  "dynamic_templates": [
+    {
+      "strings_as_keyword": {
+        "mapping": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "match_mapping_type": "string"
+      }
+    }
+  ],
+  "properties": {
+    "alert_time": {
+      "type": "date",
+      "format": "dateOptionalTime"
+    },
+    "match_time": {
+      "type": "date",
+      "format": "dateOptionalTime"
+    },
+    "match_body": {
+      "type": "object"
+    },
+    "aggregate_id": {
+      "type": "keyword"
+    },
+    "rule_name": {
+      "type": "keyword"
+    },
+    "until": {
+      "type": "date",
+      "format": "dateOptionalTime"
+    },
+    "data": {
+      "type": "object",
+      "enabled": "false"
+    },
+    "@timestamp": {
+      "type": "date",
+      "format": "dateOptionalTime"
+    }
+  }
+}


### PR DESCRIPTION
Hello there,
I have been working on this for some time.
We are using index as a service and therefore needed to simplify things so that elastalert would be able to run on a single index.
I tested this on elasticsearch 6.8 (including create_index) but do not have the means to test on 5.x or 7.x
