### PR TITLE
allow custom http_headers in config.yaml

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -53,6 +53,10 @@ es_port: 9200
 #client_cert: /path/to/client_cert.pem
 #client_key: /path/to/client_key.key
 
+# Add custom http_headers to the request to elasticsearch
+#http_headers:
+#  Bearer: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+
 # The index on es_host which is used for metadata storage
 # This can be a unmapped index, but it is recommended that you run
 # elastalert-create-index to set a mapping

--- a/elastalert/__init__.py
+++ b/elastalert/__init__.py
@@ -23,6 +23,7 @@ class ElasticSearchClient(Elasticsearch):
                                                   verify_certs=conf['verify_certs'],
                                                   ca_certs=conf['ca_certs'],
                                                   connection_class=RequestsHttpConnection,
+                                                  headers=conf['http_headers'],
                                                   http_auth=conf['http_auth'],
                                                   timeout=conf['es_conn_timeout'],
                                                   send_get_body_as=conf['send_get_body_as'],

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -204,6 +204,7 @@ def main():
         send_get_body_as = data.get('send_get_body_as', 'GET')
         ca_certs = data.get('ca_certs')
         client_cert = data.get('client_cert')
+        http_headers = data.get('http_headers')
         client_key = data.get('client_key')
         index = args.index if args.index is not None else data.get('writeback_index')
         alias = args.alias if args.alias is not None else data.get('writeback_alias')
@@ -229,6 +230,7 @@ def main():
         send_get_body_as = args.send_get_body_as
         ca_certs = None
         client_cert = None
+        http_headers = None
         client_key = None
         index = args.index if args.index is not None else input('New index name? (Default elastalert_status) ')
         if not index:
@@ -254,6 +256,7 @@ def main():
         use_ssl=use_ssl,
         verify_certs=verify_certs,
         connection_class=RequestsHttpConnection,
+        headers=http_headers,
         http_auth=http_auth,
         url_prefix=url_prefix,
         send_get_body_as=send_get_body_as,

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -315,6 +315,10 @@ class RulesLoader(object):
             rule.setdefault('client_cert', conf.get('client_cert'))
             rule.setdefault('client_key', conf.get('client_key'))
 
+        # Add supoprt for custom http headers
+        if 'http_headers' in conf:
+            rule.setdefault('http_headers', conf.get('http_headers'))
+
         # Set HipChat options from global config
         rule.setdefault('hipchat_msg_color', 'red')
         rule.setdefault('hipchat_domain', 'api.hipchat.com')

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -338,6 +338,7 @@ def build_es_conn_config(conf):
     parsed_conf['ca_certs'] = None
     parsed_conf['client_cert'] = None
     parsed_conf['client_key'] = None
+    parsed_conf['http_headers'] = None
     parsed_conf['http_auth'] = None
     parsed_conf['es_username'] = None
     parsed_conf['es_password'] = None
@@ -378,6 +379,9 @@ def build_es_conn_config(conf):
 
     if 'client_cert' in conf:
         parsed_conf['client_cert'] = conf['client_cert']
+
+    if 'http_headers' in conf:
+        parsed_conf['http_headers'] = conf['http_headers']
 
     if 'client_key' in conf:
         parsed_conf['client_key'] = conf['client_key']


### PR DESCRIPTION
This PR creates the config option
```
http_headers:
  Bearer: eyJhbGciO...
  MyFancyHeader: MyFancyValue

```
in config.yml to allow setting custom HTTP Headers in request to elasticsearch.