### PR TITLE
Fix docker test

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,6 +1,8 @@
 FROM ubuntu:latest
 
 RUN apt-get update && apt-get upgrade -y
+RUN apt-get install software-properties-common -y
+RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get -y install build-essential python3.6 python3.6-dev python3-pip libssl-dev git
 
 WORKDIR /home/elastalert

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ pylint<1.4
 pytest<3.3.0
 setuptools
 sphinx_rtd_theme
-tox<2.0
+tox==3.20.1


### PR DESCRIPTION
Fix
https://stackoverflow.com/questions/65020700/facing-issue-virtualenv-error-argument-setuptools-expected-one-argument-w

**error 1**

```
Building tox
Step 1/6 : FROM ubuntu:latest
 ---> f643c72bc252
Step 2/6 : RUN apt-get update && apt-get upgrade -y
 ---> Running in d05f8136061b
Get:1 http://security.ubuntu.com/ubuntu focal-security InRelease [109 kB]
Get:2 http://archive.ubuntu.com/ubuntu focal InRelease [265 kB]
Get:3 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages [495 kB]
Get:4 http://security.ubuntu.com/ubuntu focal-security/universe amd64 Packages [645 kB]
Get:5 http://archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
Get:6 http://security.ubuntu.com/ubuntu focal-security/restricted amd64 Packages [103 kB]
Get:7 http://security.ubuntu.com/ubuntu focal-security/multiverse amd64 Packages [1167 B]
Get:8 http://archive.ubuntu.com/ubuntu focal-backports InRelease [101 kB]
Get:9 http://archive.ubuntu.com/ubuntu focal/restricted amd64 Packages [33.4 kB]
Get:10 http://archive.ubuntu.com/ubuntu focal/multiverse amd64 Packages [177 kB]
Get:11 http://archive.ubuntu.com/ubuntu focal/universe amd64 Packages [11.3 MB]
Get:12 http://archive.ubuntu.com/ubuntu focal/main amd64 Packages [1275 kB]
Get:13 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [885 kB]
Get:14 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [885 kB]
Get:15 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [30.4 kB]
Get:16 http://archive.ubuntu.com/ubuntu focal-updates/restricted amd64 Packages [136 kB]
Get:17 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [4250 B]
Fetched 16.6 MB in 5s (3205 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
Calculating upgrade...
The following packages will be upgraded:
  apt libapt-pkg6.0
2 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 2122 kB of archives.
After this operation, 2048 B of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libapt-pkg6.0 amd64 2.0.2ubuntu0.2 [832 kB]
Get:2 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 apt amd64 2.0.2ubuntu0.2 [1290 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 2122 kB in 3s (823 kB/s)
(Reading database ... 4121 files and directories currently installed.)
Preparing to unpack .../libapt-pkg6.0_2.0.2ubuntu0.2_amd64.deb ...
Unpacking libapt-pkg6.0:amd64 (2.0.2ubuntu0.2) over (2.0.2ubuntu0.1) ...
Setting up libapt-pkg6.0:amd64 (2.0.2ubuntu0.2) ...
(Reading database ... 4121 files and directories currently installed.)
Preparing to unpack .../apt_2.0.2ubuntu0.2_amd64.deb ...
Unpacking apt (2.0.2ubuntu0.2) over (2.0.2ubuntu0.1) ...
Setting up apt (2.0.2ubuntu0.2) ...
Processing triggers for libc-bin (2.31-0ubuntu9.1) ...
Removing intermediate container d05f8136061b
 ---> 342f16906b4d
Step 3/6 : RUN apt-get -y install build-essential python3.6 python3.6-dev python3-pip libssl-dev git
 ---> Running in 17a19f1e6520
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package python3.6-dev
E: Couldn't find any package by glob 'python3.6-dev'
E: Couldn't find any package by regex 'python3.6-dev'
ERROR: Service 'tox' failed to build: The command '/bin/sh -c apt-get -y install build-essential python3.6 python3.6-dev python3-pip libssl-dev git' returned a non-zero code: 100
```

