### PR TITLE
Fix travis-ci job error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
 - TOXENV=py36
 before_script:
 - sudo apt-get update -y
-- sudo apt-get install -y cargo
+- sudo apt-get install -y cargo python3-dev
 install:
 - pip install --upgrade pip
 - pip install cryptography

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
 - TOXENV=py36
 before_script:
 - sudo apt-get update -y
-- sudo apt-get install -y cargo python3-dev
+- sudo apt-get install -y build-essential libssl-dev libffi-dev python3-dev cargo
 install:
 - pip install --upgrade pip
 - pip install cryptography

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,8 @@ python:
 env:
 - TOXENV=docs
 - TOXENV=py36
-before_script:
-- sudo apt-get update -y
-- sudo apt-get install -y build-essential libssl-dev libffi-dev python3-dev cargo
 install:
-- pip install --upgrade pip
-- pip install cryptography
+- pip install 'cryptography<3.4'
 - pip install tox
 - >
   if [[ -n "${ES_VERSION}" ]] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
 env:
 - TOXENV=docs
 - TOXENV=py36
+before_script:
+- sudo apt-get update -y
+- sudo apt-get install -y build-essential libssl-dev libffi-dev cargo
 install:
 - pip install 'cryptography<3'
 - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ env:
 before_script:
 - sudo apt-get update -y
 - sudo apt-get install -y build-essential libssl-dev libffi-dev python3-dev cargo
+- python -m pip install --upgrade pip
 install:
-- pip install 'cryptography<3.4'
+- pip install cryptography
 - pip install tox
 - >
   if [[ -n "${ES_VERSION}" ]] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
 env:
 - TOXENV=docs
 - TOXENV=py36
+before_script:
+- sudo apt-get update -y
+- sudo apt-get install -y build-essential libssl-dev libffi-dev python3-dev cargo
 install:
 - pip install 'cryptography<3.4'
 - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,8 @@ python:
 env:
 - TOXENV=docs
 - TOXENV=py36
-before_script:
-- sudo apt-get update -y
-- sudo apt-get install -y build-essential libssl-dev libffi-dev python3-dev cargo
-- python -m pip install --upgrade pip
 install:
-- pip install cryptography
+- pip install 'cryptography<3'
 - pip install tox
 - >
   if [[ -n "${ES_VERSION}" ]] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,12 @@ python:
 env:
 - TOXENV=docs
 - TOXENV=py36
+before_script:
+- sudo apt-get update -y
+- sudo apt-get install -y cargo
 install:
+- pip install --upgrade pip
+- pip install cryptography
 - pip install tox
 - >
   if [[ -n "${ES_VERSION}" ]] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,7 @@ python:
 env:
 - TOXENV=docs
 - TOXENV=py36
-before_script:
-- sudo apt-get update -y
-- sudo apt-get install -y build-essential libssl-dev libffi-dev cargo
 install:
-- pip install 'cryptography<3'
 - pip install tox
 - >
   if [[ -n "${ES_VERSION}" ]] ; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ requests>=2.0.0
 stomp.py>=4.1.17
 texttable>=0.8.8
 twilio==6.0.0
+cryptography<3.4

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'stomp.py>=4.1.17',
         'texttable>=0.8.8',
         'twilio>=6.0.0,<6.1',
-        'cffi>=1.11.5'
+        'cffi>=1.11.5',
+        'cryptography<3.4'
     ]
 )


### PR DESCRIPTION
https://github.com/Yelp/elastalert/issues/3118

**setup.py and requirements.txt**

add 「cryptography<3.4」

It is a provisional response. 
This is because adding the following run to .travis.yml didn't work.

```
sudo apt-get install -y cargo
pip install --upgrade pip
pip install cryptography
```