### PR TITLE
Fix the use of timestamps in the Jira ticket titles

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -868,7 +868,9 @@ class JiraAlerter(Alerter):
         if for_search:
             return title
 
-        title += ' - %s' % (pretty_ts(matches[0][self.rule['timestamp_field']], self.rule.get('use_local_time')))
+        timestamp = matches[0].get(self.rule['timestamp_field'])
+        if timestamp:
+            title += ' - %s' % (pretty_ts(timestamp, self.rule.get('use_local_time')))
 
         # Add count for spikes
         count = matches[0].get('spike_count')


### PR DESCRIPTION
This has come about because we currently use records which have timestamps like:

```
    "@timestamp": {
      "min": "2020-10-03T07:05:01.987Z",
      "max": "2020-10-05T07:05:09.572Z"
    },
```

These work fine in ElastAlert rules defined to use most alerting platforms, with the `timestamp_field` 
set to `@timestamp.min`.

However, when we try to create a Jira alert against records of this format, we run
into a Python error:

```
File "/usr/local/lib/python3.6/site-packages/elastalert/alerts.py", line 875, in create_default_title,
title += ' - %s' % (pretty_ts(matches[0][self.rule['timestamp_field']], self.rule.get('use_local_time'))), KeyError: '@timestamp.min'
```

This is because `matches[0][self.rule['timestamp_field']]` attempts to access
the `timestamp_field` directly rather than using a `get()`.

The proposed fix will not change any existing behaviour, but will skip the addition
of a timestamp to the ticket title if the required field doesn't exist, rather than
throwing an error and disabling the rule.