### PR TITLE
Typo in examples_rules/ssh.yaml

### DIFF
--- a/example_rules/ssh.yaml
+++ b/example_rules/ssh.yaml
@@ -1,5 +1,5 @@
 # Rule name, must be unique
-  name: SSH abuse (ElastAlert 3.0.1) - 2
+name: SSH abuse (ElastAlert 3.0.1) - 2
 
 # Alert on x events in y seconds
 type: frequency


### PR DESCRIPTION
I found a yaml typo in the examples directory.
Would be nice to fix it.