### PR TITLE
email alerter: add smtp_tls flag to allow user to disable TLS

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1479,8 +1479,10 @@ an email would be sent to ``qlo@example.com``
 
 ``smtp_port``: The port to use. Default is 25.
 
-``smtp_ssl``: Connect the SMTP host using TLS, defaults to ``false``. If ``smtp_ssl`` is not used, ElastAlert will still attempt
+``smtp_ssl``: Connect the SMTP host using SSL, defaults to ``false``. If ``smtp_ssl`` is not used, ElastAlert will still attempt
 STARTTLS.
+
+``smtp_tls``: Connect the SMTP host using TLS, defaults to ``true``.
 
 ``smtp_auth_file``: The path to a file which contains SMTP authentication credentials. The path can be either absolute or relative
 to the given rule. It should be YAML formatted and contain two fields, ``user`` and ``password``. If this is not present,

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -408,6 +408,7 @@ class EmailAlerter(Alerter):
 
         self.smtp_host = self.rule.get('smtp_host', 'localhost')
         self.smtp_ssl = self.rule.get('smtp_ssl', False)
+        self.smtp_tls = self.rule.get('smtp_tls', True)
         self.from_addr = self.rule.get('from_addr', 'ElastAlert')
         self.smtp_port = self.rule.get('smtp_port')
         if self.rule.get('smtp_auth_file'):
@@ -476,7 +477,7 @@ class EmailAlerter(Alerter):
                 else:
                     self.smtp = SMTP(self.smtp_host)
                 self.smtp.ehlo()
-                if self.smtp.has_extn('STARTTLS'):
+                if self.smtp.has_extn('STARTTLS') and self.smtp_tls:
                     self.smtp.starttls(keyfile=self.smtp_key_file, certfile=self.smtp_cert_file)
             if 'smtp_auth_file' in self.rule:
                 self.smtp.login(self.user, self.password)


### PR DESCRIPTION
Hello

I want to disable TLS and SSL completely in my case. I suggest this.
What do you think ?

Regards,