### PR TITLE
Adds --silence_qk_value option to elastalert

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -83,6 +83,11 @@ class ElastAlerter(object):
         parser.add_argument('--rule', dest='rule', help='Run only a specific rule (by filename, must still be in rules folder)')
         parser.add_argument('--silence', dest='silence', help='Silence rule for a time period. Must be used with --rule. Usage: '
                                                               '--silence <units>=<number>, eg. --silence hours=2')
+        parser.add_argument(
+            "--silence_qk_value",
+            dest="silence_qk_value",
+            help="Silence the rule only for this specific query key value.",
+        )
         parser.add_argument('--start', dest='start', help='YYYY-MM-DDTHH:MM:SS Start querying from this timestamp. '
                                                           'Use "NOW" to start from current time. (Default: present)')
         parser.add_argument('--end', dest='end', help='YYYY-MM-DDTHH:MM:SS Query to this timestamp. (Default: present)')
@@ -1853,7 +1858,10 @@ class ElastAlerter(object):
 
         # With --rule, self.rules will only contain that specific rule
         if not silence_cache_key:
-            silence_cache_key = self.rules[0]['name'] + "._silence"
+            if self.args.silence_qk_value:
+                silence_cache_key = self.rules[0]['name'] + "." + self.args.silence_qk_value
+            else:
+                silence_cache_key = self.rules[0]['name'] + "._silence"
 
         try:
             silence_ts = parse_deadline(self.args.silence)


### PR DESCRIPTION
This enables the user to silence a rule only for a specific query_key value and
not only the whole rule.
See Issue #2777