### PR TITLE
Add option for elastalert to be run on one single writeback index

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -59,6 +59,9 @@ es_port: 9200
 writeback_index: elastalert_status
 writeback_alias: elastalert_alerts
 
+#If you need elastalert to run on a single writeback index
+#run_on_single_index: True
+
 # If an alert fails for some reason, ElastAlert will retry
 # sending the alert until this time period has elapsed
 alert_time_limit:

--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -149,6 +149,9 @@ configuration.
 
 ``writeback_index``: The index on ``es_host`` to use.
 
+``run_on_single_index``: Optional; If ``True``, elastalert will only use a single writeback index instead of five. 
+The environment variable ``ES_SINGLE_INDEX`` will overwrite this field.
+
 ``max_query_size``: The maximum number of documents that will be downloaded from Elasticsearch in a single query. The
 default is 10,000, and if you expect to get near this number, consider using ``use_count_query`` for the rule. If this
 limit is reached, ElastAlert will `scroll <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html>`_

--- a/docs/source/running_elastalert.rst
+++ b/docs/source/running_elastalert.rst
@@ -70,6 +70,8 @@ Next, open up config.yaml.example. In it, you will find several configuration op
 
 ``writeback_index`` is the name of the index in which ElastAlert will store data. We will create this index later.
 
+``run_on_single_index``: Optional; If ``True``, elastalert will only use a single writeback index instead of five. 
+
 ``alert_time_limit`` is the retry window for failed alerts.
 
 Save the file as ``config.yaml``

--- a/elastalert/__init__.py
+++ b/elastalert/__init__.py
@@ -54,6 +54,15 @@ class ElasticSearchClient(Elasticsearch):
                     time.sleep(3)
         return self._es_version
 
