### PR TITLE
Fix SNS(Program & Docs)

### DIFF
--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -35,7 +35,7 @@ Currently, we have support built in for these alert types:
 - Email
 - JIRA
 - OpsGenie
-- SNS
+- AWS SNS
 - HipChat
 - Slack
 - Telegram

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1670,13 +1670,42 @@ SNS requires one option:
 
 Optional:
 
-``aws_access_key``: An access key to connect to SNS with.
+``sns_aws_access_key_id``: An access key to connect to SNS with.
 
-``aws_secret_key``: The secret key associated with the access key.
+``sns_aws_secret_access_key``: The secret key associated with the access key.
 
-``aws_region``: The AWS region in which the SNS resource is located. Default is us-east-1
+``sns_aws_region``: The AWS region in which the SNS resource is located. Default is us-east-1
 
-``profile``: The AWS profile to use. If none specified, the default will be used.
+``sns_aws_profile``: The AWS profile to use. If none specified, the default will be used.
+
+Example When not using aws_profile usage::
+
+    alert:
+      - sns
+    sns_topic_arn: 'arn:aws:sns:us-east-1:123456789:somesnstopic'
+    sns_aws_access_key_id: 'XXXXXXXXXXXXXXXXXX''
+    sns_aws_secret_access_key: 'YYYYYYYYYYYYYYYYYYYY'
+    sns_aws_region: 'us-east-1' # You must nest aws_region within your alert configuration so it is not used to sign AWS requests.
+ 
+Example When to use aws_profile usage::
+
+    # Create ~/.aws/credentials
+
+    [default]
+    aws_access_key_id = xxxxxxxxxxxxxxxxxxxx
+    aws_secret_access_key = yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+
+    # Create ~/.aws/config
+
+    [default]
+    region = us-east-1
+
+    # alert rule setting
+
+    alert:
+      - sns
+    sns_topic_arn: 'arn:aws:sns:us-east-1:123456789:somesnstopic'
+    sns_aws_profile: 'default'
 
 HipChat
 ~~~~~~~

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1657,14 +1657,14 @@ Example usage::
       Environment: '$VAR'          # environment variable
       Message: { field: message }  # field in the first match
 
-SNS
-~~~
+AWS SNS
+~~~~~~~
 
-The SNS alerter will send an SNS notification. The body of the notification is formatted the same as with other alerters.
-The SNS alerter uses boto3 and can use credentials in the rule yaml, in a standard AWS credential and config files, or
+The AWS SNS alerter will send an AWS SNS notification. The body of the notification is formatted the same as with other alerters.
+The AWS SNS alerter uses boto3 and can use credentials in the rule yaml, in a standard AWS credential and config files, or
 via environment variables. See http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html for details.
 
-SNS requires one option:
+AWS SNS requires one option:
 
 ``sns_topic_arn``: The SNS topic's ARN. For example, ``arn:aws:sns:us-east-1:123456789:somesnstopic``
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -935,11 +935,11 @@ class SnsAlerter(Alerter):
     def __init__(self, *args):
         super(SnsAlerter, self).__init__(*args)
         self.sns_topic_arn = self.rule.get('sns_topic_arn', '')
-        self.aws_access_key_id = self.rule.get('aws_access_key_id')
-        self.aws_secret_access_key = self.rule.get('aws_secret_access_key')
-        self.aws_region = self.rule.get('aws_region', 'us-east-1')
+        self.sns_aws_access_key_id = self.rule.get('sns_aws_access_key_id')
+        self.sns_aws_secret_access_key = self.rule.get('sns_aws_secret_access_key')
+        self.sns_aws_region = self.rule.get('sns_aws_region', 'us-east-1')
         self.profile = self.rule.get('boto_profile', None)  # Deprecated
-        self.profile = self.rule.get('aws_profile', None)
+        self.profile = self.rule.get('sns_aws_profile', None)
 
     def create_default_title(self, matches):
         subject = 'ElastAlert: %s' % (self.rule['name'])
@@ -948,12 +948,15 @@ class SnsAlerter(Alerter):
     def alert(self, matches):
         body = self.create_alert_body(matches)
 
-        session = boto3.Session(
-            aws_access_key_id=self.aws_access_key_id,
-            aws_secret_access_key=self.aws_secret_access_key,
-            region_name=self.aws_region,
-            profile_name=self.profile
-        )
+        if self.profile is None:
+            session = boto3.Session(
+                aws_access_key_id=self.sns_aws_access_key_id,
+                aws_secret_access_key=self.sns_aws_access_key_id,
+                region_name=self.sns_aws_region
+            )
+        else:
+            session = boto3.Session(profile_name=self.profile)
+
         sns_client = session.client('sns')
         sns_client.publish(
             TopicArn=self.sns_topic_arn,


### PR DESCRIPTION
**Review setting name**

I was planning to review only aws_region, but I thought that the same name may be used for other names, so I added "sns_" to the beginning.
I also modified the documentation

・aws_access_key_id 
　→ sns_aws_access_key_id 
・aws_secret_access_key
　→ sns_aws_secret_access_key
・aws_region
　→ sns_aws_region
・aws_profile
　→ sns_aws_profile

**Profile bug fix**

It was fixed because the implementation when using the profile was in an incorrect state.