### PR TITLE
fix: could not import module linenotify

### DIFF
--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -77,7 +77,8 @@ class RulesLoader(object):
         'servicenow': alerts.ServiceNowAlerter,
         'alerta': alerts.AlertaAlerter,
         'post': alerts.HTTPPostAlerter,
-        'hivealerter': alerts.HiveAlerter
+        'hivealerter': alerts.HiveAlerter,
+        'linenotify': alerts.LineNotifyAlerter
     }
 
     # A partial ordering of alert types. Relative order will be preserved in the resulting alerts list


### PR DESCRIPTION
To include LineNotifyAlerter in alerts_mapping.