### PR TITLE
Fix Stomp

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -371,7 +371,6 @@ class StompAlerter(Alerter):
 
         conn = stomp.Connection([(self.stomp_hostname, self.stomp_hostport)], use_ssl=self.stomp_ssl)
 
-        conn.start()
         conn.connect(self.stomp_login, self.stomp_password)
         # Ensures that the CONNECTED frame is received otherwise, the disconnect call will fail.
         time.sleep(1)


### PR DESCRIPTION
Fix
https://github.com/Yelp/elastalert/issues/2731

delete 「conn.start()」

```
conn.start()
AttributeError: 'StompConnection11' object has no attribute 'start'
```

Confirmed that ElastAlert setup.py and requirements.txt uses any version of Stomp newer than 4.1.17, and the latest version of Stomp does not support a top level .start() method call. Only the stomp.transport sub module provides a start() method. Further, the documented quick-start and related examples make no mention of the need to call .start(). Documentation referenced from this location: https://pypi.org/project/stomp.py/