### PR TITLE
Fix UnicodeEncodeError in PagerDutyAlerter

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1416,7 +1416,7 @@ class PagerDutyAlerter(Alerter):
         try:
             response = requests.post(
                 self.url,
-                data=json.dumps(payload, cls=DateTimeEncoder, ensure_ascii=False),
+                data=json.dumps(payload, cls=DateTimeEncoder, ensure_ascii=False).encode("utf-8"),
                 headers=headers,
                 proxies=proxies
             )


### PR DESCRIPTION
PagerDutyAlerter class appears to lack handling of non-Latin languages in alert subject / text. Specifically, with Japanese characters HTTP requests fail with the below error:

`    "UnicodeEncodeError: \u0027latin-1\u0027 codec can\u0027t encode characters in position 106-125: Body (\u0027\u3068\u306e\u901a\u4fe1\u3067\u5fdc\u7b54\u30bf\u30a4\u30e0\u30a2\u30a6\u30c8\u304c\u767a\u751f\u3057\u307e\u3057) is not valid Latin-1. Use body.encode(\u0027utf-8\u0027) if you want to send it encoded in UTF-8."
  ]
}'`

Tested that specifying encoding as utf-8 on line 1419 of alerts.py resolves the issue.

`data=json.dumps(payload, cls=DateTimeEncoder, ensure_ascii=False).encode("utf-8")`