+    def run_on_single_index(self):
+        """
+        Returns True if elastalert has to run on a single index
+        """
+        if "run_on_single_index" in self._conf:
+            if self._conf["run_on_single_index"] is True:
+                return True
+        return False
+
     def is_atleastfive(self):
         """
         Returns True when the Elasticsearch server version >= 5
@@ -90,6 +99,8 @@ class ElasticSearchClient(Elasticsearch):
         """ In ES6, you cannot have multiple _types per index,
         therefore we use self.writeback_index as the prefix for the actual
         index name, based on doc_type. """
+        if self.run_on_single_index():
+            return writeback_index
         if not self.is_atleastsix():
             return writeback_index
         elif doc_type == 'silence':

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -30,10 +30,10 @@ def create_index_mappings(es_client, ea_index, recreate=False, old_ea_index=None
         es_maps = es_index_mappings
         es_index_mappings = {}
         es_index_mappings['elastalert_single'] = es_maps['elastalert']
-        es_index_mappings['elastalert_single'].update(es_maps['elastalert_status'])
-        es_index_mappings['elastalert_single'].update(es_maps['elastalert_error'])
-        es_index_mappings['elastalert_single'].update(es_maps['silence'])
-        es_index_mappings['elastalert_single'].update(es_maps['past_elastalert'])
+        es_index_mappings['elastalert_single']['properties'].update(es_maps['elastalert_status']['properties'])
+        es_index_mappings['elastalert_single']['properties'].update(es_maps['elastalert_error']['properties'])
+        es_index_mappings['elastalert_single']['properties'].update(es_maps['silence']['properties'])
+        es_index_mappings['elastalert_single']['properties'].update(es_maps['past_elastalert']['properties'])
 
     es_index = IndicesClient(es_client)
     if not recreate:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -681,7 +681,12 @@ class ElastAlerter(object):
         try:
             doc_type = 'elastalert_status'
             index = self.writeback_es.resolve_writeback_index(self.writeback_index, doc_type)
-            if self.writeback_es.is_atleastsixtwo():
+            if self.writeback_es.is_atleastsix():
+                if self.writeback_es.run_on_single_index():
+                    # edit query to search on ea_type
+                    query["query"]["bool"]["must"] = [query["query"]["bool"]["filter"]]
+                    query["query"]["bool"]["must"].append({'term': {'ea_type': doc_type.replace("elastalert_", "")}})
+                    query["query"]["bool"].pop("filter", None)
                 if self.writeback_es.is_atleastsixsix():
                     res = self.writeback_es.search(index=index, size=1, body=query,
                                                    _source_includes=['endtime', 'rule_name'])
@@ -1609,6 +1614,10 @@ class ElastAlerter(object):
         if '@timestamp' not in writeback_body:
             writeback_body['@timestamp'] = dt_to_ts(ts_now())
 
+        if self.writeback_es.run_on_single_index() and self.writeback_es.is_atleastsix():
+            # ADD specific term to replace doc_type
+            body.update({"ea_type": doc_type.replace("elastalert_", "")})
+
         try:
             index = self.writeback_es.resolve_writeback_index(self.writeback_index, doc_type)
             if self.writeback_es.is_atleastsixtwo():
@@ -1637,7 +1646,11 @@ class ElastAlerter(object):
             query = {'query': inner_query, 'filter': time_filter}
         query.update(sort)
         try:
-            if self.writeback_es.is_atleastsixtwo():
+            if self.writeback_es.is_atleastsix():
+                if self.writeback_es.run_on_single_index():
+                    # edit query to search on ea_type
+                    query["query"]["bool"]["must"] = [query["query"]["bool"]["must"]]
+                    query["query"]["bool"]["must"].append({"term": {"ea_type": "elastalert"}})
                 res = self.writeback_es.search(index=self.writeback_index, body=query, size=1000)
             else:
                 res = self.writeback_es.deprecated_search(index=self.writeback_index,
@@ -1726,7 +1739,10 @@ class ElastAlerter(object):
         query = {'query': {'query_string': {'query': 'aggregate_id:%s' % (_id)}}, 'sort': {'@timestamp': 'asc'}}
         matches = []
         try:
-            if self.writeback_es.is_atleastsixtwo():
+            if self.writeback_es.is_atleastsix():
+                if self.writeback_es.run_on_single_index():
+                    # edit query to search on ea_type
+                    query = {'query': {'bool': {'must': [query["query"], {'term': {'ea_type': 'elastalert'}}]}}, 'sort': query["sort"]}
                 res = self.writeback_es.search(index=self.writeback_index, body=query,
                                                size=self.max_aggregation)
             else:
@@ -1753,7 +1769,10 @@ class ElastAlerter(object):
             query = {'query': {'bool': query}}
         query['sort'] = {'alert_time': {'order': 'desc'}}
         try:
-            if self.writeback_es.is_atleastsixtwo():
+            if self.writeback_es.is_atleastsix():
+                if self.writeback_es.run_on_single_index():
+                    # edit query to search on ea_type
+                    query['filter']['bool']['must'].append({'term': {'ea_type': 'elastalert'}})
                 res = self.writeback_es.search(index=self.writeback_index, body=query, size=1)
             else:
                 res = self.writeback_es.deprecated_search(index=self.writeback_index, doc_type='elastalert', body=query, size=1)
@@ -1897,7 +1916,10 @@ class ElastAlerter(object):
         try:
             doc_type = 'silence'
             index = self.writeback_es.resolve_writeback_index(self.writeback_index, doc_type)
-            if self.writeback_es.is_atleastsixtwo():
+            if self.writeback_es.is_atleastsix():
+                if self.writeback_es.run_on_single_index():
+                    # edit query to search on ea_type
+                    query = {"query": {"bool": {"must": [query["query"], {"term": {"ea_type": doc_type.replace("elastalert_", "")}}]}}}
                 if self.writeback_es.is_atleastsixsix():
                     res = self.writeback_es.search(index=index, size=1, body=query,
                                                    _source_includes=['until', 'exponent'])

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1623,7 +1623,7 @@ class ElastAlerter(object):
         try:
             index = self.writeback_es.resolve_writeback_index(self.writeback_index, doc_type)
             if self.writeback_es.is_atleastsixtwo():
-                res = self.writeback_es.index(index=index, body=body)
+                res = self.writeback_es.index(index=index, doc_type="_doc", body=body)
             else:
                 res = self.writeback_es.index(index=index, doc_type=doc_type, body=body)
             return res

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -636,11 +636,15 @@ class ElastAlerter(object):
                 old_len = len(data)
                 data = self.remove_duplicate_events(data, rule)
                 self.thread_data.num_dupes += old_len - len(data)
-
         # There was an exception while querying
-        if data is None:
+        try:
+            #allows to always enter add_data of the rule if something has to be done
+            run_always = rule_inst.run_always()
+        except AttributeError:
+            run_always = False
+        if data is None and not run_always:
             return False
-        elif data:
+        elif data or run_always:
             if rule.get('use_count_query'):
                 rule_inst.add_count_data(data)
             elif rule.get('use_terms_query'):

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -674,7 +674,7 @@ class NewTermsRule(RuleType):
 
             time_filter = {self.rules['timestamp_field']: {'lt': self.rules['dt_to_ts'](tmp_end), 'gte': self.rules['dt_to_ts'](tmp_start)}}
             query_template['filter'] = {'bool': {'must': [{'range': time_filter}]}}
-            query = {'aggs': {'filtered': query_template}}
+            query = {'size': 0, 'aggs': {'filtered': query_template}}
 
             if 'filter' in self.rules:
                 for item in self.rules['filter']:

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -448,7 +448,7 @@ def resolve_string(string, match, missing_text='<MISSING VALUE>'):
             string = string % dd_match
             string = string.format(**dd_match)
             break
-        except KeyError as e:
+        except KeyError, ValueError as e:
             if '{%s}' % str(e).strip("'") not in string:
                 break
             string = string.replace('{%s}' % str(e).strip("'"), '{_missing_value}')

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -356,6 +356,13 @@ def build_es_conn_config(conf):
         parsed_conf['es_username'] = conf['es_username']
         parsed_conf['es_password'] = conf['es_password']
 
+    if os.environ.get('ES_SINGLE_INDEX'):
+        parsed_conf['run_on_single_index'] = True if os.environ.get('ES_SINGLE_INDEX') == "True" else False
+    elif 'run_on_single_index' in conf:
+        parsed_conf['run_on_single_index'] = conf['run_on_single_index']
+    else:
+        parsed_conf['run_on_single_index'] = False
+
     if 'aws_region' in conf:
         parsed_conf['aws_region'] = conf['aws_region']
 

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -448,7 +448,7 @@ def resolve_string(string, match, missing_text='<MISSING VALUE>'):
             string = string % dd_match
             string = string.format(**dd_match)
             break
-        except KeyError, ValueError as e:
+        except (KeyError, ValueError) as e:
             if '{%s}' % str(e).strip("'") not in string:
                 break
             string = string.replace('{%s}' % str(e).strip("'"), '{_missing_value}')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-coverage
+coverage==4.5.4
 flake8
 pre-commit
 pylint<1.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,7 @@ class mock_es_client(object):
         self.is_atleastsixtwo = mock.Mock(return_value=False)
         self.is_atleastsixsix = mock.Mock(return_value=False)
         self.is_atleastseven = mock.Mock(return_value=False)
+        self.run_on_single_index = mock.Mock(return_value=False)
         self.resolve_writeback_index = mock.Mock(return_value=writeback_index)
 
 
@@ -98,6 +99,7 @@ class mock_es_sixsix_client(object):
         self.is_atleastsixtwo = mock.Mock(return_value=False)
         self.is_atleastsixsix = mock.Mock(return_value=True)
         self.is_atleastseven = mock.Mock(return_value=False)
+        self.run_on_single_index = mock.Mock(return_value=False)
 
         def writeback_index_side_effect(index, doc_type):
             if doc_type == 'silence':


### PR DESCRIPTION
Hello there,
I have been working on this for some time.
We are using index as a service and therefore needed to simplify things so that elastalert would be able to run on a single index.
I tested this on elasticsearch 6.8 (including create_index) but do not have the means to test on 5.x or 7.x