### PR TITLE
Fix Flake Lint Ambiguous Variable Error

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -794,9 +794,9 @@ class JiraAlerter(Alerter):
                     except JIRAError as e:
                         logging.exception("Error while commenting on ticket %s: %s" % (ticket, e))
                     if self.labels:
-                        for l in self.labels:
+                        for label in self.labels:
                             try:
-                                ticket.fields.labels.append(l)
+                                ticket.fields.labels.append(label)
                             except JIRAError as e:
                                 logging.exception("Error while appending labels to ticket %s: %s" % (ticket, e))
                 if self.transition:


### PR DESCRIPTION
Fixes a variable name that causes the CI to fail due to a variable named `l` in Jira Alerter Code. Changed the variable name from `l` to `label`.

Flake throws [E741](https://www.flake8rules.com/rules/E741.html) in Travis build. This is causing the master builds to fail continuously.

@Qmando / @pdscopes can you review?