### PR TITLE
Fix LineNotify & Pagertree

### DIFF
--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -77,7 +77,8 @@ class RulesLoader(object):
         'servicenow': alerts.ServiceNowAlerter,
         'alerta': alerts.AlertaAlerter,
         'post': alerts.HTTPPostAlerter,
-        'hivealerter': alerts.HiveAlerter
+        'hivealerter': alerts.HiveAlerter,
+        'linenotify': alerts.LineNotifyAlerter
     }
 
     # A partial ordering of alert types. Relative order will be preserved in the resulting alerts list

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -77,8 +77,10 @@ class RulesLoader(object):
         'servicenow': alerts.ServiceNowAlerter,
         'alerta': alerts.AlertaAlerter,
         'post': alerts.HTTPPostAlerter,
-        'hivealerter': alerts.HiveAlerter,
-        'linenotify': alerts.LineNotifyAlerter
+        'pagertree': alerts.PagerTreeAlerter,
+        'linenotify': alerts.LineNotifyAlerter,
+        'hivealerter': alerts.HiveAlerter
+        
     }
 
     # A partial ordering of alert types. Relative order will be preserved in the resulting alerts list

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -79,8 +79,7 @@ class RulesLoader(object):
         'post': alerts.HTTPPostAlerter,
         'pagertree': alerts.PagerTreeAlerter,
         'linenotify': alerts.LineNotifyAlerter,
-        'hivealerter': alerts.HiveAlerter
-        
+        'hivealerter': alerts.HiveAlerter        
     }
 
     # A partial ordering of alert types. Relative order will be preserved in the resulting alerts list

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -79,7 +79,7 @@ class RulesLoader(object):
         'post': alerts.HTTPPostAlerter,
         'pagertree': alerts.PagerTreeAlerter,
         'linenotify': alerts.LineNotifyAlerter,
-        'hivealerter': alerts.HiveAlerter        
+        'hivealerter': alerts.HiveAlerter
     }
 
     # A partial ordering of alert types. Relative order will be preserved in the resulting alerts list


### PR DESCRIPTION
「'linenotify': alerts.LineNotifyAlerter,」 was not listed in elastalert/loader.py

Fixed the following issues

[#2516](https://github.com/Yelp/elastalert/issues/2516)
[#2307](https://github.com/Yelp/elastalert/issues/2307)

「'pagertree': alerts.PagerTreeAlerter,」was not listed in elastalert/loader.py

https://github.com/Yelp/elastalert/issues/2571