### PR TITLE
TheHive alerter: Allow severity and tlp to be set by rule

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -2154,7 +2154,10 @@ class HiveAlerter(Alerter):
                         n += 1
                         custom_fields[cf_key] = cf
                 elif isinstance(alert_config_value, str):
-                    alert_config[alert_config_field] = alert_config_value.format(**context)
+                    alert_value = alert_config_value.format(**context)
+                    if alert_config_field in ['severity','tlp']:
+                        alert_value = int(alert_value)
+                    alert_config[alert_config_field] = alert_value
                 elif isinstance(alert_config_value, (list, tuple)):
                     formatted_list = []
                     for element in alert_config_value:

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -2155,7 +2155,7 @@ class HiveAlerter(Alerter):
                         custom_fields[cf_key] = cf
                 elif isinstance(alert_config_value, str):
                     alert_value = alert_config_value.format(**context)
-                    if alert_config_field in ['severity','tlp']:
+                    if alert_config_field in ['severity', 'tlp']:
                         alert_value = int(alert_value)
                     alert_config[alert_config_field] = alert_value
                 elif isinstance(alert_config_value, (list, tuple)):


### PR DESCRIPTION
Explicitly casts severity/tlp as `int`, which is required by TheHive api.

Closes https://github.com/Yelp/elastalert/issues/2182

@Qmando can you review?