**error 2**

```
$ docker logs -f elastalert_tox

GLOB sdist-make: /home/elastalert/setup.py
py36 recreate: /home/elastalert/.tox/py36
ERROR: invocation failed (exit code 2), logfile: /home/elastalert/.tox/py36/log/py36-0.log
ERROR: actionid=py36
msg=getenv
cmdargs=['/usr/bin/python3', '-m', 'virtualenv', '--setuptools', '--python', '/usr/bin/python3', 'py36']
env={'PATH': '/home/elastalert/.tox/py36/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', 'HOSTNAME': '4bc6e780de32', 'HOME': '/root', 'LC_CTYPE': 'C.UTF-8', 'PYTHONHASHSEED': '1380857561', 'VIRTUAL_ENV': '/home/elastalert/.tox/py36'}
SystemExit: 2
usage: virtualenv [--version] [--with-traceback] [-v | -q] [--read-only-app-data] [--app-data APP_DATA] [--reset-app-data] [--upgrade-embed-wheels] [--discovery {builtin}] [-p py] [--creator {builtin,cpython3-posix,venv}]
                  [--seeder {app-data,pip}] [--no-seed] [--activators comma_sep_list] [--clear] [--no-vcs-ignore] [--system-site-packages] [--symlinks | --copies] [--no-download | --download] [--extra-search-dir d [d ...]] [--pip version]
                  [--setuptools version] [--wheel version] [--no-pip] [--no-setuptools] [--no-wheel] [--no-periodic-update] [--symlink-app-data] [--prompt prompt] [-h]
                  dest
virtualenv: error: argument --setuptools: expected one argument

ERROR: InvocationError: /usr/bin/python3 -m virtualenv --setuptools --python /usr/bin/python3 py36 (see /home/elastalert/.tox/py36/log/py36-0.log)
docs recreate: /home/elastalert/.tox/docs
ERROR: invocation failed (exit code 2), logfile: /home/elastalert/.tox/docs/log/docs-0.log
ERROR: actionid=docs
msg=getenv
cmdargs=['/usr/bin/python3', '-m', 'virtualenv', '--setuptools', '--python', '/usr/bin/python3', 'docs']
env={'PATH': '/home/elastalert/.tox/docs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', 'HOSTNAME': '4bc6e780de32', 'HOME': '/root', 'LC_CTYPE': 'C.UTF-8', 'PYTHONHASHSEED': '1380857561', 'VIRTUAL_ENV': '/home/elastalert/.tox/docs'}
SystemExit: 2
usage: virtualenv [--version] [--with-traceback] [-v | -q] [--read-only-app-data] [--app-data APP_DATA] [--reset-app-data] [--upgrade-embed-wheels] [--discovery {builtin}] [-p py] [--creator {builtin,cpython3-posix,venv}]
                  [--seeder {app-data,pip}] [--no-seed] [--activators comma_sep_list] [--clear] [--no-vcs-ignore] [--system-site-packages] [--symlinks | --copies] [--no-download | --download] [--extra-search-dir d [d ...]] [--pip version]
                  [--setuptools version] [--wheel version] [--no-pip] [--no-setuptools] [--no-wheel] [--no-periodic-update] [--symlink-app-data] [--prompt prompt] [-h]
                  dest
virtualenv: error: argument --setuptools: expected one argument

ERROR: InvocationError: /usr/bin/python3 -m virtualenv --setuptools --python /usr/bin/python3 docs (see /home/elastalert/.tox/docs/log/docs-0.log)
___________________________________ summary ____________________________________
ERROR:   py36: InvocationError: /usr/bin/python3 -m virtualenv --setuptools --python /usr/bin/python3 py36 (see /home/elastalert/.tox/py36/log/py36-0.log)
ERROR:   docs: InvocationError: /usr/bin/python3 -m virtualenv --setuptools --python /usr/bin/python3 docs (see /home/elastalert/.tox/docs/log/docs-0.log)
```