### PR TITLE
Fix the empty compound_query_key value

### DIFF
--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -331,13 +331,8 @@ class RulesLoader(object):
 
         raw_query_key = rule.get('query_key')
         if isinstance(raw_query_key, list):
-            if len(raw_query_key) > 1:
-                rule['compound_query_key'] = raw_query_key
-                rule['query_key'] = ','.join(raw_query_key)
-            elif len(raw_query_key) == 1:
-                rule['query_key'] = raw_query_key[0]
-            else:
-                del(rule['query_key'])
+            rule['compound_query_key'] = raw_query_key
+            rule['query_key'] = ','.join(raw_query_key)
 
         if isinstance(rule.get('aggregation_key'), list):
             rule['compound_aggregation_key'] = rule['aggregation_key']


### PR DESCRIPTION
With the existing codes, the rule['compound_compare_key'] is empty when we have only one query_key in the yaml config. And it breaks the custom_format function and hence throwing the exception.

ERROR:root:Traceback (most recent call last):
File "/usr/local/home/user/lib64/python3.6/site-packages/elastalert/elastalert.py", line 1458, in alert
return self.send_alert(matches, rule, alert_time=alert_time, retried=retried)
File "/usr/local/home/user/lib64/python3.6/site-packages/elastalert/elastalert.py", line 1527, in send_alert
enhancement.process(match)
File "/usr/local/home/user/lib64/python3.6/site-packages/elast_format/custom_format.py", line 117, in process
total_hit_real_key = match[self.rule['query_key']]
KeyError: 'query_key'

It seems that the rule['compound_query_key'] is required all time for various functions to be executed if there is at least one.

I have rolled back the change to the previous working one logic, it seems the deletion of rule['query_key'] is not necessary.