### PR TITLE
unsupported operand type(s) for +=: 'int' and 'NoneType'

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -317,6 +317,8 @@ class EventWindow(object):
         """ Add an event to the window. Event should be of the form (dict, count).
         This will also pop the oldest events and call onRemoved on them until the
         window size is less than timeframe. """
+        if not event or not event[1]:
+            return self
         self.data.add(event)
         self.running_count += event[1]
 
@@ -357,6 +359,8 @@ class EventWindow(object):
     def append_middle(self, event):
         """ Attempt to place the event in the correct location in our deque.
         Returns True if successful, otherwise False. """
+        if not event or not event[1]:
+            return self
         rotation = 0
         ts = self.get_ts(event)
 


### PR DESCRIPTION
Under certain circumstances, the event argument passed in the functions 'append' or 'append_middle' of the RuleTypes class can be None.
The aforementioned functions now perform a None check so that errors such as the below are avoided:
```
ERROR:root:Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/elastalert/elastalert.py", line 1269, in handle_rule_execution
    num_matches = self.run_rule(rule, endtime, rule.get('initial_starttime'))
  File "/usr/lib/python3.6/site-packages/elastalert/elastalert.py", line 897, in run_rule
    self.run_query(rule, tmp_endtime, endtime)
  File "/usr/lib/python3.6/site-packages/elastalert/elastalert.py", line 649, in run_query
    rule_inst.add_aggregation_data(data)
  File "/usr/lib/python3.6/site-packages/elastalert/ruletypes.py", line 1144, in add_aggregation_data
    self.handle_event(event, agg_value, 'all')
  File "/usr/lib/python3.6/site-packages/elastalert/ruletypes.py", line 448, in handle_event
    self.cur_windows[qk].append((event, count))
  File "/usr/lib/python3.6/site-packages/elastalert/ruletypes.py", line 321, in append
    self.running_count += event[1]
TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'

ERROR:root:Uncaught exception running rule /opt/elastalert/rules/SpikeRule12: unsupported operand type(s) for +=: 'int' and 'NoneType'
```

@Qmando FYI