### PR TITLE
Fix initializing self.thread_data.alerts_sent for running elastalert-test-rule

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -159,6 +159,7 @@ class ElastAlerter(object):
         self.starttime = self.args.start
         self.disabled_rules = []
         self.replace_dots_in_field_names = self.conf.get('replace_dots_in_field_names', False)
+        self.thread_data.alerts_sent = 0
         self.thread_data.num_hits = 0
         self.thread_data.num_dupes = 0
         self.scheduler = BackgroundScheduler()


### PR DESCRIPTION
Fix for #2634 AttributeError: '_thread._local' object has no attribute 'alerts_sent'

This initializing seems to be lost at this commit.
https://github.com/Yelp/elastalert/commit/df481d045c7c0efb9a46c268556ac6300564c19d#diff-de8c5a47817fa23d1afa305e6d3c3e8ee717e7236c4278a57df4ab30d4ecddcaL143-R158