### PR TITLE
Task/show warn false

### DIFF
--- a/elastalert/__init__.py
+++ b/elastalert/__init__.py
@@ -22,6 +22,7 @@ class ElasticSearchClient(Elasticsearch):
                                                   use_ssl=conf['use_ssl'],
                                                   verify_certs=conf['verify_certs'],
                                                   ca_certs=conf['ca_certs'],
+                                                  ssl_show_warn=conf['ssl_show_warn'],
                                                   connection_class=RequestsHttpConnection,
                                                   http_auth=conf['http_auth'],
                                                   timeout=conf['es_conn_timeout'],

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -348,6 +348,7 @@ def build_es_conn_config(conf):
     parsed_conf['es_url_prefix'] = ''
     parsed_conf['es_conn_timeout'] = conf.get('es_conn_timeout', 20)
     parsed_conf['send_get_body_as'] = conf.get('es_send_get_body_as', 'GET')
+    parsed_conf['ssl_show_warn'] = conf.get('ssl_show_warn', True)
 
     if os.environ.get('ES_USERNAME'):
         parsed_conf['es_username'] = os.environ.get('ES_USERNAME')


### PR DESCRIPTION
Using the ssl_show_warn option of elasticsearch's library from elastalert's config file.

This options reduces the warnings when a ssl connection is performed and it's no verified.