### PR TITLE
added docs telegram_proxy_login and telegram_proxy_pass

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1842,6 +1842,10 @@ Optional:
 
 ``telegram_proxy``: By default ElastAlert will not use a network proxy to send notifications to Telegram. Set this option using ``hostname:port`` if you need to use a proxy.
 
+``telegram_proxy_login``: The Telegram proxy auth username.
+
+``telegram_proxy_pass``: The Telegram proxy auth password.
+
 GoogleChat
 ~~~~~~~~~~
 GoogleChat alerter will send a notification to a predefined GoogleChat channel. The body of the notification is formatted the same as with other alerters.


### PR DESCRIPTION
Added description of the following settings to the documentation

- telegram_proxy_login
- telegram_proxy_pass