### PR TITLE
Reduce risk of UUID collision in The Hive

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -2140,7 +2140,7 @@ class HiveAlerter(Alerter):
 
             alert_config = {
                 'artifacts': artifacts,
-                'sourceRef': str(uuid.uuid4())[0:6],
+                'sourceRef': str(uuid.uuid4()),
                 'customFields': {},
                 'caseTemplate': None,
                 'title': '{rule[index]}_{rule[name]}'.format(**context),


### PR DESCRIPTION
Use the entire UUID as Sourceref to reduce risk of alert collisions in The Hive.