### PR TITLE
Add support for custom_details in the PagerDuty alerter v2 module

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1915,6 +1915,9 @@ See https://v2.developer.pagerduty.com/docs/send-an-event-events-api-v2
 
 ``pagerduty_v2_payload_source_args``: If set, and ``pagerduty_v2_payload_source`` is a formattable string, Elastalert will format the source based on the provided array of fields from the rule or match.
 
+``pagerduty_v2_custom_details``: List of keys:values to use as the content of the custom_details payload. Example - ip:clientip will map the value from the clientip index of Elasticsearch to JSON key named ip. If not defined, all the Elasticsearch keys will be sent as a custom detail field named "information".
+
+
 PagerTree
 ~~~~~~~~~
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1357,6 +1357,7 @@ class PagerDutyAlerter(Alerter):
         self.pagerduty_v2_payload_severity = self.rule.get('pagerduty_v2_payload_severity', 'critical')
         self.pagerduty_v2_payload_source = self.rule.get('pagerduty_v2_payload_source', 'ElastAlert')
         self.pagerduty_v2_payload_source_args = self.rule.get('pagerduty_v2_payload_source_args', None)
+        self.pagerduty_v2_custom_details = self.rule.get('pagerduty_v2_custom_details', {})
 
         if self.pagerduty_api_version == 'v2':
             self.url = 'https://events.pagerduty.com/v2/enqueue'
@@ -1369,6 +1370,16 @@ class PagerDutyAlerter(Alerter):
         # post to pagerduty
         headers = {'content-type': 'application/json'}
         if self.pagerduty_api_version == 'v2':
+            # set custom_details for v2
+            custom_details_payload = {
+                'information': body
+            }
+            if self.pagerduty_v2_custom_details:
+                for match in matches:
+                    for custom_details_key, es_key in list(self.pagerduty_v2_custom_details.items()):
+                        elastalert_logger.info("PD - PagerDuty custom details: %s => %s" % (custom_details_key, es_key))
+                        custom_details_payload[custom_details_key] = lookup_es_key(match, es_key)
+
             payload = {
                 'routing_key': self.pagerduty_service_key,
                 'event_action': self.pagerduty_event_type,
@@ -1389,9 +1400,7 @@ class PagerDutyAlerter(Alerter):
                                                          self.pagerduty_v2_payload_source_args,
                                                          matches),
                     'summary': self.create_title(matches),
-                    'custom_details': {
-                        'information': body,
-                    },
+                    'custom_details': custom_details_payload,
                 },
             }
             match_timestamp = lookup_es_key(matches[0], self.rule.get('timestamp_field', '@timestamp'))

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -61,6 +61,7 @@ def _find_es_dict_by_key(lookup_dict, term):
     element which is the last subkey used to access the target specified by the term. None is
     returned for both if the key can not be found.
     """
+
     if term in lookup_dict:
         return lookup_dict, term
     # If the term does not match immediately, perform iterative lookup:
@@ -76,6 +77,10 @@ def _find_es_dict_by_key(lookup_dict, term):
     # For example:
     #  {'foo.bar': {'bar': 'ray'}} to look up foo.bar will return {'bar': 'ray'}, not 'ray'
     dict_cursor = lookup_dict
+
+    if not term:
+        elastalert_logger.error("ElasticSearch term not found!")
+        return dict_cursor, '<NOT FOUND>'
 
     while term:
         split_results = re.split(r'\[(\d)\]', term, maxsplit=1)


### PR DESCRIPTION
This PR will add the ability to set the custom_details field in the PagerDuty ruletype.
https://developer.pagerduty.com/docs/events-api-v2/trigger-events/