### PR TITLE
fix compound query key in metric aggregation with bucket_interval

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -1079,24 +1079,20 @@ class MetricAggregationRule(BaseAggregationRule):
                                              result,
                                              compound_keys[1:],
                                              match_data)
-        elif 'interval_aggs' in aggregation_data:
-            for result in aggregation_data['interval_aggs']['buckets']:
-                self.check_matches_recursive(timestamp,
-                                             query_key,
-                                             result,
-                                             compound_keys[1:],
-                                             match_data)
         else:
-            metric_val = aggregation_data[self.metric_key]['value']
-            if self.crossed_thresholds(metric_val):
-                match_data[self.rules['timestamp_field']] = timestamp
-                match_data[self.metric_key] = metric_val
+            if 'interval_aggs' in aggregation_data:
+                metric_val_arr = [term[self.metric_key]['value'] for term in aggregation_data['interval_aggs']['buckets']]
+            else:
+                metric_val_arr = [aggregation_data[self.metric_key]['value']]
+            for metric_val in metric_val_arr:
+                if self.crossed_thresholds(metric_val):
+                    match_data[self.rules['timestamp_field']] = timestamp
+                    match_data[self.metric_key] = metric_val
 
-                # add compound key to payload to allow alerts to trigger for every unique occurence
-                compound_value = [match_data[key] for key in self.rules['compound_query_key']]
-                match_data[self.rules['query_key']] = ",".join([str(value) for value in compound_value])
-
-                self.add_match(match_data)
+                    # add compound key to payload to allow alerts to trigger for every unique occurence
+                    compound_value = [match_data[key] for key in self.rules['compound_query_key']]
+                    match_data[self.rules['query_key']] = ",".join([str(value) for value in compound_value])
+                    self.add_match(match_data)
 
     def crossed_thresholds(self, metric_value):
         if metric_value is None:

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -1079,7 +1079,13 @@ class MetricAggregationRule(BaseAggregationRule):
                                              result,
                                              compound_keys[1:],
                                              match_data)
-
+        elif 'interval_aggs' in aggregation_data:
+            for result in aggregation_data['interval_aggs']['buckets']:
+                self.check_matches_recursive(timestamp,
+                                             query_key,
+                                             result,
+                                             compound_keys[1:],
+                                             match_data)
         else:
             metric_val = aggregation_data[self.metric_key]['value']
             if self.crossed_thresholds(metric_val):


### PR DESCRIPTION
## Fix metric aggregation while using compound query key and bucket_interval together
### What happened here
1. config rules with type `metric_aggregation`, compound `query_key` and `bucket_interval` like below.
```
type: metric_aggregation
query_key: ["prometheus.labels.instance","prometheus.labels.app"]
bucket_interval:
  seconds: 30
```
2. Debugging into the call stack.
the `payload_data` param in function add_aggregation_data will contain compound `bucket_aggs`key looks like below 
https://github.com/Yelp/elastalert/blob/1dc4f30f30d39a689f419ce19c7e2e4d67a50be3/elastalert/ruletypes.py#L1000-L1007

``` json
{
    "bucket_aggs": {
        "doc_count_error_upper_bound": 0,
        "sum_other_doc_count": 0,
        "buckets": [
            {
                "key": "kafka",
                "doc_count": 32916,
                "bucket_aggs": {
                    "doc_count_error_upper_bound": 0,
                    "sum_other_doc_count": 0,
                    "buckets": [
                        {
                            "key": "stress-test-kafka",
                            "doc_count": 17628,
                            "interval_aggs": {
                                "buckets": [
                                    {
                                        "key_as_string": "2021-03-31T02:11:30.000Z",
                                        "key": 1617156690000,
                                        "doc_count": 1469,
                                        "metric_prometheus.metrics.kafka_controller_kafkacontroller_activecontrollercount_sum": {
                                            "value": 1
                                        }
                                    },
...(duplicated character removed)
```
 then after  indexing https://github.com/Yelp/elastalert/blob/1dc4f30f30d39a689f419ce19c7e2e4d67a50be3/elastalert/ruletypes.py#L1005 
and  unwarp_term_bucket 
https://github.com/Yelp/elastalert/blob/1dc4f30f30d39a689f419ce19c7e2e4d67a50be3/elastalert/ruletypes.py#L1014-L1019
the `aggregation_data` param in function check_matches looks like 
https://github.com/Yelp/elastalert/blob/1dc4f30f30d39a689f419ce19c7e2e4d67a50be3/elastalert/ruletypes.py#L1056-L1058
``` json
{
    "key": "kafka",
    "doc_count": 32916,
    "bucket_aggs": {
        "doc_count_error_upper_bound": 0,
        "sum_other_doc_count": 0,
        "buckets": [
            {
                "key": "stress-test-kafka",
                "doc_count": 17628,
                "interval_aggs": {
                    "buckets": [
                        {
                            "key_as_string": "2021-03-31T02:11:30.000Z",
                            "key": 1617156690000,
                            "doc_count": 1469,
                            "metric_prometheus.metrics.kafka_controller_kafkacontroller_activecontrollercount_sum": {
                                "value": 1
                            }
                        },
...(duplicated character removed)
```
What we could see is that the `interval_aggs` key is not unwrapped here. Also, the function `check_matches_recursive` only unwrap `bucket_aggs` recursively.  
https://github.com/Yelp/elastalert/blob/1dc4f30f30d39a689f419ce19c7e2e4d67a50be3/elastalert/ruletypes.py#L1069-L1084

So if the `bucket_interval` is configured in the rules, and **line 1127** will run into the KeyError while indexing `self.metric_key`.

### How to Fix it
- adding unwrap for `interval_aggs` key in function `check_matches_recursive`