### PR TITLE
Add optional es_version attribute in config

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -19,6 +19,9 @@ es_host: elasticsearch.example.com
 # The Elasticsearch port
 es_port: 9200
 
+# The Elasticsearch version
+#es_version: 7.8.0
+
 # The AWS region to use. Set this when using AWS-managed elasticsearch
 #aws_region: us-east-1
 

--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -112,6 +112,8 @@ The environment variable ``ES_HOST`` will override this field.
 
 ``es_port``: The port corresponding to ``es_host``. The environment variable ``ES_PORT`` will override this field.
 
+``es_version``: The version of the Elasticsearch cluster. If not set, ElastAlert will send a request and retrieve it automatically.
+
 ``use_ssl``: Optional; whether or not to connect to ``es_host`` using TLS; set to ``True`` or ``False``.
 The environment variable ``ES_USE_SSL`` will override this field.
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -20,6 +20,8 @@ Rule Configuration Cheat Sheet
 +--------------------------------------------------------------+           |
 | ``es_port`` (number)                                         |           |
 +--------------------------------------------------------------+           |
+| ``es_version`` (string)                                      |           |
++--------------------------------------------------------------+           |
 | ``index`` (string)                                           |           |
 +--------------------------------------------------------------+           |
 | ``type`` (string)                                            |           |
@@ -211,6 +213,12 @@ es_port
 
 ``es_port``: The port of the Elasticsearch cluster. (Required, number, no default)
 The environment variable ``ES_PORT`` will override this field.
+
+es_version
+^^^^^^^^^^
+
+``es_version``: The version of the Elasticsearch cluster. (Optional - If not set, ElastAlert will send a request and retrieve it automatically)
+The environment variable ``ES_VERSION`` will override this field.
 
 index
 ^^^^^

--- a/docs/source/running_elastalert.rst
+++ b/docs/source/running_elastalert.rst
@@ -50,6 +50,8 @@ Next, open up config.yaml.example. In it, you will find several configuration op
 
 ``es_port`` is the port corresponding to ``es_host``.
 
+``es_version`` is the version corresponding to ``es_host``.
+
 ``use_ssl``: Optional; whether or not to connect to ``es_host`` using TLS; set to ``True`` or ``False``.
 
 ``verify_certs``: Optional; whether or not to verify TLS certificates; set to ``True`` or ``False``. The default is ``True``

--- a/elastalert/__init__.py
+++ b/elastalert/__init__.py
@@ -29,7 +29,7 @@ class ElasticSearchClient(Elasticsearch):
                                                   client_cert=conf['client_cert'],
                                                   client_key=conf['client_key'])
         self._conf = copy.copy(conf)
-        self._es_version = None
+        self._es_version = conf['es_version']
 
     @property
     def conf(self):

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -20,6 +20,7 @@ env_settings = {'ES_USE_SSL': 'use_ssl',
                 'ES_USERNAME': 'es_username',
                 'ES_HOST': 'es_host',
                 'ES_PORT': 'es_port',
+                'ES_VERSION': 'es_version',
                 'ES_URL_PREFIX': 'es_url_prefix'}
 
 env = Env(ES_USE_SSL=bool)

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -171,6 +171,7 @@ properties:
   # Common Settings
   es_host: {type: string}
   es_port: {type: integer}
+  es_version: {type: string}
   index: {type: string}
   name: {type: string}
 

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -345,6 +345,7 @@ def build_es_conn_config(conf):
     parsed_conf['profile'] = None
     parsed_conf['es_host'] = os.environ.get('ES_HOST', conf['es_host'])
     parsed_conf['es_port'] = int(os.environ.get('ES_PORT', conf['es_port']))
+    parsed_conf['es_version'] = os.environ.get('ES_VERSION', conf.get('es_version'))
     parsed_conf['es_url_prefix'] = ''
     parsed_conf['es_conn_timeout'] = conf.get('es_conn_timeout', 20)
     parsed_conf['send_get_body_as'] = conf.get('es_send_get_body_as', 'GET')

--- a/example_rules/example_cardinality.yaml
+++ b/example_rules/example_cardinality.yaml
@@ -8,6 +8,10 @@
 # Elasticsearch port
 # es_port: 14900
 
+# (Optional)
+# Elasticsearch version
+# es_version: 7.8.0
+
 # (Required)
 # Index to search, wildcard supported
 index: logstash-*

--- a/example_rules/example_frequency.yaml
+++ b/example_rules/example_frequency.yaml
@@ -8,6 +8,10 @@
 # Elasticsearch port
 # es_port: 14900
 
+# (Optional)
+# Elasticsearch version
+# es_version: 7.8.0
+
 # (OptionaL) Connect with SSL to Elasticsearch
 #use_ssl: True
 

--- a/example_rules/example_new_term.yaml
+++ b/example_rules/example_new_term.yaml
@@ -9,6 +9,10 @@
 # Elasticsearch port
 # es_port: 14900
 
+# (Optional)
+# Elasticsearch version
+# es_version: 7.8.0
+
 # (OptionaL) Connect with SSL to Elasticsearch
 #use_ssl: True
 

--- a/example_rules/example_opsgenie_frequency.yaml
+++ b/example_rules/example_opsgenie_frequency.yaml
@@ -8,6 +8,10 @@
 # Elasticsearch port
 #es_port: 9200
 
+# (Optional)
+# Elasticsearch version
+# es_version: 7.8.0
+
 # (Required)
 # OpsGenie credentials
 opsgenie_key: ogkey
@@ -24,7 +28,7 @@ opsgenie_key: ogkey
 # (Optional)
 # OpsGenie recipients with args
 # opsgenie_recipients:
-#   - {recipient} 
+#   - {recipient}
 # opsgenie_recipients_args:
 #     team_prefix:'user.email'
 
@@ -36,7 +40,7 @@ opsgenie_key: ogkey
 # (Optional)
 # OpsGenie teams with args
 # opsgenie_teams:
-#   - {team_prefix}-Team 
+#   - {team_prefix}-Team
 # opsgenie_teams_args:
 #     team_prefix:'team'
 

--- a/example_rules/example_spike.yaml
+++ b/example_rules/example_spike.yaml
@@ -8,6 +8,10 @@
 # Elasticsearch port
 # es_port: 14900
 
+# (Optional)
+# Elasticsearch version
+# es_version: 7.8.0
+
 # (Optional) Connect with SSL to Elasticsearch
 #use_ssl: True
 


### PR DESCRIPTION
Signed-off-by: Vincent Bisserie <vincent.bisserie@renault.com>

Some Elastalert user do not have sufficient rights to GET info from root of ElasticSearch node.
Here is a way to avoid info query : 
Attribute `es_version` in config or `ES_VERSION` in environment variables.