### PR TITLE
Fix for the mapping error reported in #2899.

### DIFF
--- a/elastalert/es_mappings/6/elastalert.json
+++ b/elastalert/es_mappings/6/elastalert.json
@@ -29,6 +29,7 @@
       "format": "dateOptionalTime"
     },
     "match_body": {
+      "enabled": "false",
       "type": "object"
     },
     "aggregate_id": {


### PR DESCRIPTION
Seems to fix this error:

ERROR:root:Error writing alert info to Elasticsearch: RequestError(400, 'mapper_parsing_exception', "failed to parse field [match_body.weblog.body_bytes_sent] of type [long] in document with id 'iiC6m3MBDLealW5s7dvq'") #2899

