### PR TITLE
fix(sec): upgrade boto3 to 1.4.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 apscheduler>=3.3.0
 aws-requests-auth>=0.3.0
 blist>=1.3.6
-boto3>=1.4.4
+boto3>=1.4.5
 cffi>=1.11.5
 configparser>=3.5.0
 croniter>=0.3.16


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in boto3 1.4.4
- [MPS-2022-14769](https://www.oscs1024.com/hd/MPS-2022-14769)


### What did I do？
Upgrade boto3 from 1.4.4 to 1.4.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS