### PR TITLE
Change Library blist to sortedcontainers

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -3,7 +3,7 @@ import copy
 import datetime
 import sys
 
-from sortedcontainers import SortedKeyList
+from sortedcontainers import SortedKeyList as sortedlist
 
 from .util import add_raw_postfix
 from .util import dt_to_ts
@@ -306,11 +306,11 @@ class EventWindow(object):
         self.timeframe = timeframe
         self.onRemoved = onRemoved
         self.get_ts = getTimestamp
-        self.data = SortedKeyList(key=self.get_ts)
+        self.data = sortedlist(key=self.get_ts)
         self.running_count = 0
 
     def clear(self):
-        self.data = SortedKeyList(key=self.get_ts)
+        self.data = sortedlist(key=self.get_ts)
         self.running_count = 0
 
     def append(self, event):

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -3,7 +3,7 @@ import copy
 import datetime
 import sys
 
-from blist import sortedlist
+from sortedcontainers import SortedKeyList
 
 from .util import add_raw_postfix
 from .util import dt_to_ts
@@ -306,11 +306,11 @@ class EventWindow(object):
         self.timeframe = timeframe
         self.onRemoved = onRemoved
         self.get_ts = getTimestamp
-        self.data = sortedlist(key=self.get_ts)
+        self.data = SortedKeyList(key=self.get_ts)
         self.running_count = 0
 
     def clear(self):
-        self.data = sortedlist(key=self.get_ts)
+        self.data = SortedKeyList(key=self.get_ts)
         self.running_count = 0
 
     def append(self, event):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 apscheduler>=3.3.0
 aws-requests-auth>=0.3.0
-blist>=1.3.6
+sortedcontainers>=2.2.2
 boto3>=1.4.4
 cffi>=1.11.5
 configparser>=3.5.0

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         'apscheduler>=3.3.0',
         'aws-requests-auth>=0.3.0',
-        'blist>=1.3.6',
+        'sortedcontainers>=2.2.2',
         'boto3>=1.4.4',
         'configparser>=3.5.0',
         'croniter>=0.3.16',


### PR DESCRIPTION
I've found that blist hasn't been updated for quite some time and that it doesn't work properly in Python 3.9, 
so I suggest changing it to another library.

Related issue
https://github.com/Yelp/elastalert/issues/2983