### PR TITLE
Fix Zabbix(Docs & schema.yaml)

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2242,4 +2242,4 @@ Required:
 ``zbx_sender_host``: The address where zabbix server is running.
 ``zbx_sender_port``: The port where zabbix server is listenning.
 ``zbx_host``: This field setup the host in zabbix that receives the value sent by Elastalert.
-``zbx_item``: This field setup the item in the host that receives the value sent by Elastalert.
+``zbx_key``: This field setup the key in the host that receives the value sent by Elastalert.

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -386,4 +386,4 @@ properties:
   zbx_sender_host: {type: string}
   zbx_sender_port: {type: integer}
   zbx_host: {type: string}
-  zbx_item: {type: string}
+  zbx_key: {type: string}


### PR DESCRIPTION
Although it is described as "zbx_item" in the document,
 it is in a state different from the implementation. Correctly "zbx_key"