### PR TITLE
Added Squadcast http post alert config

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2164,6 +2164,20 @@ Example usage::
     http_post_headers:
       authorization: Basic 123dr3234
 
+Squadcast
+~~~~~~~~
+
+Alerts can be sent to Squadcast using the `http post` method described above and Squadcast will process it and send Phone, SMS, Email and Push notifications to the relevant person(s) and let them take actions.
+
+Configuration variables in rules YAML file::
+
+	alert: post
+	http_post_url: <ElastAlert Webhook URL copied from Squadcast dashboard>
+	http_post_static_payload:
+    	Title: <Incident Title>
+	http_post_all_values: true
+
+For more details, you can refer the `Squadcast documentation <https://support.squadcast.com/docs/elastalert>`_.
 
 Alerter
 ~~~~~~~

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2174,7 +2174,7 @@ Configuration variables in rules YAML file::
 	alert: post
 	http_post_url: <ElastAlert Webhook URL copied from Squadcast dashboard>
 	http_post_static_payload:
-    	Title: <Incident Title>
+       Title: <Incident Title>
 	http_post_all_values: true
 
 For more details, you can refer the `Squadcast documentation <https://support.squadcast.com/docs/elastalert>`_.

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2171,11 +2171,11 @@ Alerts can be sent to Squadcast using the `http post` method described above and
 
 Configuration variables in rules YAML file::
 
-	alert: post
-	http_post_url: <ElastAlert Webhook URL copied from Squadcast dashboard>
-	http_post_static_payload:
-       Title: <Incident Title>
-	http_post_all_values: true
+    alert: post
+    http_post_url: <ElastAlert Webhook URL copied from Squadcast dashboard>
+    http_post_static_payload:
+      Title: <Incident Title>
+    http_post_all_values: true
 
 For more details, you can refer the `Squadcast documentation <https://support.squadcast.com/docs/elastalert>`_.
 


### PR DESCRIPTION
Added Squadcast http post alert config details and sample YAML configuration and a link to Squadcast documentation.

Squadcast is an IT Alerting and on-call incident management tool which uses the default http post method to send alerts instead of creating it's own alerter.