### PR TITLE
Parsing error fixed at line 2.

### DIFF
--- a/example_rules/ssh.yaml
+++ b/example_rules/ssh.yaml
@@ -1,5 +1,5 @@
 # Rule name, must be unique
-  name: SSH abuse (ElastAlert 3.0.1) - 2
+name: SSH abuse (ElastAlert 3.0.1) - 2
 
 # Alert on x events in y seconds
 type: frequency


### PR DESCRIPTION
`yaml.parser.ParserError: did not find expected <document start>
  in "/opt/elastalert/example_rules/cron.yaml", line 5, column 1`

This error occurred while testing rule with wrong indentation(Tab).