### PR TITLE
Update docs Running ElastAlert

### DIFF
--- a/docs/source/running_elastalert.rst
+++ b/docs/source/running_elastalert.rst
@@ -10,7 +10,10 @@ Requirements
 - ISO8601 or Unix timestamped data
 - Python 3.6
 - pip, see requirements.txt
-- Packages on Ubuntu 14.x: python-pip python-dev libffi-dev libssl-dev
+- Packages on Ubuntu 18.x: build-essential python3-pip python3.6-dev libffi-dev libssl-dev
+- Packages on Ubuntu 20.x: build-essential python3-pip python3.6 python3.6-dev libffi-dev libssl-dev 
+- Packages on CentOS 7.x: 'Development Tools' python3-pip python3-devel python3-libs python3-setuptools libffi-devel openssl-devel
+- Packages on CentOS 8.x: 'Development Tools' python3-pip python36 python3-devel python3-setuptools python3-libs libffi-devel openssl-devel
 
 Downloading and Configuring
 ---------------------------


### PR DESCRIPTION
**before**

- Packages on Ubuntu 14.x: python-pip python-dev libffi-dev libssl-dev

**after**

- Packages on Ubuntu 18.x: build-essential python3-pip python3.6-dev libffi-dev libssl-dev
- Packages on Ubuntu 20.x: build-essential python3-pip python3.6 python3.6-dev libffi-dev libssl-dev 
- Packages on CentOS 7.x: 'Development Tools' python3-pip python3-devel python3-libs python3-setuptools libffi-devel openssl-devel
- Packages on CentOS 8.x: 'Development Tools' python3-pip python36 python3-devel python3-setuptools python3-libs libffi-devel openssl-devel