### PR TITLE
Re-add TheHive alerter without any libraries

### DIFF
--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -42,6 +42,7 @@ Currently, we have support built in for these alert types:
 - GoogleChat
 - Debug
 - Stomp
+- TheHive
 
 Additional rule types and alerts can be easily imported or written. (See :ref:`Writing rule types <writingrules>` and :ref:`Writing alerts <writingalerts>`)
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2186,6 +2186,51 @@ Required:
 
 ``linenotify_access_token``: The access token that you got from https://notify-bot.line.me/my/
 
+theHive
+~~~~~~
+
+theHive alert type will send JSON request to theHive (Security Incident Response Platform) with TheHive4py API. Sent request will be stored like Hive Alert with description and observables.
+
+Required:
+
+``hive_connection``: The connection details as key:values. Required keys are ``hive_host``, ``hive_port`` and ``hive_apikey``.
+
+``hive_alert_config``: Configuration options for the alert.
+
+Optional:
+
+``hive_proxies``: Proxy configuration.
+
+``hive_observable_data_mapping``: If needed, matched data fields can be mapped to TheHive observable types using python string formatting.
+
+Example usage::
+
+    alert: hivealerter
+
+     hive_connection:
+       hive_host: http://localhost
+       hive_port: <hive_port>
+       hive_apikey: <hive_apikey>
+       hive_proxies:
+         http: ''
+         https: ''
+
+      hive_alert_config:
+        title: 'Title'  ## This will default to {rule[index]_rule[name]} if not provided
+        type: 'external'
+        source: 'elastalert'
+        description: '{match[field1]} {rule[name]} Sample description'
+        severity: 2
+        tags: ['tag1', 'tag2 {rule[name]}']
+        tlp: 3
+        status: 'New'
+        follow: True
+
+    hive_observable_data_mapping:
+        - domain: "{match[field1]}_{rule[name]}"
+        - domain: "{match[field]}"
+        - ip: "{match[ip_field]}"
+
 
 Zabbix
 ~~~~~~~~~~~

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -77,6 +77,7 @@ class RulesLoader(object):
         'servicenow': alerts.ServiceNowAlerter,
         'alerta': alerts.AlertaAlerter,
         'post': alerts.HTTPPostAlerter,
+        'hivealerter': alerts.HiveAlerter
     }
 
     # A partial ordering of alert types. Relative order will be preserved in the resulting alerts list


### PR DESCRIPTION
Re add TheHive alerter that was removed in https://github.com/Yelp/elastalert/pull/2738 using no libraries.

Tested by capturing the requests from the old version and the new version using some example data and the documentation's example config:

Config:
```
rule = {'name': 'qlos rule', 'index': 'testindex'}
match = {'@timestamp': '2020-04-15T00:00:00Z',
         'field1': 'field1value',
         'field2': 'field2value',
         'ip_field': '8.8.8.8'}
config = yaml.load('''
config:
    hive_connection:
       hive_host: http://localhost
       hive_port: 12346
       hive_apikey: ABC123DEF
       hive_proxies:
         http: ''
         https: ''

    hive_alert_config:
        title: 'Title'  ## This will default to {rule[index]_rule[name]} if not provided
        type: 'external'
        source: 'elastalert'
        description: '{match[field1]} {rule[name]} Sample description'
        severity: 2
        tags: ['tag1', 'tag2 {rule[name]}']
        tlp: 3
        status: 'New'
        follow: True

    hive_observable_data_mapping:
        - domain: "{match[field1]}_{rule[name]}"
        - domain: "{match[field]}"
        - ip: "{match[ip_field]}"
''')['config']
```

Yielding:
```
POST /api/alert HTTP/1.1
Host: localhost:12346
User-Agent: python-requests/2.22.0
Accept-Encoding: gzip, deflate
Accept: */*
Connection: keep-alive
Content-Type: application/json
Authorization: Bearer ABC123DEF
Content-Length: 734

{
    "artifacts": [
        {
            "data": "field1value_qlos rule",
            "dataType": "domain",
            "message": null,
            "tags": [],
            "tlp": 2
        },
        {
            "data": "8.8.8.8",
            "dataType": "ip",
            "message": null,
            "tags": [],
            "tlp": 2
        }
    ],
    "caseTemplate": null,
    "customFields": {},
    "date": 1586984926000,
    "description": "field1value qlos rule Sample description",
    "follow": true,
    "severity": 2,
    "source": "elastalert",
    "sourceRef": "f1f8a7",
    "status": "New",
    "tags": [
        "tag1",
        "tag2 qlos rule"
    ],
    "title": "Title",
    "tlp": 3,
    "type": "external"
}
```

Which compared to the old alerter's request:
```
 diff old_req new_req
8d7
< Content-Length: 693
9a9
> Content-Length: 734
30c30
<     "date": 1586984925000,
---
>     "date": 1586984926000,
31a32
>     "follow": true,
34c35,36
<     "sourceRef": "56e52a",
---
>     "sourceRef": "f1f8a7",
>     "status": "New",
```

"status" and "follow" are both valid API parameters (https://github.com/TheHive-Project/TheHiveDocs/blob/master/api/alert.md) but don't seem to be inlcuded in TheHive4Py for some reason.
"sourceref" and "date" of course are dynamic values.