### PR TITLE
use rule timeframe when scan_entire_timeframe is set

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -743,7 +743,7 @@ class ElastAlerter(object):
                 # Query from the end of the last run, if it exists, otherwise a run_every sized window
                 rule['starttime'] = rule.get('previous_endtime', endtime - self.run_every)
             else:
-                rule['starttime'] = rule.get('previous_endtime', endtime - rule['timeframe'])
+                rule['starttime'] = endtime - rule['timeframe']
 
     def adjust_start_time_for_overlapping_agg_query(self, rule):
         if rule.get('aggregation_query_element'):


### PR DESCRIPTION
#3041 There is rule option [scan_entire_timeframe](https://elastalert.readthedocs.io/en/latest/ruletypes.html#scan-entire-timeframe) which indicate that elastalert should scan entire timeframe set in rule. Unfortunately it scans the timeframe only in the first run. Currently it is almost impossible to ensure that rule timeframe is scan. This brings issues where errors could be overlooked. For example the elastalert query data only for last minute when *run_every* is set to 1 minute but the logs are not ingested in such fast manner. This change only affects rules with option *use_count_query* or *use_term_query*.