### PR TITLE
Sns docs update

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# v0.2.4
+
+### Added
+- Added back customFields support for The Hive
+
 # v0.2.3
 
 ### Added

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1670,13 +1670,22 @@ SNS requires one option:
 
 Optional:
 
-``aws_access_key``: An access key to connect to SNS with.
+``aws_access_key_id``: An access key to connect to SNS with.
 
-``aws_secret_key``: The secret key associated with the access key.
+``aws_secret_access_key``: The secret key associated with the access key.
 
 ``aws_region``: The AWS region in which the SNS resource is located. Default is us-east-1
 
-``profile``: The AWS profile to use. If none specified, the default will be used.
+``aws_profile``: The AWS profile to use. If none specified, the default will be used.
+
+Example usage::
+
+    alert:
+      - sns:
+          aws_region: 'us-east-1' # You must nest aws_region within your alert configuration so it is not used to sign AWS requests.
+    sns_topic_arn: 'arn:aws:sns:us-east-1:123456789:somesnstopic'
+    aws_access_key_id: 'XXXXXXXXXXXXXXXXXX''
+    aws_secret_access_key: 'YYYYYYYYYYYYYYYYYYYY'
 
 HipChat
 ~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 base_dir = os.path.dirname(__file__)
 setup(
     name='elastalert',
-    version='0.2.3',
+    version='0.2.4',
     description='Runs custom filters on Elasticsearch and alerts on matches',
     author='Quentin Long',
     author_email='qlo@yelp.com',


### PR DESCRIPTION
Since the documentation on SNS is old,
aws_access_key, aws_secret_key, profile is
You need to update to aws_access_key_id, aws_secret_access_key, and aws_profile.