### PR TITLE
Remove the forgotten code of new_style_string_format

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -896,10 +896,6 @@ class CommandAlerter(Alerter):
                 logging.warning('Warning! You could be vulnerable to shell injection!')
             self.rule['command'] = [self.rule['command']]
 
-        self.new_style_string_format = False
-        if 'new_style_string_format' in self.rule and self.rule['new_style_string_format']:
-            self.new_style_string_format = True
-
     def alert(self, matches):
         # Format the command and arguments
         try:

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -1072,32 +1072,6 @@ def test_command():
         alert.alert([match])
     assert mock_popen.called_with('/bin/test/foo.sh', stdin=subprocess.PIPE, shell=True)
 
-    # Test command as string with formatted arg (new-style string format)
-    rule = {'command': '/bin/test/ --arg {match[somefield]}', 'new_style_string_format': True}
-    alert = CommandAlerter(rule)
-    with mock.patch("elastalert.alerts.subprocess.Popen") as mock_popen:
-        alert.alert([match])
-    assert mock_popen.called_with('/bin/test --arg foobarbaz', stdin=subprocess.PIPE, shell=False)
-
-    rule = {'command': '/bin/test/ --arg {match[nested][field]}', 'new_style_string_format': True}
-    alert = CommandAlerter(rule)
-    with mock.patch("elastalert.alerts.subprocess.Popen") as mock_popen:
-        alert.alert([match])
-    assert mock_popen.called_with('/bin/test --arg 1', stdin=subprocess.PIPE, shell=False)
-
-    # Test command as string without formatted arg (new-style string format)
-    rule = {'command': '/bin/test/foo.sh', 'new_style_string_format': True}
-    alert = CommandAlerter(rule)
-    with mock.patch("elastalert.alerts.subprocess.Popen") as mock_popen:
-        alert.alert([match])
-    assert mock_popen.called_with('/bin/test/foo.sh', stdin=subprocess.PIPE, shell=True)
-
-    rule = {'command': '/bin/test/foo.sh {{bar}}', 'new_style_string_format': True}
-    alert = CommandAlerter(rule)
-    with mock.patch("elastalert.alerts.subprocess.Popen") as mock_popen:
-        alert.alert([match])
-    assert mock_popen.called_with('/bin/test/foo.sh {bar}', stdin=subprocess.PIPE, shell=True)
-
     # Test command with pipe_match_json
     rule = {'command': ['/bin/test/', '--arg', '%(somefield)s'],
             'pipe_match_json': True}


### PR DESCRIPTION
Deleted the code that was omitted when new_style_string_format was deleted at the following commit. Also deleted the test code of new_style_string_format

Refactored resolve_string
https://github.com/Yelp/elastalert/commit/ca82ece621e1d2248bbe7d42d63941f34da53e00#diff-93c4ac73b454d85d4631ec52accb336d3cc319ada04dfa64ad14bc7242294c09