### PR TITLE
Add a new rule: find_match

### DIFF
--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -50,6 +50,7 @@ class RulesLoader(object):
         'cardinality': ruletypes.CardinalityRule,
         'metric_aggregation': ruletypes.MetricAggregationRule,
         'percentage_match': ruletypes.PercentageMatchRule,
+        'find_match': ruletypes.FindMatchRule,
     }
 
     # Used to map names of alerts to their classes

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -161,6 +161,16 @@ oneOf:
     properties:
       type: {enum: [percentage_match]}
 
+  - title: Find Match
+    required: [query_key, compare_key, start_value, end_value, timeframe, invert]
+    properties:
+      type: {enum: [find_match]}
+      compare_key: {'items': {'type': 'string'},'type': ['string', 'array']}
+      start_value: {type: string}
+      end_value: {type: string}
+      timeframe: *timeframe
+      invert: {type: boolean}
+
   - title: Custom Rule from Module
     properties:
       # custom rules include a period in the rule type


### PR DESCRIPTION
Hi guys!

I'd like you to take a look at the rule I wrote some time ago for a customer.
For option invert: false the rule is an equivalent of elapsed filter plugin for logstash meaning an event gets marked as start event when value of compare_key field is equal to start_value.
An event gets marked as end event when value of compare_key field is equal to end_value.
Elapsed time between those two events with the same query_key is calculated.
If the calculated time is within specified timeframe we have an alert.

For invert: true we are alerting when end event is not present within specified timeframe.

Sample rule:

name: test
type: find_match
index: test*
query_key: id
compare_key: message
start_value: "start"
end_value: "end"
invert: false
timeframe:
  minutes: 1

alert:
  - command
command: ['/bin/echo', 'ALERT']