### PR TITLE
Security advisory - malicious exotel dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ configparser>=3.5.0
 croniter>=0.3.16
 elasticsearch>=7.0.0
 envparse>=0.2.0
-exotel>=0.1.3
+exotel==0.1.5
 jira>=1.0.10,<1.0.15
 jsonschema>=3.0.2
 mock>=2.0.0


### PR DESCRIPTION
Informational advisory.

For around 6 hours today, the Pypi package [exotel](https://pypi.org/project/exotel/#history) had a malicious release, `0.1.6` published. It's `setup.py` would, on install, run a post-install hook, and call back to a C2 server.

If you installed `Yelp/elastalert` during this time window, you might be affected. There is a loose version constraint to `exotel` package in `requirements.txt`: https://github.com/Yelp/elastalert/blob/master/requirements.txt#L10

The malicious version was pulled by PyPi some minutes ago and is no longer installable. The library seems unmaintained since its last release `0.1.5` in 2017. Just in case - pin version to last known good - `0.1.5`.

Ref https://github.com/jertel/elastalert2/pull/931 & https://github.com/sarathsp06/exotel-py/issues/10

_(this is a backport of the hotfix from jertel/elastalert2, and not strictly needed to apply, as impact time window has passed )_