### PR TITLE
Pin elasticsearch to 7.0.0 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ boto3>=1.4.4
 cffi>=1.11.5
 configparser>=3.5.0
 croniter>=0.3.16
-elasticsearch>=7.0.0
+elasticsearch==7.0.0
 envparse>=0.2.0
 exotel>=0.1.3
 jira>=1.0.10,<1.0.15


### PR DESCRIPTION
in accordance with fix_497 , the pin seems to be missing in the `requirements.txt`