### PR TITLE
Fix PyYAML Deprecated Warning

### DIFF
--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -192,7 +192,7 @@ def main():
 
     if filename:
         with open(filename) as config_file:
-            data = yaml.load(config_file, Loader=yaml.SafeLoader)
+            data = yaml.load(config_file, Loader=yaml.UnsafeLoader)
         host = args.host if args.host else data.get('es_host')
         port = args.port if args.port else data.get('es_port')
         username = args.username if args.username else data.get('es_username')

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -192,7 +192,7 @@ def main():
 
     if filename:
         with open(filename) as config_file:
-            data = yaml.load(config_file, Loader=yaml.FullLoader)
+            data = yaml.load(config_file, Loader=yaml.SafeLoader)
         host = args.host if args.host else data.get('es_host')
         port = args.port if args.port else data.get('es_port')
         username = args.username if args.username else data.get('es_username')

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -92,7 +92,7 @@ class RulesLoader(object):
     def __init__(self, conf):
         # schema for rule yaml
         self.rule_schema = jsonschema.Draft7Validator(
-            yaml.load(open(os.path.join(os.path.dirname(__file__), 'schema.yaml')), Loader=yaml.FullLoader))
+            yaml.load(open(os.path.join(os.path.dirname(__file__), 'schema.yaml')), Loader=yaml.SafeLoader))
 
         self.base_config = copy.deepcopy(conf)
 

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -92,7 +92,7 @@ class RulesLoader(object):
     def __init__(self, conf):
         # schema for rule yaml
         self.rule_schema = jsonschema.Draft7Validator(
-            yaml.load(open(os.path.join(os.path.dirname(__file__), 'schema.yaml')), Loader=yaml.SafeLoader))
+            yaml.load(open(os.path.join(os.path.dirname(__file__), 'schema.yaml')), Loader=yaml.UnsafeLoader))
 
         self.base_config = copy.deepcopy(conf)
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'prison>=0.1.2',
         'PyStaticConfiguration>=0.10.3',
         'python-dateutil>=2.6.0,<2.7.0',
-        'PyYAML>=3.12',
+        'PyYAML>=5.1',
         'requests>=2.10.0',
         'stomp.py>=4.1.17',
         'texttable>=0.8.8',


### PR DESCRIPTION
Fixed the following issues

[Error on loading yaml because of incorrect dependency version (PyYAML) #2956](https://github.com/Yelp/elastalert/issues/2956)

**create_index.py, loaders.py**

```
yaml.FullLoader
       ↓
yaml.UnsafeLoader
```

**setup.py**

Sync requirements.txt

```
PyYAML>=3.12
       ↓
PyYAML>=5.1
```